### PR TITLE
Add AI-friendly package for EFC Closure Conjectures

### DIFF
--- a/docs/papers/efc/EFC_Closure_Conjectures/LICENSE
+++ b/docs/papers/efc/EFC_Closure_Conjectures/LICENSE
@@ -1,0 +1,43 @@
+Creative Commons Attribution 4.0 International License (CC BY 4.0)
+
+Copyright (c) 2026 Morten Magnusson
+
+You are free to:
+
+- Share — copy and redistribute the material in any medium or format
+- Adapt — remix, transform, and build upon the material for any purpose,
+  even commercially
+
+Under the following terms:
+
+- Attribution — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any
+  reasonable manner, but not in any way that suggests the licensor
+  endorses you or your use.
+
+- No additional restrictions — You may not apply legal terms or
+  technological measures that legally restrict others from doing
+  anything the license permits.
+
+Notices:
+
+You do not have to comply with the license for elements of the material
+in the public domain or where your use is permitted by an applicable
+exception or limitation.
+
+No warranties are given. The license may not give you all of the
+permissions necessary for your intended use. For example, other rights
+such as publicity, privacy, or moral rights may limit how you use the
+material.
+
+---
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode
+
+---
+
+When citing this work, please use:
+
+Magnusson, M. (2026). The Regime-Consistent Measurement Principle (RCMP):
+A Methodological Framework for Multi-Scale Physics.
+DOI: 10.6084/m9.figshare.31222900

--- a/docs/papers/efc/EFC_Closure_Conjectures/README.md
+++ b/docs/papers/efc/EFC_Closure_Conjectures/README.md
@@ -1,0 +1,157 @@
+# EFC Closure Conjectures
+
+## AI-Friendly Package
+
+**Version**: 1.0
+**Author**: Morten Magnusson (ORCID: 0009-0002-4860-5095)
+**Date**: February 2026
+**License**: CC-BY-4.0
+
+## Overview
+
+This paper proposes two **closure relations** for EFC transition parameters, motivated by Euler's number *e* appearing naturally in the Core Lock structure.
+
+**Epistemic Status**: Conjectured closure. Consistent with data but NOT derived from first principles. Testable.
+
+## The Two Conjectures
+
+### 1. Transition Acceleration
+```
+g† = c × H₀ / e
+```
+- Links cosmological scale (cH₀) to galactic transition
+- Motivated by one *e*-fold drop in grid stiffness: f(ΔS) = f₀/e
+
+### 2. Phase Factor
+```
+C = 2e - 1 ≈ 4.437
+```
+- Matches inferred C ≈ 4.4 ± 0.6 from SPARC
+- Can be written as (e-1) + e
+
+## Key Prediction
+
+Inverting the g† relation gives a **non-circular test**:
+
+```
+H₀ = e × g† / c
+```
+
+Using SPARC-measured g† = (2.51 ± 0.60) × 10⁻¹⁰ m/s²:
+
+**H₀ = 70.2 ± 16.8 km/s/Mpc**
+
+| Measurement | H₀ (km/s/Mpc) | Consistent? |
+|-------------|---------------|-------------|
+| Planck (CMB) | 67.4 | ✓ (within 1σ) |
+| SH0ES (local) | 73.0 | ✓ (within 1σ) |
+| TRGB | 69.8 | ✓ (within 1σ) |
+| **SPARC prediction** | **70.2 ± 16.8** | - |
+
+The 24% uncertainty prevents discrimination between H₀ values, but the central value falls at the midpoint of the tension.
+
+## Numerical Consistency
+
+| Parameter | Conjectured | Observed | Status |
+|-----------|-------------|----------|--------|
+| g† | cH₀/e | (2.51 ± 0.60) × 10⁻¹⁰ m/s² | See note |
+| C | 2e - 1 = 4.437 | 4.4 ± 0.6 | ✓ Consistent |
+| ΔΦ_cosmo | e^S_today - 1 | ~1.7 | ✓ Consistent |
+
+**Note on g†**: The conjectured relation gives:
+- H₀ = 67.4 → g† = 2.41 × 10⁻¹⁰ m/s²
+- H₀ = 73.0 → g† = 2.61 × 10⁻¹⁰ m/s²
+- H₀ = 70.2 → g† = 2.51 × 10⁻¹⁰ m/s² (matches SPARC central value)
+
+## What Remains Free
+
+Even with these conjectures, **one parameter remains irreducible**:
+
+```
+a_G ≈ 0.094
+```
+
+All other parameters follow:
+- k = a_G × C
+- ΔΦ_cosmo ≈ e^S_today - 1
+- H₀ offset via Friedmann: a_H₀ = ½ a_G
+
+## Falsification Conditions
+
+These conjectures are **falsified** if:
+
+1. **Improved g† measurements** (with <10% uncertainty) are inconsistent with cH₀/e at >3σ
+
+2. **Phase factor C**, when measured independently, deviates from 2e-1 = 4.437 by more than 20%
+
+3. **Alternative f(S) forms** (power-law, Lorentzian) fit RAR better without factors of *e*
+
+## Package Contents
+
+```
+├── README.md                 # This file
+├── CITATION.cff             # Citation metadata
+├── LICENSE                  # CC-BY-4.0
+├── index.json               # Machine-readable metadata
+│
+├── src/
+│   ├── __init__.py
+│   ├── closure_relations.py  # g† and C computations
+│   └── h0_prediction.py      # H₀ from SPARC
+│
+├── data/
+│   └── conjectures.json      # All conjectured values
+│
+└── examples/
+    └── test_conjectures.py   # Numerical tests
+```
+
+## Quick Usage
+
+```python
+import math
+from src.closure_relations import compute_g_dagger, compute_C, predict_h0
+
+e = math.e
+c = 299792458  # m/s
+
+# Conjecture 1: g† = cH₀/e
+g_dagger = compute_g_dagger(H0=70.0)  # 2.50e-10 m/s²
+
+# Conjecture 2: C = 2e - 1
+C = compute_C()  # 4.437
+
+# Non-circular test: H₀ from SPARC
+H0_pred = predict_h0(g_dagger=2.51e-10)  # 70.2 km/s/Mpc
+```
+
+## Physical Motivation
+
+The Core Lock structure:
+```
+f(S) = f₀ exp(-S/ΔS)
+```
+
+At S = ΔS, the grid stiffness falls to **f₀/e**.
+
+We conjecture that the screening transition occurs at this natural *e*-fold threshold, linking:
+- Cosmological scale: cH₀
+- Galactic transition: g†
+- Via the exponential factor: 1/e
+
+## Related EFC Papers
+
+- [Core Lock](../Core-Lock/) - Source of exponential structure
+- [SPARC Validation](../EFC_Phase_3__SPARC_Validation/) - Source of g† measurement
+- [H₀-RAR Unification](../Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification/) - Source of a_G
+
+## Citation
+
+```bibtex
+@article{magnusson2026closure,
+  author = {Magnusson, Morten},
+  title = {EFC Closure Conjectures: g† = cH₀/e and C ≈ 2e-1},
+  year = {2026},
+  note = {Testable ansatz, not first-principles derivation}
+}
+```

