### PR TITLE
Add AI-friendly package for Triangulation Test paper

### DIFF
--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/CITATION.cff
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+message: "If you use this work, please cite it as below."
+title: "A Triangulation Test for Possible Thermodynamic Contributions to Gravitational Lensing in Galaxy Clusters"
+type: article
+authors:
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+    affiliation: "Independent Researcher"
+version: "1.0"
+date-released: "2026-02-05"
+license: "CC-BY-4.0"
+repository-code: "https://github.com/supertedai/EFC"
+doi: "10.6084/m9.figshare.31267297"
+journal: "MNRAS"
+volume: "000"
+pages: "1-7"
+keywords:
+  - "gravitational lensing"
+  - "galaxy clusters"
+  - "intracluster medium"
+  - "entropy"
+  - "hydrostatic equilibrium"
+  - "mass discrepancy"
+  - "thermodynamic gravity"
+abstract: >
+  A triangulation methodology to test whether gravitational lensing
+  in galaxy clusters exhibits residual structure correlated with
+  intracluster medium (ICM) thermodynamics beyond what is expected
+  from mass alone. The method compares three independent observables:
+  (1) projected mass from gravitational lensing, (2) dynamical mass
+  inferred from hydrostatic equilibrium, and (3) entropy gradients
+  derived from X-ray temperature and density profiles. Applied to
+  the Bullet Cluster and Abell 1835, no statistically significant
+  correlation is detected (Bullet: ρ = -0.129, p = 0.21), consistent
+  with sensitivity limits for %-level effects.

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/LICENSE
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/LICENSE
@@ -1,0 +1,13 @@
+Creative Commons Attribution 4.0 International License (CC-BY-4.0)
+
+Copyright (c) 2026 Morten Magnusson
+
+You are free to:
+- Share: copy and redistribute the material in any medium or format
+- Adapt: remix, transform, and build upon the material for any purpose, even commercially
+
+Under the following terms:
+- Attribution: You must give appropriate credit, provide a link to the license,
+  and indicate if changes were made.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/README.md
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/README.md
@@ -1,0 +1,153 @@
+# Triangulation Test for Thermodynamic-Lensing Coupling
+
+**AI-friendly package for**: "A Triangulation Test for Possible Thermodynamic Contributions to Gravitational Lensing in Galaxy Clusters"
+
+**Author**: Morten Magnusson
+**Date**: February 2026
+**DOI**: [10.6084/m9.figshare.31267297](https://doi.org/10.6084/m9.figshare.31267297)
+
+## Overview
+
+This paper introduces a **triangulation methodology** to test whether gravitational lensing in galaxy clusters exhibits residual structure correlated with ICM thermodynamics beyond what is expected from mass alone.
+
+## The Three Independent Observables
+
+### Observable 1: Lensing Mass (Geometric)
+```
+M_lens(<r) = π r² Σ_crit κ̄(<r)
+```
+- From weak lensing shear and strong lensing multiple images
+- Measures total projected mass through photon deflection
+
+### Observable 2: Hydrostatic Mass (Dynamic)
+```
+M_HSE(<r) = -(kT r)/(μ m_p G) × [d ln n_e/d ln r + d ln T/d ln r]
+```
+- From X-ray temperature T(r) and density n_e(r) profiles
+- Assumes spherical hydrostatic equilibrium
+
+### Observable 3: Entropy Gradient (Thermodynamic)
+```
+K(r) = T(r) n_e(r)^(-2/3)    [ICM entropy]
+|∇K(r)| ≈ |dK/dr|            [entropy gradient]
+```
+- Marks sites of irreversible thermodynamic processes (shocks, mixing)
+
+## The Triangulation Test
+
+**Mass Residual**:
+```
+R(r) = M_lens(r) - M_HSE(r)
+```
+
+**Core Test**: Correlation between R(r) and |∇K(r)|
+
+| Hypothesis | Expected ρ | Interpretation |
+|------------|------------|----------------|
+| ΛCDM (null) | ρ ≈ 0 | R from non-thermal pressure, no systematic correlation |
+| Thermodynamic coupling | ρ > 0 | If κ ∝ ∇²K, then R ∝ \|∇K\| |
+
+## Pilot Results
+
+| Cluster | Type | Pearson ρ | Spearman ρ | p-value | Result |
+|---------|------|-----------|------------|---------|--------|
+| Bullet Cluster | Merging | -0.129 | -0.179 | 0.21 | Not significant |
+| Abell 1835 | Relaxed | -0.052 | -0.147 | 0.70 | Not significant |
+
+**Interpretation**: No statistically significant correlation detected, consistent with sensitivity limits for %-level effects.
+
+## Consistency Requirements
+
+Any phenomenological coupling κ ~ κ_GR + α∇²K must satisfy:
+
+| Test | Observable | Data | Status |
+|------|------------|------|--------|
+| Achromaticity | κ(λ) | H0LiCOW | ✓ Consistent |
+| CMB spectrum | Δy, Δμ | FIRAS | △ Assumed |
+| WEP | ε | LLR+MICROSCOPE | △ Assumed |
+| BBN | N_eff | Planck+D/H | △ Assumed |
+| Time delays | τ(λ) | TDCOSMO | ✓ Consistent |
+| Void lensing | κ_void | DES Y3 | △ Intriguing |
+
+## Detection Thresholds
+
+For N = 57 radial bins (single cluster):
+- Need ρ ≈ 0.25 for p < 0.05 significance
+- Expected signal ρ ~ 0.1-0.2 is under-powered
+
+**Scaling to larger samples**:
+| Clusters | N_eff | Detectable ρ at 3σ |
+|----------|-------|-------------------|
+| 10 | 570 | ~0.08 |
+| 20 | 1140 | ~0.06 |
+| 50 | 2850 | ~0.04 |
+
+## Speculative Prediction: Line-of-Sight Redshift
+
+If thermodynamic coupling exists, absorption systems passing through cluster ICM could show:
+```
+Δz_LOS ~ 10⁻⁶ to 10⁻⁵
+```
+- Independent of photon frequency
+- Correlated spatially with entropy structure
+- Detectable by stacking cluster-quasar sightlines
+
+## Quick Start
+
+```python
+from triangulation_test import TriangulationAnalysis
+
+# Initialize with cluster data
+analysis = TriangulationAnalysis(
+    r_bins,      # Radial bins [kpc]
+    M_lens,      # Lensing mass profile [M_sun]
+    M_HSE,       # Hydrostatic mass profile [M_sun]
+    K_profile    # Entropy profile [keV cm²]
+)
+
+# Compute mass residual and entropy gradient
+R_norm = analysis.compute_residual()
+grad_K = analysis.compute_entropy_gradient()
+
+# Run correlation test
+results = analysis.correlation_test()
+print(f"Pearson ρ = {results['pearson_rho']:.3f}")
+print(f"p-value = {results['p_value']:.3f}")
+```
+
+## Key Equations Summary
+
+| Quantity | Formula |
+|----------|---------|
+| Lensing mass | M_lens = πr²Σ_crit κ̄ |
+| HSE mass | M_HSE = -(kTr)/(μm_pG)[d ln n_e/d ln r + d ln T/d ln r] |
+| Entropy | K = T n_e^(-2/3) |
+| Mass residual | R(r) = M_lens(r) - M_HSE(r) |
+| Normalized residual | R_norm = R/M_lens |
+| Test statistic | t = ρ√[(N-2)/(1-ρ²)] |
+
+## What This Work Does NOT Claim
+
+- Does NOT present evidence for modified gravity
+- Does NOT claim detection of thermodynamic-lensing coupling
+- Pilot results are consistent with null hypothesis (ΛCDM)
+- Establishes methodology for future high-precision tests
+
+## Citation
+
+```bibtex
+@article{magnusson2026triangulation,
+  title={A Triangulation Test for Possible Thermodynamic Contributions
+         to Gravitational Lensing in Galaxy Clusters},
+  author={Magnusson, Morten},
+  journal={MNRAS},
+  volume={000},
+  pages={1--7},
+  year={2026},
+  doi={10.6084/m9.figshare.31267297}
+}
+```
+
+## License
+
+CC-BY-4.0

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/data/pilot_results.json
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/data/pilot_results.json
@@ -1,0 +1,56 @@
+{
+  "bullet_cluster": {
+    "name": "1E 0657-56 (Bullet Cluster)",
+    "type": "merging",
+    "redshift": 0.296,
+    "description": "Merging cluster with strong shock structures and pronounced entropy gradients",
+    "lensing_source": "JWST NIRCam (Cha et al. 2025; Cho et al. 2025)",
+    "xray_source": "Chandra 500 ks (Million & Allen 2008) + ACCEPT",
+    "results": {
+      "n_bins": 57,
+      "pearson_rho": -0.129,
+      "spearman_rho": -0.179,
+      "p_value": 0.21,
+      "significant": false,
+      "interpretation": "No statistically significant correlation detected"
+    },
+    "notes": [
+      "Strong shock structures and pronounced entropy gradients",
+      "Large hydrostatic mass bias expected for mergers",
+      "Correlation sign not robust given uncertainties"
+    ]
+  },
+  "abell_1835": {
+    "name": "Abell 1835",
+    "type": "relaxed",
+    "redshift": 0.253,
+    "description": "Dynamically relaxed, cool-core cluster with smooth entropy structure",
+    "lensing_source": "HST + Subaru (Smith et al. 2005)",
+    "xray_source": "Chandra + ACCEPT",
+    "results": {
+      "n_bins": null,
+      "pearson_rho": -0.052,
+      "spearman_rho": -0.147,
+      "p_value": 0.70,
+      "significant": false,
+      "interpretation": "No statistically significant correlation detected"
+    },
+    "notes": [
+      "Relaxed system used as control",
+      "Weaker residuals and gradients as expected",
+      "Thermodynamic coupling hypothesis predicts weaker signal in relaxed systems"
+    ]
+  },
+  "expected_behavior": {
+    "null_hypothesis": {
+      "name": "ΛCDM",
+      "expected_rho": "~0 or weak",
+      "mechanism": "R arises from non-thermal pressure (bulk motions, turbulence)"
+    },
+    "alternative_hypothesis": {
+      "name": "Thermodynamic coupling",
+      "expected_rho": "> 0, significant",
+      "mechanism": "If κ ∝ ∇²K, then R ∝ |∇K|"
+    }
+  }
+}

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/examples/triangulation_demo.py
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/examples/triangulation_demo.py
@@ -1,0 +1,160 @@
+"""
+Example: Triangulation Test Analysis
+
+Demonstrates the triangulation methodology on simulated cluster data.
+"""
+
+import numpy as np
+import sys
+sys.path.insert(0, '..')
+
+from src.triangulation_test import (
+    TriangulationAnalysis,
+    ClusterData,
+    stacked_detection_threshold
+)
+
+
+def create_mock_merging_cluster():
+    """Create mock data for a merging cluster (Bullet-like)."""
+    # Radial bins from 50 to 1500 kpc
+    r = np.linspace(50, 1500, 57)  # kpc
+
+    # Mock lensing mass profile (NFW-like)
+    M_200 = 1.5e15  # M_sun
+    c = 4.0  # concentration
+    r_s = 375  # scale radius kpc
+    x = r / r_s
+    M_lens = M_200 * (np.log(1 + x) - x/(1 + x)) / (np.log(1 + c) - c/(1 + c))
+
+    # Mock temperature profile with shock
+    T_base = 10.0  # keV
+    T = T_base * (1 + 0.5 * np.exp(-(r - 500)**2 / 100**2))  # Shock at 500 kpc
+
+    # Mock density profile
+    n_0 = 0.01  # cm^-3
+    r_c = 200  # core radius kpc
+    beta = 0.67
+    n_e = n_0 * (1 + (r/r_c)**2)**(-1.5*beta)
+
+    return ClusterData(
+        name="Mock Bullet-like Cluster",
+        cluster_type="merging",
+        r_bins=r,
+        M_lens=M_lens,
+        M_lens_err=M_lens * 0.1,
+        T_profile=T,
+        n_e_profile=n_e
+    )
+
+
+def create_mock_relaxed_cluster():
+    """Create mock data for a relaxed cluster (Abell 1835-like)."""
+    r = np.linspace(50, 1500, 50)
+
+    # Smooth NFW profile
+    M_200 = 1.2e15
+    c = 5.0
+    r_s = 240
+    x = r / r_s
+    M_lens = M_200 * (np.log(1 + x) - x/(1 + x)) / (np.log(1 + c) - c/(1 + c))
+
+    # Smooth temperature profile (cool core)
+    T = 8.0 * (r / (r + 100))  # keV, rising from cool core
+
+    # Smooth density profile
+    n_0 = 0.05
+    r_c = 50
+    beta = 0.6
+    n_e = n_0 * (1 + (r/r_c)**2)**(-1.5*beta)
+
+    return ClusterData(
+        name="Mock Relaxed Cluster",
+        cluster_type="relaxed",
+        r_bins=r,
+        M_lens=M_lens,
+        M_lens_err=M_lens * 0.08,
+        T_profile=T,
+        n_e_profile=n_e
+    )
+
+
+def main():
+    print("=" * 60)
+    print("Triangulation Test for Thermodynamic-Lensing Coupling")
+    print("=" * 60)
+    print()
+
+    # Analyze mock merging cluster
+    print("1. MERGING CLUSTER ANALYSIS")
+    print("-" * 40)
+
+    merging_data = create_mock_merging_cluster()
+    merging_analysis = TriangulationAnalysis(merging_data)
+
+    # Compute quantities
+    K = merging_analysis.compute_entropy()
+    grad_K = merging_analysis.compute_entropy_gradient()
+    M_HSE = merging_analysis.compute_hydrostatic_mass()
+    R = merging_analysis.compute_mass_residual()
+
+    print(f"Cluster: {merging_data.name}")
+    print(f"Entropy range: {K.min():.1f} - {K.max():.1f} keV cm²")
+    print(f"Max entropy gradient: {grad_K.max():.2e} keV cm² / kpc")
+    print(f"Mean M_lens/M_HSE ratio: {np.mean(merging_data.M_lens / M_HSE):.2f}")
+    print()
+
+    # Run correlation test
+    results = merging_analysis.correlation_test()
+    print("Correlation Test Results:")
+    print(f"  Pearson ρ  = {results['pearson_rho']:.3f} (p = {results['pearson_p']:.3f})")
+    print(f"  Spearman ρ = {results['spearman_rho']:.3f} (p = {results['spearman_p']:.3f})")
+    print(f"  Required |ρ| for 2σ: {results['rho_required_2sigma']:.3f}")
+    print(f"  Significant: {results['significant_2sigma']}")
+    print(f"  Interpretation: {results['interpretation']}")
+    print()
+
+    # Analyze mock relaxed cluster
+    print("2. RELAXED CLUSTER ANALYSIS (Control)")
+    print("-" * 40)
+
+    relaxed_data = create_mock_relaxed_cluster()
+    relaxed_analysis = TriangulationAnalysis(relaxed_data)
+
+    print(relaxed_analysis.summary())
+
+    # Detection thresholds for stacked samples
+    print("3. DETECTION THRESHOLDS FOR STACKED SAMPLES")
+    print("-" * 40)
+    print()
+    print("| N_clusters | N_eff | Detectable ρ (3σ) |")
+    print("|------------|-------|-------------------|")
+
+    for n_clusters in [10, 20, 50, 100]:
+        rho_min = stacked_detection_threshold(n_clusters, bins_per_cluster=57, sigma=3.0)
+        n_eff = n_clusters * 57
+        print(f"| {n_clusters:10d} | {n_eff:5d} | {rho_min:17.3f} |")
+
+    print()
+    print("=" * 60)
+    print("INTERPRETATION")
+    print("=" * 60)
+    print("""
+The triangulation test compares:
+  1. M_lens(r) - Lensing mass (geometric)
+  2. M_HSE(r)  - Hydrostatic mass (dynamic)
+  3. |∇K(r)|  - Entropy gradient (thermodynamic)
+
+Expected behavior:
+  - ΛCDM (null): ρ ≈ 0, R from non-thermal pressure
+  - Thermodynamic coupling: ρ > 0 if κ ∝ ∇²K
+
+Current pilot results (Bullet Cluster):
+  - ρ = -0.129, p = 0.21 (not significant)
+  - Consistent with sensitivity limits for %-level effects
+  - Larger samples (20-50 clusters) needed for decisive test
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/index.json
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/index.json
@@ -1,0 +1,161 @@
+{
+  "title": "A Triangulation Test for Possible Thermodynamic Contributions to Gravitational Lensing in Galaxy Clusters",
+  "short_title": "Triangulation Test for Thermodynamic-Lensing Coupling",
+  "author": "Morten Magnusson",
+  "affiliation": "Independent Researcher",
+  "orcid": "0009-0002-4860-5095",
+  "date": "2026-02",
+  "doi": "10.6084/m9.figshare.31267297",
+  "journal": "MNRAS",
+  "version": "1.0",
+
+  "methodology": {
+    "name": "Triangulation Test",
+    "description": "Compare three independent observables to test for thermodynamic-lensing coupling",
+    "observables": [
+      {
+        "name": "Lensing Mass",
+        "symbol": "M_lens",
+        "type": "geometric",
+        "formula": "M_lens(<r) = π r² Σ_crit κ̄(<r)",
+        "data_sources": ["JWST NIRCam", "HST ACS/WFC3", "Subaru HSC"],
+        "uncertainty": "5-10%"
+      },
+      {
+        "name": "Hydrostatic Mass",
+        "symbol": "M_HSE",
+        "type": "dynamic",
+        "formula": "M_HSE(<r) = -(kTr)/(μm_pG)[d ln n_e/d ln r + d ln T/d ln r]",
+        "data_sources": ["Chandra ACIS", "XMM-Newton EPIC", "ACCEPT catalog"],
+        "uncertainty": "10-20%"
+      },
+      {
+        "name": "Entropy Gradient",
+        "symbol": "|∇K|",
+        "type": "thermodynamic",
+        "formula": "K(r) = T(r) n_e(r)^(-2/3)",
+        "data_sources": ["X-ray T and n_e profiles"],
+        "uncertainty": "20-30%"
+      }
+    ],
+    "test_statistic": {
+      "mass_residual": "R(r) = M_lens(r) - M_HSE(r)",
+      "normalized_residual": "R_norm(r) = R(r)/M_lens(r)",
+      "normalized_gradient": "G_norm(r) = |∇K(r)|/max|∇K|",
+      "correlation": "ρ(R_norm, G_norm)"
+    }
+  },
+
+  "pilot_results": {
+    "bullet_cluster": {
+      "name": "1E 0657-56 (Bullet Cluster)",
+      "type": "merging",
+      "n_bins": 57,
+      "pearson_rho": -0.129,
+      "spearman_rho": -0.179,
+      "p_value": 0.21,
+      "significant": false,
+      "lensing_data": "JWST NIRCam (Cha et al. 2025)",
+      "xray_data": "Chandra 500 ks + ACCEPT"
+    },
+    "abell_1835": {
+      "name": "Abell 1835",
+      "type": "relaxed",
+      "pearson_rho": -0.052,
+      "spearman_rho": -0.147,
+      "p_value": 0.70,
+      "significant": false,
+      "lensing_data": "HST + Subaru",
+      "xray_data": "Chandra + ACCEPT"
+    }
+  },
+
+  "consistency_checks": {
+    "achromaticity": {
+      "test": "Lensing independent of wavelength",
+      "data": "H0LiCOW (6 lensed quasars)",
+      "result": "χ²/dof = 0.91",
+      "status": "consistent"
+    },
+    "cmb_spectrum": {
+      "test": "Standard blackbody at z ~ 1000",
+      "data": "COBE/FIRAS",
+      "result": "|Δy| < 1.5e-5, |Δμ| < 9e-5",
+      "status": "assumed"
+    },
+    "wep": {
+      "test": "Composition-independent free fall",
+      "data": "LLR + MICROSCOPE",
+      "result": "ε < 1e-15",
+      "status": "assumed"
+    },
+    "bbn": {
+      "test": "Standard expansion at z ~ 1e9",
+      "data": "Planck + D/H",
+      "result": "N_eff = 2.99 ± 0.17",
+      "status": "assumed"
+    },
+    "time_delays": {
+      "test": "Achromatic gravitational delays",
+      "data": "H0LiCOW + TDCOSMO",
+      "result": "Δχ²/dof = 8.7e-4",
+      "status": "consistent"
+    },
+    "void_lensing": {
+      "test": "Underdensity lensing signal",
+      "data": "DES Y3",
+      "result": "κ_void/κ_ΛCDM = 0.79 ± 0.15",
+      "status": "intriguing"
+    }
+  },
+
+  "detection_thresholds": {
+    "single_cluster": {
+      "n_bins": 57,
+      "rho_required_2sigma": 0.25,
+      "expected_signal": "0.1-0.2",
+      "power": "under-powered"
+    },
+    "stacked_samples": [
+      {"n_clusters": 10, "n_eff": 570, "detectable_rho_3sigma": 0.08},
+      {"n_clusters": 20, "n_eff": 1140, "detectable_rho_3sigma": 0.06},
+      {"n_clusters": 50, "n_eff": 2850, "detectable_rho_3sigma": 0.04}
+    ]
+  },
+
+  "speculative_prediction": {
+    "name": "Line-of-sight redshift signal",
+    "magnitude": "Δz_LOS ~ 1e-6 to 1e-5",
+    "properties": [
+      "Frequency-independent",
+      "Correlated with entropy structure",
+      "Detectable by stacking cluster-quasar sightlines"
+    ],
+    "test_method": "VLT/UVES (R~40000) or stacked DESI spectra",
+    "null_hypothesis": "ΛCDM predicts no such correlation"
+  },
+
+  "key_caveats": [
+    "Pilot results consistent with null hypothesis",
+    "No evidence for modified gravity claimed",
+    "Methodology validation, not detection",
+    "Larger samples needed for decisive sensitivity"
+  ],
+
+  "confounding_factors": [
+    "Dynamical state coupling (shocks produce both entropy jumps and HSE deviations)",
+    "Projection effects (LOS integration)",
+    "Non-thermal pressure (cosmic rays, magnetic fields, turbulence)",
+    "Mass-sheet degeneracy"
+  ],
+
+  "keywords": [
+    "gravitational lensing",
+    "galaxy clusters",
+    "intracluster medium",
+    "entropy",
+    "hydrostatic equilibrium",
+    "mass discrepancy",
+    "thermodynamic gravity"
+  ]
+}

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/src/__init__.py
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/src/__init__.py
@@ -1,0 +1,20 @@
+"""
+Triangulation Test for Thermodynamic-Lensing Coupling
+
+A methodology to test whether gravitational lensing in galaxy clusters
+exhibits residual structure correlated with ICM thermodynamics.
+"""
+
+from .triangulation_test import (
+    TriangulationAnalysis,
+    ClusterData,
+    run_triangulation_test,
+    stacked_detection_threshold
+)
+
+__all__ = [
+    'TriangulationAnalysis',
+    'ClusterData',
+    'run_triangulation_test',
+    'stacked_detection_threshold'
+]

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/src/triangulation_test.py
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/src/triangulation_test.py
@@ -1,0 +1,326 @@
+"""
+Triangulation Test for Thermodynamic-Lensing Coupling
+
+Implementation of the methodology from:
+"A Triangulation Test for Possible Thermodynamic Contributions
+to Gravitational Lensing in Galaxy Clusters"
+Magnusson (2026) - DOI: 10.6084/m9.figshare.31267297
+"""
+
+import numpy as np
+from scipy import stats
+from typing import Dict, Tuple, Optional
+from dataclasses import dataclass
+
+
+# Physical constants
+k_B = 1.381e-23      # Boltzmann constant [J/K]
+m_p = 1.673e-27      # Proton mass [kg]
+G = 6.674e-11        # Gravitational constant [m³/kg/s²]
+c = 2.998e8          # Speed of light [m/s]
+MU_ICM = 0.6         # Mean molecular weight for ICM
+
+
+@dataclass
+class ClusterData:
+    """Container for cluster observational data."""
+    name: str
+    cluster_type: str  # 'merging' or 'relaxed'
+    r_bins: np.ndarray  # Radial bins [kpc]
+    M_lens: np.ndarray  # Lensing mass profile [M_sun]
+    M_lens_err: np.ndarray  # Lensing mass errors
+    T_profile: np.ndarray  # Temperature profile [keV]
+    n_e_profile: np.ndarray  # Electron density profile [cm^-3]
+    T_err: Optional[np.ndarray] = None
+    n_e_err: Optional[np.ndarray] = None
+
+
+class TriangulationAnalysis:
+    """
+    Triangulation test for thermodynamic-lensing coupling.
+
+    Compares three independent observables:
+    1. M_lens(r) - Lensing mass (geometric)
+    2. M_HSE(r) - Hydrostatic mass (dynamic)
+    3. |∇K(r)| - Entropy gradient (thermodynamic)
+
+    Tests correlation between mass residual R = M_lens - M_HSE
+    and entropy gradient magnitude |∇K|.
+    """
+
+    def __init__(self, data: ClusterData):
+        """
+        Initialize triangulation analysis.
+
+        Parameters
+        ----------
+        data : ClusterData
+            Cluster observational data container
+        """
+        self.data = data
+        self.r = data.r_bins
+        self.M_lens = data.M_lens
+        self.T = data.T_profile
+        self.n_e = data.n_e_profile
+
+        # Computed quantities
+        self._M_HSE = None
+        self._K = None
+        self._grad_K = None
+        self._R = None
+
+    def compute_entropy(self) -> np.ndarray:
+        """
+        Compute ICM entropy profile.
+
+        K(r) = T(r) * n_e(r)^(-2/3)  [keV cm²]
+
+        Returns
+        -------
+        K : ndarray
+            Entropy profile
+        """
+        self._K = self.T * np.power(self.n_e, -2/3)
+        return self._K
+
+    def compute_entropy_gradient(self) -> np.ndarray:
+        """
+        Compute entropy gradient magnitude.
+
+        |∇K(r)| ≈ |dK/dr|
+
+        Returns
+        -------
+        grad_K : ndarray
+            Entropy gradient profile
+        """
+        if self._K is None:
+            self.compute_entropy()
+
+        # Numerical gradient
+        self._grad_K = np.abs(np.gradient(self._K, self.r))
+        return self._grad_K
+
+    def compute_hydrostatic_mass(self) -> np.ndarray:
+        """
+        Compute hydrostatic equilibrium mass.
+
+        M_HSE(<r) = -(kT r)/(μ m_p G) × [d ln n_e/d ln r + d ln T/d ln r]
+
+        Returns
+        -------
+        M_HSE : ndarray
+            Hydrostatic mass profile [M_sun]
+        """
+        # Convert units: T in keV, r in kpc, n_e in cm^-3
+        # Result in solar masses
+
+        # Logarithmic derivatives
+        d_ln_ne_d_ln_r = np.gradient(np.log(self.n_e), np.log(self.r))
+        d_ln_T_d_ln_r = np.gradient(np.log(self.T), np.log(self.r))
+
+        # Convert keV to Joules
+        T_J = self.T * 1.602e-16  # keV to J
+
+        # Convert kpc to meters
+        r_m = self.r * 3.086e19  # kpc to m
+
+        # HSE mass formula
+        M_kg = -(k_B * T_J * r_m) / (MU_ICM * m_p * G) * (
+            d_ln_ne_d_ln_r + d_ln_T_d_ln_r
+        )
+
+        # Convert to solar masses
+        M_sun = 1.989e30  # kg
+        self._M_HSE = np.abs(M_kg) / M_sun
+
+        return self._M_HSE
+
+    def compute_mass_residual(self) -> np.ndarray:
+        """
+        Compute mass residual.
+
+        R(r) = M_lens(r) - M_HSE(r)
+
+        Returns
+        -------
+        R : ndarray
+            Mass residual profile
+        """
+        if self._M_HSE is None:
+            self.compute_hydrostatic_mass()
+
+        self._R = self.M_lens - self._M_HSE
+        return self._R
+
+    def compute_normalized_quantities(self) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Compute normalized residual and gradient for correlation analysis.
+
+        R_norm(r) = R(r) / M_lens(r)
+        G_norm(r) = |∇K(r)| / max|∇K|
+
+        Returns
+        -------
+        R_norm, G_norm : tuple of ndarray
+            Normalized residual and gradient
+        """
+        if self._R is None:
+            self.compute_mass_residual()
+        if self._grad_K is None:
+            self.compute_entropy_gradient()
+
+        R_norm = self._R / self.M_lens
+        G_norm = self._grad_K / np.max(self._grad_K)
+
+        return R_norm, G_norm
+
+    def correlation_test(self) -> Dict:
+        """
+        Perform correlation test between mass residual and entropy gradient.
+
+        Returns
+        -------
+        results : dict
+            Contains Pearson/Spearman correlations, p-values, and interpretation
+        """
+        R_norm, G_norm = self.compute_normalized_quantities()
+
+        # Remove NaN/inf values
+        mask = np.isfinite(R_norm) & np.isfinite(G_norm)
+        R_clean = R_norm[mask]
+        G_clean = G_norm[mask]
+
+        N = len(R_clean)
+
+        # Pearson correlation
+        pearson_rho, pearson_p = stats.pearsonr(R_clean, G_clean)
+
+        # Spearman rank correlation (robust to outliers)
+        spearman_rho, spearman_p = stats.spearmanr(R_clean, G_clean)
+
+        # Significance test
+        # t = ρ √[(N-2)/(1-ρ²)]
+        if abs(pearson_rho) < 1:
+            t_stat = pearson_rho * np.sqrt((N - 2) / (1 - pearson_rho**2))
+        else:
+            t_stat = np.inf
+
+        # Required correlation for 2σ detection
+        rho_2sigma = 2.0 / np.sqrt(N - 2) if N > 2 else 1.0
+
+        results = {
+            'n_bins': N,
+            'pearson_rho': pearson_rho,
+            'pearson_p': pearson_p,
+            'spearman_rho': spearman_rho,
+            'spearman_p': spearman_p,
+            't_statistic': t_stat,
+            'rho_required_2sigma': rho_2sigma,
+            'significant_2sigma': abs(pearson_rho) > rho_2sigma,
+            'interpretation': self._interpret_results(pearson_rho, pearson_p)
+        }
+
+        return results
+
+    def _interpret_results(self, rho: float, p: float) -> str:
+        """Generate interpretation of correlation results."""
+        if p > 0.05:
+            return "No statistically significant correlation detected (p > 0.05)"
+        elif p > 0.01:
+            if rho > 0:
+                return "Weak positive correlation (consistent with thermodynamic coupling)"
+            else:
+                return "Weak negative correlation (opposite to expected sign)"
+        else:
+            if rho > 0:
+                return "Significant positive correlation detected"
+            else:
+                return "Significant negative correlation (unexpected)"
+
+    def summary(self) -> str:
+        """Generate summary report of triangulation analysis."""
+        results = self.correlation_test()
+
+        report = f"""
+Triangulation Test Results: {self.data.name}
+{'='*50}
+Cluster type: {self.data.cluster_type}
+Number of radial bins: {results['n_bins']}
+
+Correlation Analysis:
+  Pearson ρ  = {results['pearson_rho']:.3f}  (p = {results['pearson_p']:.3f})
+  Spearman ρ = {results['spearman_rho']:.3f} (p = {results['spearman_p']:.3f})
+
+Detection threshold (2σ): |ρ| > {results['rho_required_2sigma']:.3f}
+Significant at 2σ: {results['significant_2sigma']}
+
+Interpretation: {results['interpretation']}
+"""
+        return report
+
+
+def stacked_detection_threshold(n_clusters: int, bins_per_cluster: int = 57,
+                                 sigma: float = 3.0) -> float:
+    """
+    Calculate detectable correlation for stacked cluster sample.
+
+    Parameters
+    ----------
+    n_clusters : int
+        Number of clusters in stack
+    bins_per_cluster : int
+        Average number of radial bins per cluster
+    sigma : float
+        Detection significance level
+
+    Returns
+    -------
+    rho_min : float
+        Minimum detectable correlation at given significance
+    """
+    N_eff = n_clusters * bins_per_cluster
+    rho_min = sigma / np.sqrt(N_eff - 2)
+    return rho_min
+
+
+# Convenience function for quick analysis
+def run_triangulation_test(r_kpc: np.ndarray, M_lens_Msun: np.ndarray,
+                           T_keV: np.ndarray, n_e_cm3: np.ndarray,
+                           name: str = "Cluster",
+                           cluster_type: str = "unknown") -> Dict:
+    """
+    Run triangulation test on cluster data.
+
+    Parameters
+    ----------
+    r_kpc : array
+        Radial bins in kpc
+    M_lens_Msun : array
+        Lensing mass profile in solar masses
+    T_keV : array
+        Temperature profile in keV
+    n_e_cm3 : array
+        Electron density profile in cm^-3
+    name : str
+        Cluster name
+    cluster_type : str
+        'merging' or 'relaxed'
+
+    Returns
+    -------
+    results : dict
+        Correlation test results
+    """
+    data = ClusterData(
+        name=name,
+        cluster_type=cluster_type,
+        r_bins=np.array(r_kpc),
+        M_lens=np.array(M_lens_Msun),
+        M_lens_err=np.zeros_like(M_lens_Msun),
+        T_profile=np.array(T_keV),
+        n_e_profile=np.array(n_e_cm3)
+    )
+
+    analysis = TriangulationAnalysis(data)
+    return analysis.correlation_test()


### PR DESCRIPTION
Methodology to test for thermodynamic-lensing coupling in galaxy clusters.

Package includes:
- README.md: Full documentation with equations and detection thresholds
- index.json: Machine-readable metadata and pilot results
- src/triangulation_test.py: TriangulationAnalysis class
- data/pilot_results.json: Bullet Cluster and Abell 1835 results
- examples/triangulation_demo.py: Demonstration on mock data
- CITATION.cff (DOI: 10.6084/m9.figshare.31267297) and LICENSE

Three observables: M_lens (geometric), M_HSE (dynamic), |∇K| (thermodynamic) Pilot results: Bullet ρ=-0.129 (p=0.21), Abell 1835 ρ=-0.052 (p=0.70) Both null - consistent with sensitivity limits for %-level effects

https://claude.ai/code/session_01DU4ATUVjhJgkqLDz9ZdvzX