### PR TITLE
Add AI-friendly package for Entropy-Structure Coupling paper

### DIFF
--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/CITATION.cff
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/CITATION.cff
@@ -1,0 +1,32 @@
+cff-version: 1.2.0
+message: "If you use this work, please cite it as below."
+type: article
+title: "A Pre-Registered Test of Entropy–Structure Coupling in Simulated and Observed Galaxy Clusters"
+authors:
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+date-released: 2026-02-01
+identifiers:
+  - type: doi
+    value: "10.6084/m9.figshare.31286368"
+    description: "Figshare DOI"
+repository: "https://github.com/supertedai/EFC"
+keywords:
+  - galaxy clusters
+  - intracluster medium
+  - cool cores
+  - entropy profiles
+  - cosmological simulations
+  - TNG-Cluster
+  - pre-registered analysis
+  - ACCEPT
+abstract: >-
+  We test whether the observed positive correlation between entropy profile
+  steepness and cool-core state reported in the ACCEPT X-ray cluster sample
+  (ρ(α, y_CCT) ~ +0.36) is reproduced in the TNG-Cluster cosmological MHD
+  simulation (352 halos). Using pre-registered statistical tests, we find a
+  strong negative correlation ρ(n_e-slope, K0) = -0.872 (p ~ 10^-111), robust
+  against mass confounding. This potential sim-obs mismatch raises questions
+  about ICM physics in modern ΛCDM hydrodynamic simulations.
+license: MIT

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/LICENSE
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Morten Magnusson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/README.md
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/README.md
@@ -1,0 +1,171 @@
+# A Pre-Registered Test of Entropy–Structure Coupling in Simulated and Observed Galaxy Clusters
+
+**Author:** Morten Magnusson
+**ORCID:** [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095)
+**Date:** February 2026
+**DOI:** [10.6084/m9.figshare.31286368](https://doi.org/10.6084/m9.figshare.31286368)
+
+## Abstract
+
+This paper tests whether the observed positive correlation between entropy profile steepness and cool-core state reported in the ACCEPT X-ray cluster sample (ρ(α, y_CCT) ~ +0.36; Cavagnolo et al. 2009) is reproduced in the TNG-Cluster cosmological magnetohydrodynamical simulation (352 halos, 10¹⁴ < M₅₀₀c/M☉ < 2×10¹⁵ at z = 0). Using pre-registered statistical tests, we find a **strong negative correlation** ρ(n_e-slope, K₀) = -0.872 (p ~ 10⁻¹¹¹), robust against mass confounding and consistent across all four mass bins.
+
+## Key Findings
+
+### Sign Flip in Entropy-Structure Coupling
+
+| Dataset | Correlation | Value | p-value |
+|---------|-------------|-------|---------|
+| **TNG-Cluster** | ρ(n_e-slope, K₀) | **-0.872** | ~8×10⁻¹¹¹ |
+| **TNG-Cluster** | ρ(n_e-slope, t_cool) | **-0.878** | ~7×10⁻¹¹⁴ |
+| **ACCEPT (observed)** | ρ(α, y_CCT) | **+0.36** | — |
+
+The sign is **completely reversed** between simulation and observation.
+
+### Robustness Tests
+
+- **Mass-controlled**: ρ_partial(n_e-slope, K₀ | M) = -0.880 (p = 2×10⁻¹¹⁵)
+- **Mass explains**: 0% of the correlation
+- **All mass bins**: Negative correlations in all four bins
+
+## Physical Model
+
+### Entropy Profile (Cavagnolo et al. 2009)
+
+```
+K(r) = K₀ + K₁₀₀ × (r / 100 kpc)^α
+```
+
+Where:
+- **K₀**: Central entropy (keV cm²)
+- **K₁₀₀**: Entropy normalisation at 100 kpc
+- **α**: Power-law index (entropy gradient steepness)
+
+### Proxy Definition
+
+The entropy slope decomposes as:
+
+```
+α = d ln K / d ln r = d ln T / d ln r + (2/3) × (-d ln n_e / d ln r)
+```
+
+We define the density-based proxy:
+
+```
+α_proxy = (2/3) × n_e-slope
+```
+
+This is a **lower bound** on α under the physical expectation that temperature rises with radius in cluster cores.
+
+### Cool-Core Classification (Hudson et al. 2010)
+
+| Class | K₀ threshold | TNG-Cluster count |
+|-------|-------------|-------------------|
+| SCC (Strong Cool-Core) | K₀ ≤ 22 keV cm² | 28 (8%) |
+| WCC (Weak Cool-Core) | 22 < K₀ ≤ 150 | 206 (59%) |
+| NCC (Non-Cool-Core) | K₀ > 150 | 118 (34%) |
+
+## Mass-Binned Results
+
+| Mass bin (log M) | N | ρ | p-value |
+|------------------|---|---|---------|
+| [14.0, 14.3) | 41 | -0.790 | 9×10⁻¹⁰ |
+| [14.3, 14.6) | 118 | -0.860 | 1×10⁻³⁵ |
+| [14.6, 14.9) | 121 | -0.901 | 5×10⁻⁴⁵ |
+| [14.9, 15.5) | 71 | -0.897 | 4×10⁻²⁶ |
+| **All (partial\|M)** | 352 | **-0.880** | 2×10⁻¹¹⁵ |
+
+## Pre-Registered Test Design
+
+### Two-Stage Approach
+
+1. **Path B (Pre-test)**: Proxy-based analysis using α_proxy = (2/3) × n_e-slope
+   - Computationally efficient
+   - Tests sign of correlation
+   - Results: Sign flip confirmed
+
+2. **Path A (Decisive)**: Full Cavagnolo-model K(r) fit over [20, 400] kpc
+   - Definition-matched comparison
+   - Eliminates systematic ambiguities
+   - Pre-registered, awaiting execution
+
+### Stop/Go Criterion
+
+- **STOP**: ρ(α_fit, K₀) > 0 → Sign flip reverses under definition matching
+- **GO**: ρ(α_fit, K₀) < 0 → Sign flip survives (genuine mismatch)
+- **PARTIAL**: Mixed signs require further investigation
+
+## Interpretation Framework
+
+If the sign flip is confirmed by Path A, three explanations must be considered:
+
+1. **Subgrid modelling**: AGN feedback in TNG may produce overly mechanical CC/NCC transitions
+2. **Observational systematics**: Projection effects or selection effects in ACCEPT
+3. **Missing physics**: Cosmic ray transport, anisotropic conduction, magnetic draping
+
+## Data Sources
+
+- **TNG-Cluster**: 352 zoom simulations at TNG300-1 resolution (Nelson et al. 2024)
+- **Lehle et al. (2024)**: Supplementary catalogue with K₀, n_e-slope, t_cool, C_phys
+- **ACCEPT**: 239 Chandra clusters with deprojected entropy profiles (Cavagnolo et al. 2009)
+
+## Package Contents
+
+```
+├── README.md                    # This file
+├── index.json                   # Machine-readable metadata
+├── src/
+│   └── entropy_structure_coupling.py  # Reference implementation
+├── data/
+│   └── tng_cluster_results.json      # Correlation data and statistics
+├── examples/
+│   └── entropy_structure_demo.py     # Demonstration script
+├── CITATION.cff                 # Citation metadata
+└── LICENSE                      # MIT License
+```
+
+## Quick Start
+
+```python
+from src.entropy_structure_coupling import (
+    EntropyProfileModel, CorrelationAnalysis, CoolCoreClassifier
+)
+
+# Initialize entropy profile model
+model = EntropyProfileModel(K0=20.0, K100=150.0, alpha=1.1)
+
+# Compute entropy at radius
+K = model.entropy(r=100)  # keV cm²
+
+# Correlation analysis
+analysis = CorrelationAnalysis()
+tng_result = analysis.tng_correlation()
+# Returns: rho=-0.872, p=8e-111
+
+# Cool-core classification
+classifier = CoolCoreClassifier()
+cc_class = classifier.classify(K0=15.0)  # Returns: "SCC"
+```
+
+## Key Equations
+
+### Entropy Definition
+```
+K = k_B T × n_e^(-2/3)
+```
+
+### Spearman Correlation with Mass Control
+```
+ρ_partial(X, Y | M) = ρ(X_residual, Y_residual)
+```
+where residuals are computed via rank-based residualisation on log M₅₀₀c.
+
+## References
+
+- Cavagnolo, K. W., et al. 2009, ApJS, 182, 12 (ACCEPT)
+- Hudson, D. S., et al. 2010, A&A, 513, A37 (CC classification)
+- Lehle, K., et al. 2024, A&A, 687, A30 (TNG-Cluster CC properties)
+- Nelson, D., et al. 2024, A&A, 686, A157 (TNG-Cluster simulation)
+
+## License
+
+MIT License - See LICENSE file for details.

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/data/tng_cluster_results.json
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/data/tng_cluster_results.json
@@ -1,0 +1,163 @@
+{
+  "dataset": "TNG-Cluster + ACCEPT comparison",
+  "description": "Entropy-structure coupling correlation analysis",
+  "reference": "Magnusson (2026), DOI: 10.6084/m9.figshare.31286368",
+  "tng_cluster": {
+    "description": "TNG-Cluster cosmological MHD simulation",
+    "reference": "Nelson et al. 2024; Lehle et al. 2024",
+    "n_halos": 352,
+    "redshift": 0,
+    "mass_range": {
+      "log_M500c_min": 14.0,
+      "log_M500c_max": 15.3,
+      "unit": "log10(M_sun)"
+    },
+    "cool_core_population": {
+      "SCC": {"count": 28, "fraction": 0.08, "threshold": "K0 <= 22 keV cm^2"},
+      "WCC": {"count": 206, "fraction": 0.59, "threshold": "22 < K0 <= 150 keV cm^2"},
+      "NCC": {"count": 118, "fraction": 0.34, "threshold": "K0 > 150 keV cm^2"}
+    }
+  },
+  "accept": {
+    "description": "Archive of Chandra Cluster Entropy Profile Tables",
+    "reference": "Cavagnolo et al. 2009",
+    "n_clusters": 239,
+    "correlation_alpha_yCCT": {
+      "rho": 0.36,
+      "description": "Entropy slope alpha vs central cooling time indicator"
+    }
+  },
+  "primary_correlations": {
+    "ne_slope_vs_K0": {
+      "description": "Electron density slope vs central entropy",
+      "rho": -0.872,
+      "p_value": 7.96e-111,
+      "N": 352
+    },
+    "ne_slope_vs_tcool": {
+      "description": "Electron density slope vs central cooling time",
+      "rho": -0.878,
+      "p_value": 7.21e-114,
+      "N": 352
+    },
+    "Cphys_vs_K0": {
+      "description": "X-ray concentration vs central entropy",
+      "rho": -0.927,
+      "N": 352
+    },
+    "Cphys_vs_ne_slope": {
+      "description": "X-ray concentration vs density slope",
+      "rho": 0.875,
+      "N": 352
+    },
+    "K0_vs_M500c": {
+      "description": "Central entropy vs halo mass (weak correlation)",
+      "rho": 0.242,
+      "p_value": 4.33e-6,
+      "N": 352
+    }
+  },
+  "mass_controlled": {
+    "partial_ne_slope_K0_given_M": {
+      "description": "Partial correlation controlling for log M500c",
+      "rho": -0.880,
+      "p_value": 2e-115,
+      "N": 352,
+      "mass_contribution": "0%"
+    },
+    "interpretation": "Mass confounding does NOT explain the sign flip"
+  },
+  "mass_binned_analysis": {
+    "description": "Spearman correlations ne_slope vs K0 by mass bin",
+    "bins": [
+      {
+        "mass_bin": "[14.0, 14.3)",
+        "N": 41,
+        "rho": -0.790,
+        "p_value": 9e-10
+      },
+      {
+        "mass_bin": "[14.3, 14.6)",
+        "N": 118,
+        "rho": -0.860,
+        "p_value": 1e-35
+      },
+      {
+        "mass_bin": "[14.6, 14.9)",
+        "N": 121,
+        "rho": -0.901,
+        "p_value": 5e-45
+      },
+      {
+        "mass_bin": "[14.9, 15.5)",
+        "N": 71,
+        "rho": -0.897,
+        "p_value": 4e-26
+      }
+    ],
+    "verdict": "All mass bins show negative correlations"
+  },
+  "proxy_definition_matching": {
+    "description": "Alpha proxy = (2/3) × ne_slope analysis",
+    "alpha_proxy_distribution": {
+      "min": -0.23,
+      "max": 1.60,
+      "median": 0.31,
+      "accept_median_for_comparison": 1.1
+    },
+    "correlations": {
+      "alpha_proxy_vs_K0_raw": {"rho": -0.872, "p_value": 8e-111, "N": 352},
+      "alpha_proxy_vs_K0_partial_M": {"rho": -0.880, "p_value": 2e-115, "N": 352},
+      "alpha_proxy_vs_tcool_raw": {"rho": -0.878, "p_value": 7e-114, "N": 352},
+      "alpha_proxy_vs_tcool_partial_M": {"rho": -0.876, "p_value": 1e-112, "N": 352}
+    }
+  },
+  "ks_test": {
+    "description": "Kolmogorov-Smirnov test between SCC and NCC density slopes",
+    "D_statistic": 1.000,
+    "p_value": 2.4e-30,
+    "interpretation": "Complete separation between SCC and NCC"
+  },
+  "sign_flip_summary": {
+    "tng_cluster_rho": -0.872,
+    "accept_rho": 0.36,
+    "sign_reversal": true,
+    "magnitude_difference": 1.23,
+    "statistical_significance": "p ~ 10^-111 for TNG result"
+  },
+  "pre_registered_tests": {
+    "path_b_pretest": {
+      "status": "completed",
+      "method": "Proxy-based using alpha_proxy = (2/3) × ne_slope",
+      "result": "Sign flip confirmed",
+      "verdict": "GO - proceed to Path A"
+    },
+    "path_a_decisive": {
+      "status": "pre-registered, awaiting execution",
+      "method": "Full Cavagnolo-model K(r) fit over [20, 400] kpc",
+      "locked_parameters": {
+        "centre": "SUBFIND-determined",
+        "fit_range_kpc": [20, 400],
+        "initial_alpha_guess": 1.1,
+        "n_radial_bins": 30,
+        "binning": "mass-weighted",
+        "min_bin_occupancy": 5,
+        "gas_selection": "non-star-forming, T > 1e6 K"
+      },
+      "stop_go_criterion": {
+        "STOP": "rho(alpha_fit, K0) > 0 AND rho(alpha_fit, tcool) > 0",
+        "GO": "rho(alpha_fit, K0) < 0",
+        "PARTIAL": "Mixed signs"
+      }
+    }
+  },
+  "systematic_considerations": {
+    "irreducible_differences": [
+      "TNG: intrinsic 3D mass-weighted quantities",
+      "ACCEPT: deprojected X-ray spectroscopic with emission weighting",
+      "TNG: mass-selected sample",
+      "ACCEPT: X-ray selected, flux-limited sample"
+    ],
+    "expected_impact": "Affects absolute normalisation but not expected to reverse rank-order correlations"
+  }
+}

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/examples/entropy_structure_demo.py
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/examples/entropy_structure_demo.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""
+Entropy-Structure Coupling - Demonstration
+
+This script demonstrates the key concepts from:
+Magnusson (2026) "A Pre-Registered Test of Entropy–Structure Coupling
+in Simulated and Observed Galaxy Clusters"
+DOI: 10.6084/m9.figshare.31286368
+"""
+
+import sys
+sys.path.insert(0, '..')
+
+from src.entropy_structure_coupling import (
+    EntropyProfileModel, AlphaProxy, CoolCoreClassifier, CoolCoreClass,
+    CorrelationAnalysis, PreRegisteredTest, InterpretationFramework,
+    compute_entropy, classify_cool_core
+)
+
+
+def demo_entropy_profile():
+    """
+    Demonstrate the Cavagnolo et al. (2009) entropy profile model.
+
+    K(r) = K0 + K100 × (r / 100 kpc)^α
+    """
+    print("=" * 60)
+    print("ENTROPY PROFILE MODEL (Cavagnolo et al. 2009)")
+    print("=" * 60)
+
+    # Typical cool-core cluster parameters
+    model_cc = EntropyProfileModel(K0=10.0, K100=100.0, alpha=1.1)
+
+    # Typical non-cool-core cluster parameters
+    model_ncc = EntropyProfileModel(K0=200.0, K100=80.0, alpha=0.9)
+
+    print("\nCool-core cluster:")
+    print(f"  K0 = {model_cc.params.K0} keV cm²")
+    print(f"  K100 = {model_cc.params.K100} keV cm²")
+    print(f"  α = {model_cc.params.alpha}")
+
+    print("\nNon-cool-core cluster:")
+    print(f"  K0 = {model_ncc.params.K0} keV cm²")
+    print(f"  K100 = {model_ncc.params.K100} keV cm²")
+    print(f"  α = {model_ncc.params.alpha}")
+
+    # Compute entropy at various radii
+    print("\n" + "-" * 40)
+    print("Entropy profiles K(r) [keV cm²]:")
+    print("-" * 40)
+    print(f"{'r [kpc]':>10}  {'CC cluster':>12}  {'NCC cluster':>12}")
+    print("-" * 36)
+
+    for r in [10, 20, 50, 100, 200, 400]:
+        K_cc = model_cc.entropy(r)
+        K_ncc = model_ncc.entropy(r)
+        print(f"{r:>10}  {K_cc:>12.1f}  {K_ncc:>12.1f}")
+
+    print("\nKey insight: CC clusters have steep gradients (low K0, high α)")
+    print("             NCC clusters have flat profiles (high K0, lower α)")
+
+
+def demo_cool_core_classification():
+    """
+    Demonstrate cool-core classification following Hudson et al. (2010).
+    """
+    print("\n" + "=" * 60)
+    print("COOL-CORE CLASSIFICATION (Hudson et al. 2010)")
+    print("=" * 60)
+
+    classifier = CoolCoreClassifier()
+
+    print("\nClassification thresholds:")
+    print("  SCC (Strong Cool-Core):  K0 ≤ 22 keV cm²")
+    print("  WCC (Weak Cool-Core):    22 < K0 ≤ 150 keV cm²")
+    print("  NCC (Non-Cool-Core):     K0 > 150 keV cm²")
+
+    print("\n" + "-" * 40)
+    print("Example classifications:")
+    print("-" * 40)
+
+    test_values = [10, 22, 50, 100, 150, 200, 300]
+    for K0 in test_values:
+        cc_class = classifier.classify(K0)
+        print(f"  K0 = {K0:>4} keV cm² → {cc_class.name} ({cc_class.value})")
+
+    # TNG-Cluster population
+    print("\n" + "-" * 40)
+    print("TNG-Cluster population (352 halos at z=0):")
+    print("-" * 40)
+    pop = classifier.tng_population()
+    print(f"  SCC: {pop['SCC']['count']:>4} ({pop['SCC']['fraction']*100:.0f}%)")
+    print(f"  WCC: {pop['WCC']['count']:>4} ({pop['WCC']['fraction']*100:.0f}%)")
+    print(f"  NCC: {pop['NCC']['count']:>4} ({pop['NCC']['fraction']*100:.0f}%)")
+
+
+def demo_alpha_proxy():
+    """
+    Demonstrate the α_proxy definition for entropy gradient.
+    """
+    print("\n" + "=" * 60)
+    print("ALPHA PROXY DEFINITION")
+    print("=" * 60)
+
+    print("\nEntropy slope decomposition:")
+    print("  α = d ln K / d ln r = d ln T / d ln r + (2/3) × (-d ln n_e / d ln r)")
+    print("\nProxy definition:")
+    print("  α_proxy = (2/3) × n_e-slope")
+    print("\nPhysical interpretation:")
+    print("  - Represents density contribution to entropy gradient")
+    print("  - Lower bound on α (assuming T increases with r in cores)")
+
+    print("\n" + "-" * 40)
+    print("Example calculations:")
+    print("-" * 40)
+
+    ne_slopes = [0.3, 0.5, 1.0, 1.5, 2.0, 2.5]
+    print(f"{'n_e-slope':>12}  {'α_proxy':>10}")
+    print("-" * 24)
+    for ne_slope in ne_slopes:
+        alpha_proxy = AlphaProxy.compute(ne_slope)
+        print(f"{ne_slope:>12.1f}  {alpha_proxy:>10.3f}")
+
+    print("\nTNG-Cluster α_proxy distribution:")
+    print("  Min: -0.23, Max: 1.60, Median: 0.31")
+    print("  ACCEPT median α ~ 1.1")
+
+
+def demo_sign_flip():
+    """
+    Demonstrate the key finding: sign flip in entropy-structure coupling.
+    """
+    print("\n" + "=" * 60)
+    print("SIGN FLIP: THE KEY FINDING")
+    print("=" * 60)
+
+    analysis = CorrelationAnalysis()
+
+    tng = analysis.tng_correlation("ne_slope_vs_K0")
+    accept = analysis.accept_correlation()
+
+    print("\nCorrelation between entropy gradient steepness and cool-core state:")
+    print("\n" + "-" * 50)
+    print(f"{'Dataset':>20}  {'Correlation':>15}  {'Sign':>8}")
+    print("-" * 50)
+    print(f"{'TNG-Cluster':>20}  ρ = {tng.rho:>+.3f}       {'NEGATIVE':>8}")
+    print(f"{'ACCEPT (observed)':>20}  ρ = {accept.rho:>+.3f}       {'POSITIVE':>8}")
+    print("-" * 50)
+
+    print("\n⚠️  COMPLETE SIGN REVERSAL!")
+    print("\nInterpretation:")
+    print("  In OBSERVATIONS: Steeper profiles → higher cooling times")
+    print("  In SIMULATIONS:  Steeper profiles → lower cooling times")
+
+    print("\nStatistical significance:")
+    print(f"  TNG: p ~ {tng.p_value:.0e} (N = {tng.N})")
+    print("  This is NOT a statistical fluctuation!")
+
+
+def demo_robustness():
+    """
+    Demonstrate robustness tests for the sign flip.
+    """
+    print("\n" + "=" * 60)
+    print("ROBUSTNESS TESTS")
+    print("=" * 60)
+
+    analysis = CorrelationAnalysis()
+
+    print("\n1. MASS CONFOUNDING TEST")
+    print("-" * 40)
+    summary = analysis.summary()
+    print(f"  Raw correlation:     ρ = {summary['tng_rho']:.3f}")
+    print(f"  Mass-controlled:     ρ = {summary['partial_rho_mass_controlled']:.3f}")
+    print(f"  Mass contribution:   {summary['mass_contribution']}")
+    print("  → Mass does NOT explain the sign flip")
+
+    print("\n2. MASS-BINNED ANALYSIS")
+    print("-" * 40)
+    print(f"{'Mass bin':>15}  {'N':>5}  {'ρ':>8}")
+    print("-" * 32)
+    for bin_result in analysis.mass_binned_results():
+        print(f"{bin_result['bin']:>15}  {bin_result['N']:>5}  {bin_result['rho']:>+8.3f}")
+    print("-" * 32)
+    print("  → ALL bins show negative correlations")
+
+    print("\n3. DEFINITION MATCHING")
+    print("-" * 40)
+    print("  Using α_proxy = (2/3) × n_e-slope:")
+    print(f"    ρ(α_proxy, K0) raw:       {-0.872:+.3f}")
+    print(f"    ρ(α_proxy, K0) partial|M: {-0.880:+.3f}")
+    print(f"    ρ(α_proxy, tcool) raw:    {-0.878:+.3f}")
+    print("  → Sign flip persists under proxy definition matching")
+
+
+def demo_pre_registered_test():
+    """
+    Demonstrate the pre-registered test design.
+    """
+    print("\n" + "=" * 60)
+    print("PRE-REGISTERED TEST DESIGN")
+    print("=" * 60)
+
+    test = PreRegisteredTest()
+
+    print("\nTWO-STAGE APPROACH:")
+
+    # Path B
+    print("\n1. PATH B: Proxy-Based Pre-Test")
+    print("-" * 40)
+    path_b = test.path_b_summary()
+    print(f"  Status: {path_b['status']}")
+    print(f"  Proxy:  {path_b['proxy']}")
+    print(f"  Result: {path_b['result']}")
+    print(f"  Verdict: {path_b['verdict']}")
+
+    # Path A
+    print("\n2. PATH A: Decisive Full Profile Fit")
+    print("-" * 40)
+    path_a = test.path_a_summary()
+    print(f"  Status: {path_a['status']}")
+    print(f"  Method: {path_a['description']}")
+    print("  Locked parameters:")
+    for key, value in path_a['parameters'].items():
+        print(f"    {key}: {value}")
+
+    print("\n3. STOP/GO CRITERION")
+    print("-" * 40)
+    print("  STOP:    ρ(α_fit, K0) > 0 AND ρ(α_fit, tcool) > 0")
+    print("           → Sign flip reverses under definition matching")
+    print("  GO:      ρ(α_fit, K0) < 0")
+    print("           → Sign flip survives (genuine sim-obs mismatch)")
+    print("  PARTIAL: Mixed signs → further investigation needed")
+
+
+def demo_interpretation():
+    """
+    Demonstrate the interpretation framework.
+    """
+    print("\n" + "=" * 60)
+    print("INTERPRETATION FRAMEWORK")
+    print("=" * 60)
+
+    framework = InterpretationFramework()
+
+    print("\nIf sign flip is confirmed by Path A, three explanations:")
+    print()
+
+    for i, explanation in enumerate(framework.POSSIBLE_EXPLANATIONS, 1):
+        print(f"{i}. {explanation['name'].upper()}")
+        print(f"   {explanation['description']}")
+        print(f"   Testable via: {explanation['testable']}")
+        print()
+
+    print("-" * 60)
+    print("KEY IMPLICATION:")
+    print("-" * 60)
+    print(framework.get_implications())
+
+
+def demo_ks_test():
+    """
+    Demonstrate the Kolmogorov-Smirnov test between CC populations.
+    """
+    print("\n" + "=" * 60)
+    print("POPULATION SEPARATION TEST")
+    print("=" * 60)
+
+    print("\nKolmogorov-Smirnov test: SCC vs NCC density slopes")
+    print("-" * 40)
+    print("  D statistic: 1.000")
+    print("  p-value:     2.4 × 10⁻³⁰")
+    print()
+    print("  Interpretation: COMPLETE SEPARATION")
+    print("  SCC and NCC clusters have entirely non-overlapping")
+    print("  density slope distributions in TNG-Cluster.")
+
+
+def main():
+    """Run all demonstrations."""
+    print("\n" + "#" * 60)
+    print("# ENTROPY-STRUCTURE COUPLING DEMONSTRATION")
+    print("# From: Magnusson (2026)")
+    print("# DOI: 10.6084/m9.figshare.31286368")
+    print("#" * 60)
+
+    demo_entropy_profile()
+    demo_cool_core_classification()
+    demo_alpha_proxy()
+    demo_sign_flip()
+    demo_robustness()
+    demo_pre_registered_test()
+    demo_ks_test()
+    demo_interpretation()
+
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print("""
+TNG-Cluster shows a STRONG NEGATIVE correlation between entropy
+gradient steepness and cool-core state (ρ = -0.87), while ACCEPT
+observations show a POSITIVE correlation (ρ = +0.36).
+
+This sign flip is:
+  ✓ Not driven by mass confounding
+  ✓ Consistent across all mass bins
+  ✓ Preserved under proxy definition matching
+
+The pre-registered Path A test will determine whether this represents
+a genuine simulation-observation mismatch in ICM physics.
+
+If confirmed, the question arises: Why do modern ΛCDM hydrodynamic
+simulations not reproduce the observed entropy-structure coupling
+in galaxy clusters?
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/index.json
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/index.json
@@ -1,0 +1,230 @@
+{
+  "paper": {
+    "title": "A Pre-Registered Test of Entropy–Structure Coupling in Simulated and Observed Galaxy Clusters",
+    "short_title": "Entropy-Structure Coupling Test",
+    "author": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "date": "2026-02",
+    "status": "pre-print",
+    "doi": "10.6084/m9.figshare.31286368",
+    "keywords": [
+      "galaxy clusters",
+      "intracluster medium",
+      "cool cores",
+      "entropy profiles",
+      "cosmological simulations",
+      "TNG-Cluster",
+      "pre-registered analysis"
+    ]
+  },
+  "abstract": "Tests whether the observed positive correlation between entropy profile steepness and cool-core state in ACCEPT X-ray clusters is reproduced in TNG-Cluster simulations. Finds a strong negative correlation (sign flip), robust against mass confounding.",
+  "key_result": {
+    "description": "Sign flip in entropy-structure coupling between simulation and observation",
+    "tng_cluster": {
+      "correlation_ne_slope_K0": -0.872,
+      "p_value": "8e-111",
+      "n_halos": 352
+    },
+    "accept_observed": {
+      "correlation_alpha_yCCT": 0.36,
+      "n_clusters": 239
+    },
+    "interpretation": "Complete sign reversal indicates potential sim-obs mismatch in ICM physics"
+  },
+  "data_sources": {
+    "tng_cluster": {
+      "reference": "Nelson et al. 2024",
+      "description": "352 zoom simulations of massive galaxy clusters",
+      "mass_range": {
+        "min_log_M500c": 14.0,
+        "max_log_M500c": 15.3,
+        "unit": "log10(M_sun)"
+      },
+      "redshift": 0,
+      "resolution": "TNG300-1",
+      "gas_mass_resolution": {
+        "value": 1.2e7,
+        "unit": "M_sun"
+      }
+    },
+    "lehle_catalogue": {
+      "reference": "Lehle et al. 2024",
+      "variables": ["K0", "ne_slope", "tcool", "ne", "Cphys", "Cscaled"],
+      "gas_selection": "non-star-forming, T > 1e6 K, mass-weighted"
+    },
+    "accept": {
+      "reference": "Cavagnolo et al. 2009",
+      "description": "Archive of Chandra Cluster Entropy Profile Tables",
+      "n_clusters": 239,
+      "instrument": "Chandra"
+    }
+  },
+  "models": {
+    "entropy_profile": {
+      "name": "Cavagnolo model",
+      "equation": "K(r) = K0 + K100 * (r / 100 kpc)^alpha",
+      "parameters": {
+        "K0": {
+          "description": "Central entropy",
+          "unit": "keV cm^2"
+        },
+        "K100": {
+          "description": "Entropy normalisation at 100 kpc",
+          "unit": "keV cm^2"
+        },
+        "alpha": {
+          "description": "Power-law index (entropy gradient steepness)",
+          "accept_median": 1.1
+        }
+      }
+    },
+    "alpha_proxy": {
+      "equation": "alpha_proxy = (2/3) * ne_slope",
+      "description": "Density contribution to entropy gradient",
+      "interpretation": "Lower bound on alpha under physical temperature gradient assumption",
+      "tng_distribution": {
+        "min": -0.23,
+        "max": 1.60,
+        "median": 0.31
+      }
+    },
+    "entropy_decomposition": {
+      "equation": "alpha = d_ln_T/d_ln_r + (2/3) * (-d_ln_ne/d_ln_r)",
+      "description": "Logarithmic entropy slope decomposed into temperature and density terms"
+    }
+  },
+  "cool_core_classification": {
+    "reference": "Hudson et al. 2010",
+    "thresholds": {
+      "SCC": {
+        "name": "Strong Cool-Core",
+        "criterion": "K0 <= 22 keV cm^2"
+      },
+      "WCC": {
+        "name": "Weak Cool-Core",
+        "criterion": "22 < K0 <= 150 keV cm^2"
+      },
+      "NCC": {
+        "name": "Non-Cool-Core",
+        "criterion": "K0 > 150 keV cm^2"
+      }
+    },
+    "tng_population": {
+      "SCC": {"count": 28, "fraction": 0.08},
+      "WCC": {"count": 206, "fraction": 0.59},
+      "NCC": {"count": 118, "fraction": 0.34}
+    }
+  },
+  "results": {
+    "primary_correlations": {
+      "ne_slope_vs_K0": {
+        "rho": -0.872,
+        "p_value": "8e-111",
+        "N": 352
+      },
+      "ne_slope_vs_tcool": {
+        "rho": -0.878,
+        "p_value": "7e-114",
+        "N": 352
+      },
+      "Cphys_vs_K0": {
+        "rho": -0.927,
+        "description": "Internal consistency check"
+      },
+      "Cphys_vs_ne_slope": {
+        "rho": 0.875,
+        "description": "Internal consistency check"
+      }
+    },
+    "mass_controlled": {
+      "partial_ne_slope_K0_given_M": {
+        "rho": -0.880,
+        "p_value": "2e-115",
+        "mass_contribution": "0%"
+      },
+      "interpretation": "Sign flip is NOT driven by mass confounding"
+    },
+    "mass_binned": [
+      {"bin": "[14.0, 14.3)", "N": 41, "rho": -0.790, "p_value": "9e-10"},
+      {"bin": "[14.3, 14.6)", "N": 118, "rho": -0.860, "p_value": "1e-35"},
+      {"bin": "[14.6, 14.9)", "N": 121, "rho": -0.901, "p_value": "5e-45"},
+      {"bin": "[14.9, 15.5)", "N": 71, "rho": -0.897, "p_value": "4e-26"}
+    ],
+    "proxy_definition_matching": {
+      "alpha_proxy_vs_K0_raw": {"rho": -0.872, "p_value": "8e-111"},
+      "alpha_proxy_vs_K0_partial_M": {"rho": -0.880, "p_value": "2e-115"},
+      "alpha_proxy_vs_tcool_raw": {"rho": -0.878, "p_value": "7e-114"},
+      "alpha_proxy_vs_tcool_partial_M": {"rho": -0.876, "p_value": "1e-112"}
+    },
+    "ks_test_scc_vs_ncc": {
+      "D_statistic": 1.000,
+      "p_value": "2.4e-30",
+      "interpretation": "Complete separation between SCC and NCC density slopes"
+    }
+  },
+  "pre_registered_tests": {
+    "path_b": {
+      "name": "Proxy-Based Pre-Test",
+      "status": "completed",
+      "description": "Computationally efficient test using alpha_proxy",
+      "result": "Sign flip confirmed"
+    },
+    "path_a": {
+      "name": "Decisive Full Profile Fit",
+      "status": "pre-registered, awaiting execution",
+      "description": "Full Cavagnolo-model K(r) fit over [20, 400] kpc",
+      "parameters_locked": {
+        "centre": "SUBFIND-determined",
+        "fit_range_kpc": [20, 400],
+        "initial_alpha_guess": 1.1,
+        "binning": "mass-weighted",
+        "n_radial_bins": 30,
+        "min_bin_occupancy": 5
+      }
+    },
+    "stop_go_criterion": {
+      "STOP": "rho(alpha_fit, K0) > 0 AND rho(alpha_fit, tcool) > 0",
+      "GO": "rho(alpha_fit, K0) < 0",
+      "PARTIAL": "Mixed signs across CC proxies"
+    }
+  },
+  "interpretation": {
+    "possible_explanations": [
+      {
+        "name": "Subgrid modelling",
+        "description": "AGN feedback in TNG may produce overly mechanical CC/NCC transitions"
+      },
+      {
+        "name": "Observational systematics",
+        "description": "Projection effects, spectral fitting biases, or selection effects in ACCEPT"
+      },
+      {
+        "name": "Missing physics",
+        "description": "Cosmic ray transport, anisotropic conduction, magnetic draping not captured"
+      }
+    ],
+    "systematic_differences": [
+      "TNG: intrinsic 3D mass-weighted quantities",
+      "ACCEPT: deprojected X-ray spectroscopic with emission weighting",
+      "TNG: mass-selected sample",
+      "ACCEPT: X-ray selected, flux-limited sample"
+    ],
+    "implications": "Framework-independent question: Why do modern ΛCDM hydrodynamic simulations not reproduce the observed entropy-structure coupling?"
+  },
+  "package_contents": {
+    "source_code": "src/entropy_structure_coupling.py",
+    "data_file": "data/tng_cluster_results.json",
+    "example": "examples/entropy_structure_demo.py",
+    "documentation": "README.md"
+  },
+  "references": [
+    {"key": "Cavagnolo2009", "citation": "Cavagnolo, K. W., et al. 2009, ApJS, 182, 12"},
+    {"key": "Fabian1994", "citation": "Fabian, A. C. 1994, ARA&A, 32, 277"},
+    {"key": "Hudson2010", "citation": "Hudson, D. S., et al. 2010, A&A, 513, A37"},
+    {"key": "Lehle2024", "citation": "Lehle, K., et al. 2024, A&A, 687, A30"},
+    {"key": "Nelson2024", "citation": "Nelson, D., et al. 2024, A&A, 686, A157"},
+    {"key": "Peterson2006", "citation": "Peterson, J. R. & Fabian, A. C. 2006, Phys. Rep., 427, 1"},
+    {"key": "Pillepich2018", "citation": "Pillepich, A., et al. 2018, MNRAS, 473, 4077"},
+    {"key": "Weinberger2017", "citation": "Weinberger, R., et al. 2017, MNRAS, 465, 3291"}
+  ]
+}

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/src/entropy_structure_coupling.py
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/src/entropy_structure_coupling.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Entropy-Structure Coupling Analysis
+
+Reference implementation for:
+Magnusson (2026) "A Pre-Registered Test of Entropy–Structure Coupling
+in Simulated and Observed Galaxy Clusters"
+DOI: 10.6084/m9.figshare.31286368
+
+This module provides tools for analyzing entropy profiles in galaxy clusters
+and comparing simulation results with observational data.
+"""
+
+import numpy as np
+from dataclasses import dataclass
+from typing import Tuple, List, Optional, Dict
+from enum import Enum
+
+
+class CoolCoreClass(Enum):
+    """Cool-core classification following Hudson et al. (2010)."""
+    SCC = "Strong Cool-Core"  # K0 <= 22 keV cm^2
+    WCC = "Weak Cool-Core"    # 22 < K0 <= 150 keV cm^2
+    NCC = "Non-Cool-Core"     # K0 > 150 keV cm^2
+
+
+@dataclass
+class EntropyProfileParams:
+    """Parameters for Cavagnolo et al. (2009) entropy profile model."""
+    K0: float       # Central entropy [keV cm^2]
+    K100: float     # Entropy normalisation at 100 kpc [keV cm^2]
+    alpha: float    # Power-law index
+
+
+@dataclass
+class CorrelationResult:
+    """Result of a Spearman correlation analysis."""
+    rho: float
+    p_value: float
+    N: int
+    description: str = ""
+
+
+class EntropyProfileModel:
+    """
+    Cavagnolo et al. (2009) entropy profile model.
+
+    K(r) = K0 + K100 × (r / 100 kpc)^α
+
+    This is the standard parametric form for cluster entropy profiles
+    used in the ACCEPT sample analysis.
+    """
+
+    def __init__(self, K0: float, K100: float, alpha: float):
+        """
+        Initialize entropy profile model.
+
+        Parameters
+        ----------
+        K0 : float
+            Central entropy [keV cm^2]
+        K100 : float
+            Entropy normalisation at 100 kpc [keV cm^2]
+        alpha : float
+            Power-law index (entropy gradient steepness)
+        """
+        self.params = EntropyProfileParams(K0=K0, K100=K100, alpha=alpha)
+
+    def entropy(self, r: float) -> float:
+        """
+        Compute entropy at radius r.
+
+        Parameters
+        ----------
+        r : float
+            Radius [kpc]
+
+        Returns
+        -------
+        K : float
+            Entropy [keV cm^2]
+        """
+        return self.params.K0 + self.params.K100 * (r / 100.0) ** self.params.alpha
+
+    def entropy_profile(self, r_array: np.ndarray) -> np.ndarray:
+        """
+        Compute entropy profile over array of radii.
+
+        Parameters
+        ----------
+        r_array : np.ndarray
+            Radii [kpc]
+
+        Returns
+        -------
+        K_array : np.ndarray
+            Entropy values [keV cm^2]
+        """
+        return self.params.K0 + self.params.K100 * (r_array / 100.0) ** self.params.alpha
+
+    def log_slope(self, r: float) -> float:
+        """
+        Compute logarithmic slope d ln K / d ln r at radius r.
+
+        Parameters
+        ----------
+        r : float
+            Radius [kpc]
+
+        Returns
+        -------
+        slope : float
+            Logarithmic slope
+        """
+        K = self.entropy(r)
+        dK_dr = self.params.K100 * self.params.alpha / 100.0 * (r / 100.0) ** (self.params.alpha - 1)
+        return r * dK_dr / K
+
+    @staticmethod
+    def from_gas_properties(T: float, n_e: float) -> float:
+        """
+        Compute entropy from temperature and electron density.
+
+        K = k_B T × n_e^(-2/3)
+
+        Parameters
+        ----------
+        T : float
+            Temperature [keV]
+        n_e : float
+            Electron density [cm^-3]
+
+        Returns
+        -------
+        K : float
+            Entropy [keV cm^2]
+        """
+        return T * n_e ** (-2.0 / 3.0)
+
+
+class AlphaProxy:
+    """
+    Proxy for entropy gradient α based on density slope.
+
+    α_proxy = (2/3) × n_e-slope
+
+    This represents the density contribution to the entropy gradient
+    and is a lower bound on α under the physical expectation that
+    temperature rises with radius in cluster cores.
+    """
+
+    @staticmethod
+    def compute(ne_slope: float) -> float:
+        """
+        Compute α_proxy from electron density slope.
+
+        Parameters
+        ----------
+        ne_slope : float
+            Logarithmic electron density slope (-d ln n_e / d ln r)
+
+        Returns
+        -------
+        alpha_proxy : float
+            Proxy for entropy power-law index
+        """
+        return (2.0 / 3.0) * ne_slope
+
+    @staticmethod
+    def entropy_slope_decomposition(T_slope: float, ne_slope: float) -> float:
+        """
+        Compute full entropy slope from temperature and density slopes.
+
+        α = d ln T / d ln r + (2/3) × n_e-slope
+
+        Parameters
+        ----------
+        T_slope : float
+            Logarithmic temperature slope (d ln T / d ln r)
+        ne_slope : float
+            Logarithmic density slope contribution ((2/3) × (-d ln n_e / d ln r))
+
+        Returns
+        -------
+        alpha : float
+            Full entropy power-law index
+        """
+        return T_slope + (2.0 / 3.0) * ne_slope
+
+
+class CoolCoreClassifier:
+    """
+    Galaxy cluster cool-core classification following Hudson et al. (2010).
+
+    Thresholds based on central entropy K0:
+    - SCC (Strong Cool-Core): K0 ≤ 22 keV cm²
+    - WCC (Weak Cool-Core): 22 < K0 ≤ 150 keV cm²
+    - NCC (Non-Cool-Core): K0 > 150 keV cm²
+    """
+
+    SCC_THRESHOLD = 22.0   # keV cm^2
+    WCC_THRESHOLD = 150.0  # keV cm^2
+
+    def classify(self, K0: float) -> CoolCoreClass:
+        """
+        Classify cluster based on central entropy.
+
+        Parameters
+        ----------
+        K0 : float
+            Central entropy [keV cm^2]
+
+        Returns
+        -------
+        cc_class : CoolCoreClass
+            Cool-core classification
+        """
+        if K0 <= self.SCC_THRESHOLD:
+            return CoolCoreClass.SCC
+        elif K0 <= self.WCC_THRESHOLD:
+            return CoolCoreClass.WCC
+        else:
+            return CoolCoreClass.NCC
+
+    def classify_str(self, K0: float) -> str:
+        """Return classification as string."""
+        return self.classify(K0).name
+
+    @staticmethod
+    def tng_population() -> Dict[str, Dict[str, float]]:
+        """
+        Return TNG-Cluster cool-core population statistics.
+
+        Returns
+        -------
+        population : dict
+            Counts and fractions for each CC class
+        """
+        return {
+            "SCC": {"count": 28, "fraction": 0.08},
+            "WCC": {"count": 206, "fraction": 0.59},
+            "NCC": {"count": 118, "fraction": 0.34},
+            "total": {"count": 352}
+        }
+
+
+class CorrelationAnalysis:
+    """
+    Correlation analysis for entropy-structure coupling.
+
+    Compares TNG-Cluster simulation results with ACCEPT observations.
+    """
+
+    # TNG-Cluster results from Lehle et al. (2024) catalogue
+    TNG_RESULTS = {
+        "ne_slope_vs_K0": CorrelationResult(
+            rho=-0.872, p_value=8e-111, N=352,
+            description="Electron density slope vs central entropy"
+        ),
+        "ne_slope_vs_tcool": CorrelationResult(
+            rho=-0.878, p_value=7e-114, N=352,
+            description="Electron density slope vs cooling time"
+        ),
+        "Cphys_vs_K0": CorrelationResult(
+            rho=-0.927, p_value=0.0, N=352,
+            description="X-ray concentration vs central entropy"
+        ),
+        "Cphys_vs_ne_slope": CorrelationResult(
+            rho=0.875, p_value=0.0, N=352,
+            description="X-ray concentration vs density slope"
+        ),
+    }
+
+    # Mass-controlled results
+    PARTIAL_CORRELATIONS = {
+        "ne_slope_vs_K0_given_M": CorrelationResult(
+            rho=-0.880, p_value=2e-115, N=352,
+            description="Density slope vs K0, controlling for mass"
+        ),
+        "alpha_proxy_vs_K0_given_M": CorrelationResult(
+            rho=-0.880, p_value=2e-115, N=352,
+            description="Alpha proxy vs K0, controlling for mass"
+        ),
+        "alpha_proxy_vs_tcool_given_M": CorrelationResult(
+            rho=-0.876, p_value=1e-112, N=352,
+            description="Alpha proxy vs tcool, controlling for mass"
+        ),
+    }
+
+    # ACCEPT observational reference
+    ACCEPT_RESULT = CorrelationResult(
+        rho=0.36, p_value=0.0, N=239,
+        description="ACCEPT: alpha vs y_CCT (Cavagnolo et al. 2009)"
+    )
+
+    def tng_correlation(self, variable: str = "ne_slope_vs_K0") -> CorrelationResult:
+        """
+        Get TNG-Cluster correlation result.
+
+        Parameters
+        ----------
+        variable : str
+            Correlation to retrieve
+
+        Returns
+        -------
+        result : CorrelationResult
+        """
+        return self.TNG_RESULTS.get(variable, self.TNG_RESULTS["ne_slope_vs_K0"])
+
+    def accept_correlation(self) -> CorrelationResult:
+        """Get ACCEPT observational correlation."""
+        return self.ACCEPT_RESULT
+
+    def sign_flip_detected(self) -> bool:
+        """
+        Check if sign flip is detected between TNG and ACCEPT.
+
+        Returns
+        -------
+        sign_flip : bool
+            True if correlations have opposite signs
+        """
+        tng_rho = self.TNG_RESULTS["ne_slope_vs_K0"].rho
+        accept_rho = self.ACCEPT_RESULT.rho
+        return (tng_rho * accept_rho) < 0
+
+    def mass_binned_results(self) -> List[Dict]:
+        """
+        Get mass-binned correlation results.
+
+        Returns
+        -------
+        results : list of dict
+            Correlation results for each mass bin
+        """
+        return [
+            {"bin": "[14.0, 14.3)", "N": 41, "rho": -0.790, "p_value": 9e-10},
+            {"bin": "[14.3, 14.6)", "N": 118, "rho": -0.860, "p_value": 1e-35},
+            {"bin": "[14.6, 14.9)", "N": 121, "rho": -0.901, "p_value": 5e-45},
+            {"bin": "[14.9, 15.5)", "N": 71, "rho": -0.897, "p_value": 4e-26},
+        ]
+
+    def summary(self) -> Dict:
+        """
+        Get summary of correlation analysis.
+
+        Returns
+        -------
+        summary : dict
+            Key results and comparison
+        """
+        return {
+            "tng_rho": self.TNG_RESULTS["ne_slope_vs_K0"].rho,
+            "accept_rho": self.ACCEPT_RESULT.rho,
+            "sign_flip": self.sign_flip_detected(),
+            "partial_rho_mass_controlled": self.PARTIAL_CORRELATIONS["ne_slope_vs_K0_given_M"].rho,
+            "mass_contribution": "0%",
+            "all_mass_bins_negative": True,
+            "interpretation": "Complete sign reversal, not driven by mass confounding"
+        }
+
+
+class PreRegisteredTest:
+    """
+    Pre-registered test design for entropy-structure coupling.
+
+    Two-stage approach:
+    - Path B: Proxy-based pre-test (completed)
+    - Path A: Full Cavagnolo-model fit (awaiting execution)
+    """
+
+    @dataclass
+    class PathAParams:
+        """Locked parameters for Path A decisive test."""
+        centre: str = "SUBFIND-determined"
+        fit_range_kpc: Tuple[float, float] = (20.0, 400.0)
+        initial_alpha_guess: float = 1.1  # ACCEPT median
+        binning: str = "mass-weighted"
+        n_radial_bins: int = 30
+        min_bin_occupancy: int = 5
+        gas_selection: str = "non-star-forming, T > 1e6 K"
+
+    def __init__(self):
+        self.path_a_params = self.PathAParams()
+        self.path_b_completed = True
+        self.path_b_result = "Sign flip confirmed"
+
+    def stop_go_criterion(self, rho_alpha_K0: float, rho_alpha_tcool: Optional[float] = None) -> str:
+        """
+        Evaluate pre-registered stop/go criterion.
+
+        Parameters
+        ----------
+        rho_alpha_K0 : float
+            Correlation between fitted alpha and K0
+        rho_alpha_tcool : float, optional
+            Correlation between fitted alpha and tcool
+
+        Returns
+        -------
+        decision : str
+            "STOP", "GO", or "PARTIAL"
+        """
+        if rho_alpha_K0 < 0:
+            return "GO"  # Sign flip survives → genuine mismatch
+        elif rho_alpha_tcool is not None and rho_alpha_K0 > 0 and rho_alpha_tcool > 0:
+            return "STOP"  # Sign flip reverses under definition matching
+        else:
+            return "PARTIAL"  # Mixed signs require further investigation
+
+    def path_b_summary(self) -> Dict:
+        """Get Path B (proxy-based pre-test) summary."""
+        return {
+            "status": "completed",
+            "proxy": "alpha_proxy = (2/3) × ne_slope",
+            "result": self.path_b_result,
+            "correlations": {
+                "alpha_proxy_vs_K0": -0.872,
+                "alpha_proxy_vs_K0_partial_M": -0.880,
+                "alpha_proxy_vs_tcool": -0.878,
+                "alpha_proxy_vs_tcool_partial_M": -0.876,
+            },
+            "verdict": "GO - Sign flip survives definition matching"
+        }
+
+    def path_a_summary(self) -> Dict:
+        """Get Path A (decisive full profile fit) summary."""
+        return {
+            "status": "pre-registered, awaiting execution",
+            "description": "Full Cavagnolo-model K(r) = K0 + K100(r/100)^alpha fit",
+            "parameters": {
+                "centre": self.path_a_params.centre,
+                "fit_range_kpc": self.path_a_params.fit_range_kpc,
+                "initial_alpha_guess": self.path_a_params.initial_alpha_guess,
+                "binning": self.path_a_params.binning,
+                "n_radial_bins": self.path_a_params.n_radial_bins,
+                "min_bin_occupancy": self.path_a_params.min_bin_occupancy,
+            },
+            "purpose": "Eliminate systematic ambiguities: T-slope variation, local vs global slope, radius mismatch"
+        }
+
+
+class InterpretationFramework:
+    """
+    Framework for interpreting entropy-structure coupling results.
+
+    If sign flip is confirmed, three explanations must be considered.
+    """
+
+    POSSIBLE_EXPLANATIONS = [
+        {
+            "name": "Subgrid modelling",
+            "description": "AGN feedback in TNG may produce overly mechanical CC/NCC transitions that couple structure and entropy too tightly and in the wrong direction.",
+            "testable": "Compare with FLAMINGO, SIMBA, MillenniumTNG"
+        },
+        {
+            "name": "Observational systematics",
+            "description": "Projection effects, spectral fitting biases, or selection effects in ACCEPT could weaken or reverse the intrinsic correlation.",
+            "testable": "Forward-modelled mock X-ray observations of TNG-Cluster"
+        },
+        {
+            "name": "Missing physics",
+            "description": "Physical processes not captured by TNG (cosmic ray transport, anisotropic conduction, magnetic draping) may be required.",
+            "testable": "Simulations with additional physics modules"
+        },
+    ]
+
+    SYSTEMATIC_DIFFERENCES = [
+        "TNG profiles: intrinsic 3D mass-weighted quantities",
+        "ACCEPT profiles: deprojected X-ray spectroscopic with emission weighting",
+        "TNG sample: mass-selected",
+        "ACCEPT sample: X-ray selected, flux-limited",
+        "These affect absolute normalisation but not expected to reverse rank-order correlations"
+    ]
+
+    def get_implications(self) -> str:
+        """Get key implication of confirmed sign flip."""
+        return (
+            "Framework-independent question: Why do modern ΛCDM hydrodynamic "
+            "simulations not reproduce the observed relationship between core "
+            "entropy and structural gradients in galaxy clusters? This is an "
+            "ICM physics question with implications for AGN feedback modelling, "
+            "thermal conduction prescriptions, and CC/NCC demographics."
+        )
+
+
+# Convenience functions
+
+def compute_entropy(T: float, n_e: float) -> float:
+    """
+    Compute entropy from temperature and electron density.
+
+    K = k_B T × n_e^(-2/3)
+
+    Parameters
+    ----------
+    T : float
+        Temperature [keV]
+    n_e : float
+        Electron density [cm^-3]
+
+    Returns
+    -------
+    K : float
+        Entropy [keV cm^2]
+    """
+    return EntropyProfileModel.from_gas_properties(T, n_e)
+
+
+def classify_cool_core(K0: float) -> str:
+    """
+    Classify cluster cool-core state from central entropy.
+
+    Parameters
+    ----------
+    K0 : float
+        Central entropy [keV cm^2]
+
+    Returns
+    -------
+    classification : str
+        "SCC", "WCC", or "NCC"
+    """
+    return CoolCoreClassifier().classify_str(K0)
+
+
+def compute_alpha_proxy(ne_slope: float) -> float:
+    """
+    Compute entropy gradient proxy from density slope.
+
+    Parameters
+    ----------
+    ne_slope : float
+        Electron density logarithmic slope
+
+    Returns
+    -------
+    alpha_proxy : float
+        Proxy for entropy power-law index
+    """
+    return AlphaProxy.compute(ne_slope)


### PR DESCRIPTION
Adds machine-readable package for "A Pre-Registered Test of Entropy–Structure Coupling in Simulated and Observed Galaxy Clusters" (DOI: 10.6084/m9.figshare.31286368)

Contents:
- README.md with model documentation and sign flip analysis
- index.json with metadata, correlations, and pre-registered test design
- src/entropy_structure_coupling.py implementing analysis framework
- data/tng_cluster_results.json with TNG-Cluster vs ACCEPT comparison
- examples/entropy_structure_demo.py demonstration script
- CITATION.cff and LICENSE

Key finding:
- TNG-Cluster: ρ(n_e-slope, K0) = -0.872 (p ~ 10^-111)
- ACCEPT observed: ρ(α, y_CCT) = +0.36
- Sign flip robust against mass confounding (ρ_partial|M = -0.880)
- Pre-registered Path A test awaiting execution

https://claude.ai/code/session_01DU4ATUVjhJgkqLDz9ZdvzX