--- a/docs/papers/efc/EFC_Closure_Conjectures/examples/test_conjectures.py
+++ b/docs/papers/efc/EFC_Closure_Conjectures/examples/test_conjectures.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+Test EFC Closure Conjectures
+
+Demonstrates numerical consistency of the proposed relations.
+"""
+
+import sys
+import math
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from closure_relations import (
+    ClosureConjectures,
+    compute_g_dagger,
+    compute_C,
+    predict_h0,
+)
+
+
+def main():
+    """Test the closure conjectures."""
+
+    e = math.e
+
+    print("=" * 60)
+    print("EFC CLOSURE CONJECTURES")
+    print("Proposed Relations: g† = cH₀/e and C = 2e - 1")
+    print("=" * 60)
+    print()
+
+    # Initialize
+    conj = ClosureConjectures(aG=0.094)
+
+    # Test Conjecture 1: g† = cH₀/e
+    print("CONJECTURE 1: g† = c × H₀ / e")
+    print("-" * 40)
+
+    h0_values = [67.4, 70.2, 73.0]
+    labels = ["Planck", "Mean", "SH0ES"]
+
+    for h0, label in zip(h0_values, labels):
+        g_dag = compute_g_dagger(h0)
+        print(f"  H₀ = {h0} ({label}): g† = {g_dag:.2e} m/s²")
+
+    print(f"\n  SPARC measured: g† = (2.51 ± 0.60) × 10⁻¹⁰ m/s²")
+    print()
+
+    # Test Conjecture 2: C = 2e - 1
+    print("CONJECTURE 2: C = 2e - 1")
+    print("-" * 40)
+
+    C = compute_C()
+    C_observed = 4.4
+    C_error = 0.6
+
+    print(f"  Conjectured: C = 2×{e:.4f} - 1 = {C:.3f}")
+    print(f"  Observed:    C = {C_observed} ± {C_error}")
+    print(f"  Difference:  {abs(C - C_observed):.3f} ({abs(C - C_observed)/C_observed*100:.1f}%)")
+    print(f"  Status:      {'✓ CONSISTENT' if abs(C - C_observed) < C_error else '✗ INCONSISTENT'}")
+    print()
+
+    # Key prediction: H₀ from SPARC
+    print("KEY PREDICTION: H₀ = e × g† / c")
+    print("-" * 40)
+
+    g_dagger_sparc = 2.51e-10
+    g_dagger_error = 0.60e-10
+
+    H0_pred, H0_err = predict_h0(g_dagger_sparc, g_dagger_error)
+
+    print(f"  Using SPARC g† = ({g_dagger_sparc*1e10:.2f} ± {g_dagger_error*1e10:.2f}) × 10⁻¹⁰ m/s²")
+    print(f"  H₀ = {H0_pred:.1f} ± {H0_err:.1f} km/s/Mpc")
+    print()
+
+    # Comparison with measurements
+    print("  Comparison with measurements:")
+    measurements = [
+        ("Planck (CMB)", 67.4, 0.5),
+        ("SH0ES (local)", 73.04, 1.04),
+        ("TRGB", 69.8, 1.7),
+    ]
+
+    for name, h0, err in measurements:
+        diff = abs(H0_pred - h0)
+        sigma = diff / math.sqrt(H0_err**2 + err**2)
+        status = "✓" if sigma < 2 else "✗"
+        print(f"    {name}: {h0} ± {err} → {sigma:.1f}σ {status}")
+
+    print()
+
+    # What remains free
+    print("=" * 60)
+    print("IRREDUCIBLE PARAMETER")
+    print("=" * 60)
+    print(f"""
+Even with these conjectures, one parameter remains free:
+
+    a_G ≈ 0.094
+
+All other parameters follow:
+    k = a_G × C = {conj.aG} × {C:.3f} = {conj.k:.3f}
+    ΔΦ_cosmo ≈ e - 1 = {e - 1:.3f}
+    a_H₀ = ½ a_G = {conj.aG / 2:.4f}
+""")
+
+    # Falsification conditions
+    print("=" * 60)
+    print("FALSIFICATION CONDITIONS")
+    print("=" * 60)
+    print("""
+These conjectures are FALSIFIED if:
+
+1. Improved g† measurements (with <10% uncertainty)
+   are inconsistent with cH₀/e at >3σ
+
+2. Phase factor C deviates from 2e-1 = 4.437
+   by more than 20%
+
+3. Alternative f(S) forms (power-law, Lorentzian)
+   fit RAR better without natural factors of e
+
+Current status: CONSISTENT (but large uncertainties)
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/papers/efc/EFC_Closure_Conjectures/index.json
+++ b/docs/papers/efc/EFC_Closure_Conjectures/index.json
@@ -1,0 +1,73 @@
+{
+  "id": "efc-closure-conjectures",
+  "title": "EFC Closure Conjectures",
+  "subtitle": "Proposed Relations: g† = cH₀/e and C ≈ 2e - 1",
+  "version": "1.0",
+  "date": "2026-02-01",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Independent Researcher, Norway"
+  },
+  "license": "CC-BY-4.0",
+  "type": "theoretical_conjecture",
+  "epistemic_layer": "C",
+  "epistemic_status": "Conjectured closure. Consistent with data but not derived from first principles. Testable.",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "radial acceleration relation",
+    "Hubble tension",
+    "transition acceleration",
+    "closure relations",
+    "Euler number"
+  ],
+  "conjectures": {
+    "transition_acceleration": {
+      "formula": "g† = c × H₀ / e",
+      "motivation": "One e-fold drop in grid stiffness at S = ΔS",
+      "numerical_value": "2.51e-10 m/s² for H₀ = 70.2"
+    },
+    "phase_factor": {
+      "formula": "C = 2e - 1",
+      "numerical_value": 4.437,
+      "interpretation": "Galactic phase = (e-1) + e"
+    }
+  },
+  "key_prediction": {
+    "formula": "H₀ = e × g† / c",
+    "using_sparc": {
+      "g_dagger": "2.51e-10 m/s²",
+      "g_dagger_error": "0.60e-10 m/s²",
+      "h0_predicted": 70.2,
+      "h0_error": 16.8,
+      "unit": "km/s/Mpc"
+    },
+    "consistency": {
+      "planck": "within 1σ",
+      "sh0es": "within 1σ",
+      "trgb": "within 1σ"
+    }
+  },
+  "irreducible_parameter": {
+    "name": "a_G",
+    "value": 0.094,
+    "note": "Cannot currently be derived from simpler quantities"
+  },
+  "falsification_conditions": [
+    "g† measurements with <10% uncertainty inconsistent with cH₀/e at >3σ",
+    "Phase factor C deviates from 2e-1 by more than 20%",
+    "Alternative f(S) forms fit RAR better without factors of e"
+  ],
+  "related_papers": [
+    {
+      "id": "core-lock",
+      "doi": "10.6084/m9.figshare.31223503",
+      "relationship": "source of exponential structure"
+    },
+    {
+      "id": "sparc-validation",
+      "doi": "10.6084/m9.figshare.31224397",
+      "relationship": "source of g† measurement"
+    }
+  ]
+}

--- a/docs/papers/efc/EFC_Closure_Conjectures/src/__init__.py
+++ b/docs/papers/efc/EFC_Closure_Conjectures/src/__init__.py
@@ -1,0 +1,25 @@
+"""
+EFC Closure Conjectures
+
+Proposed relations: g† = cH₀/e and C = 2e - 1
+"""
+
+from .closure_relations import (
+    compute_g_dagger,
+    compute_C,
+    predict_h0,
+    compute_k,
+    ClosureConjectures,
+    ClosureResult,
+)
+
+__all__ = [
+    "compute_g_dagger",
+    "compute_C",
+    "predict_h0",
+    "compute_k",
+    "ClosureConjectures",
+    "ClosureResult",
+]
+
+__version__ = "1.0.0"

--- a/docs/papers/efc/EFC_Closure_Conjectures/src/closure_relations.py
+++ b/docs/papers/efc/EFC_Closure_Conjectures/src/closure_relations.py
@@ -1,0 +1,197 @@
+"""
+EFC Closure Relations
+
+Implements the conjectured closure relations:
+    g† = c × H₀ / e
+    C = 2e - 1
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+# Physical constants
+c = 299792458  # Speed of light in m/s
+e = math.e     # Euler's number
+
+# Unit conversions
+KM_S_MPC_TO_SI = 1e3 / 3.086e22  # km/s/Mpc to 1/s
+
+
+@dataclass
+class ClosureResult:
+    """Result of closure relation computation."""
+    g_dagger: float          # Transition acceleration (m/s²)
+    C: float                 # Phase factor
+    H0: float               # Hubble constant (km/s/Mpc)
+    k: Optional[float]      # Screening exponent (if aG provided)
+    delta_phi_cosmo: float  # Cosmological phase
+
+
+def compute_g_dagger(H0: float) -> float:
+    """
+    Compute transition acceleration from H₀.
+
+    g† = c × H₀ / e
+
+    Args:
+        H0: Hubble constant in km/s/Mpc
+
+    Returns:
+        Transition acceleration in m/s²
+
+    Example:
+        >>> compute_g_dagger(70.0)
+        2.50e-10
+    """
+    H0_si = H0 * KM_S_MPC_TO_SI
+    return c * H0_si / e
+
+
+def compute_C() -> float:
+    """
+    Compute the phase factor.
+
+    C = 2e - 1 ≈ 4.437
+
+    Returns:
+        Phase factor C
+    """
+    return 2 * e - 1
+
+
+def predict_h0(g_dagger: float, g_dagger_error: Optional[float] = None) -> tuple[float, Optional[float]]:
+    """
+    Predict H₀ from measured g†.
+
+    H₀ = e × g† / c
+
+    Args:
+        g_dagger: Transition acceleration in m/s²
+        g_dagger_error: Uncertainty on g† (optional)
+
+    Returns:
+        Tuple of (H₀, H₀_error) in km/s/Mpc
+
+    Example:
+        >>> predict_h0(2.51e-10, 0.60e-10)
+        (70.2, 16.8)
+    """
+    H0_si = e * g_dagger / c
+    H0 = H0_si / KM_S_MPC_TO_SI
+
+    if g_dagger_error is not None:
+        # Error propagation (linear)
+        H0_error = H0 * (g_dagger_error / g_dagger)
+        return H0, H0_error
+
+    return H0, None
+
+
+def compute_k(aG: float) -> float:
+    """
+    Compute screening exponent from a_G.
+
+    k = a_G × C = a_G × (2e - 1)
+
+    Args:
+        aG: Universal coupling coefficient
+
+    Returns:
+        Screening exponent k
+    """
+    return aG * compute_C()
+
+
+def compute_delta_phi_cosmo(S_today: float = 1.0) -> float:
+    """
+    Compute cosmological phase difference.
+
+    ΔΦ_cosmo ≈ e^S_today - 1
+
+    Args:
+        S_today: Entropy parameter today (default: 1.0)
+
+    Returns:
+        Cosmological phase difference
+    """
+    return math.exp(S_today) - 1
+
+
+def full_closure(H0: float, aG: float = 0.094, S_today: float = 1.0) -> ClosureResult:
+    """
+    Compute all closure parameters.
+
+    Args:
+        H0: Hubble constant in km/s/Mpc
+        aG: Universal coupling coefficient
+        S_today: Entropy parameter today
+
+    Returns:
+        ClosureResult with all parameters
+    """
+    return ClosureResult(
+        g_dagger=compute_g_dagger(H0),
+        C=compute_C(),
+        H0=H0,
+        k=compute_k(aG),
+        delta_phi_cosmo=compute_delta_phi_cosmo(S_today),
+    )
+
+
+class ClosureConjectures:
+    """
+    EFC closure conjectures calculator.
+
+    Conjectures:
+        1. g† = c × H₀ / e
+        2. C = 2e - 1 ≈ 4.437
+
+    Example:
+        conj = ClosureConjectures()
+
+        # From H₀
+        g_dagger = conj.g_dagger_from_h0(70.0)
+
+        # From SPARC g†
+        H0, H0_err = conj.h0_from_sparc(2.51e-10, 0.60e-10)
+    """
+
+    def __init__(self, aG: float = 0.094):
+        """Initialize with universal coupling."""
+        self.aG = aG
+        self.C = compute_C()
+        self.k = compute_k(aG)
+
+    def g_dagger_from_h0(self, H0: float) -> float:
+        """Compute g† from H₀."""
+        return compute_g_dagger(H0)
+
+    def h0_from_sparc(
+        self,
+        g_dagger: float,
+        g_dagger_error: Optional[float] = None
+    ) -> tuple[float, Optional[float]]:
+        """Predict H₀ from SPARC g†."""
+        return predict_h0(g_dagger, g_dagger_error)
+
+    def summary(self) -> str:
+        """Get summary of conjectures."""
+        return (
+            f"EFC Closure Conjectures\n"
+            f"{'=' * 40}\n"
+            f"\n"
+            f"Conjecture 1: g† = c × H₀ / e\n"
+            f"  For H₀ = 67.4: g† = {compute_g_dagger(67.4):.2e} m/s²\n"
+            f"  For H₀ = 70.2: g† = {compute_g_dagger(70.2):.2e} m/s²\n"
+            f"  For H₀ = 73.0: g† = {compute_g_dagger(73.0):.2e} m/s²\n"
+            f"\n"
+            f"Conjecture 2: C = 2e - 1\n"
+            f"  C = {self.C:.3f}\n"
+            f"  k = a_G × C = {self.aG} × {self.C:.3f} = {self.k:.3f}\n"
+            f"\n"
+            f"Key prediction:\n"
+            f"  H₀ = e × g† / c\n"
+            f"  Using SPARC g† = 2.51e-10 m/s²:\n"
+            f"  H₀ = {predict_h0(2.51e-10)[0]:.1f} km/s/Mpc\n"
+        )


### PR DESCRIPTION
Two testable conjectures motivated by Euler's number e in Core Lock:

1. Transition acceleration: g† = c × H₀ / e
2. Phase factor: C = 2e - 1 ≈ 4.437

Key prediction (non-circular test):
  H₀ = e × g† / c = 70.2 ± 16.8 km/s/Mpc (from SPARC)
  Consistent with Planck, SH0ES, TRGB within 1σ

Package includes:
- README.md with full explanation
- index.json with machine-readable metadata
- src/closure_relations.py - all computations
- examples/test_conjectures.py - numerical tests

Epistemic status: Conjectured closure, NOT first-principles derivation

https://claude.ai/code/session_01DU4ATUVjhJgkqLDz9ZdvzX