### PR TITLE
Add SOTA AI-optimized metadata for EFC-C and remaining papers

### DIFF
--- a/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/citations.bib
+++ b/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/citations.bib
@@ -1,0 +1,78 @@
+@article{magnusson2026consciousness,
+  author = {Magnusson, Morten},
+  title = {Consciousness as Field Resonance: From Ego-Filtered Ontology to Differentiation-Dominant Dynamics},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31289806},
+  keywords = {consciousness, spectral entropy, transfer entropy, differentiation, integration, field ontology, EEG, CEM}
+}
+
+@article{chennu2016,
+  author = {Chennu, Srivas and O'Connor, S. and Adapa, R. and Menon, D. K. and Bekinschtein, T. A.},
+  title = {Brain connectivity dissociates responsiveness from drug exposure during propofol-induced transitions of consciousness},
+  journal = {PLoS Comput Biol},
+  volume = {12},
+  number = {1},
+  pages = {e1004669},
+  year = {2016}
+}
+
+@article{koch2016,
+  author = {Koch, Christof and Massimini, Marcello and Boly, Melanie and Tononi, Giulio},
+  title = {Neural correlates of consciousness: progress and problems},
+  journal = {Nat Rev Neurosci},
+  volume = {17},
+  pages = {307--321},
+  year = {2016}
+}
+
+@article{tononi2016,
+  author = {Tononi, Giulio and Boly, Melanie and Massimini, Marcello and Koch, Christof},
+  title = {Integrated information theory: an updated account},
+  journal = {Arch Ital Biol},
+  volume = {154},
+  pages = {1--28},
+  year = {2016}
+}
+
+@article{tononi1998,
+  author = {Tononi, Giulio and Edelman, Gerald M.},
+  title = {Consciousness and complexity},
+  journal = {Science},
+  volume = {282},
+  number = {5395},
+  pages = {1846--1851},
+  year = {1998}
+}
+
+@article{owen2006,
+  author = {Owen, Adrian M. and others},
+  title = {Detecting awareness in the vegetative state},
+  journal = {Science},
+  volume = {313},
+  number = {5792},
+  pages = {1402},
+  year = {2006}
+}
+
+@article{tagliazucchi2012,
+  author = {Tagliazucchi, Enzo and others},
+  title = {Criticality in large-scale brain fMRI dynamics},
+  journal = {Front Physiol},
+  volume = {3},
+  pages = {15},
+  year = {2012}
+}
+
+@misc{magnusson2025cem,
+  author = {Magnusson, Morten},
+  title = {Energy-Flow Cosmology: Cognitive Extension (EFM-CEM-Cosmos)},
+  year = {2025},
+  howpublished = {magnusson.as}
+}
+
+@misc{magnusson2025efc,
+  author = {Magnusson, Morten},
+  title = {EFC-v2.1: Unified Thermodynamic Framework},
+  year = {2025},
+  doi = {10.6084/m9.figshare.30478916.v1}
+}

--- a/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/consciousness-field-resonance.jsonld
+++ b/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/consciousness-field-resonance.jsonld
@@ -1,0 +1,76 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+    "efc": "https://github.com/supertedai/EFC/vocab#",
+    "doi": "https://doi.org/",
+    "orcid": "https://orcid.org/"
+  },
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31289806",
+  "name": "Consciousness as Field Resonance: From Ego-Filtered Ontology to Differentiation-Dominant Dynamics",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": {
+      "@type": "PropertyValue",
+      "propertyID": "ORCID",
+      "value": "orcid:0009-0002-4860-5095"
+    },
+    "affiliation": "Independent Researcher, Sandnes, Norway"
+  },
+  "datePublished": "2026",
+  "description": "Consciousness is best understood as a resonant regime within a universal dynamical field, where systems differ by their capacity to form differentiated, self-referential dynamical structures. Empirical analysis shows spectral differentiation (Omega) tracks conscious state (Cohen's d = 1.50) with double dissociation. The pre-registered multiplicative model C = Omega x kappa is falsified (F1).",
+  "keywords": ["consciousness", "spectral entropy", "transfer entropy", "differentiation", "integration", "field ontology", "EEG", "CEM framework"],
+  "isPartOf": {
+    "@type": "Collection",
+    "name": "Energy-Flow Cosmology Paper Collection",
+    "url": "https://github.com/supertedai/EFC/tree/main/docs/papers/efc"
+  },
+  "efc:framework": "Consciousness-Ego-Mirror (CEM)",
+  "efc:keyFindings": [
+    {
+      "@type": "efc:EmpiricalResult",
+      "name": "Differentiation Effect",
+      "measure": "Omega (spectral entropy)",
+      "effectSize": 1.50,
+      "interpretation": "Primary marker of consciousness"
+    },
+    {
+      "@type": "efc:EmpiricalResult",
+      "name": "Integration Effect",
+      "measure": "kappa (transfer entropy)",
+      "effectSize": 0.42,
+      "interpretation": "Weak, not significant"
+    },
+    {
+      "@type": "efc:EmpiricalResult",
+      "name": "Product Test F1",
+      "status": "FALSIFIED",
+      "interpretation": "Multiplicative model does not improve prediction"
+    },
+    {
+      "@type": "efc:EmpiricalResult",
+      "name": "Regional Posterior",
+      "measure": "C(parietal)",
+      "effectSize": 2.10,
+      "status": "Exploratory candidate"
+    },
+    {
+      "@type": "efc:EmpiricalResult",
+      "name": "Balance Signal",
+      "measure": "corr(Omega, kappa)",
+      "value": -0.27,
+      "interpretation": "Trade-off between differentiation and integration"
+    }
+  ],
+  "efc:revisedModel": {
+    "falsified": "Consciousness = Omega x kappa (both maximised globally)",
+    "supported": "Consciousness = differentiation-dominant resonance regime, constrained by sufficient regional feedback"
+  },
+  "efc:conclusion": "Consciousness is best described as a high-differentiation resonance regime within a universal dynamical field, stabilised by regional feedback rather than global integration. The ego is not the origin of awareness but a structured expression within this regime.",
+  "citation": [
+    {"@id": "doi:10.1371/journal.pcbi.1004669", "name": "Chennu et al. 2016"},
+    {"@id": "doi:10.1038/nrn.2016.22", "name": "Koch et al. 2016"},
+    {"@id": "doi:10.6084/m9.figshare.30478916.v1", "name": "EFC-v2.1"}
+  ]
+}

--- a/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/index.json
+++ b/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/index.json
@@ -1,0 +1,122 @@
+{
+  "id": "efc-c-consciousness-field-resonance",
+  "title": "Consciousness as Field Resonance: From Ego-Filtered Ontology to Differentiation-Dominant Dynamics",
+  "doi": "10.6084/m9.figshare.31289806",
+  "version": "1.0",
+  "date": "2026-02-08",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Independent Researcher, Sandnes, Norway"
+  },
+  "abstract": "The ontology of consciousness remains constrained by a hidden assumption: that awareness is a local property generated inside isolated systems. This paper argues that consciousness is best understood as a resonant regime within a universal dynamical field, where systems differ by their capacity to form differentiated, self-referential dynamical structures. Empirical analysis of EEG under propofol sedation shows spectral differentiation (Omega) tracks conscious state with a double dissociation. A pre-registered multiplicative model is falsified (F1). A differentiation-dominant, regionally constrained resonance model is supported.",
+  "keywords": [
+    "consciousness",
+    "spectral entropy",
+    "transfer entropy",
+    "differentiation",
+    "integration",
+    "field ontology",
+    "propofol",
+    "EEG",
+    "Energy-Flow Cosmology",
+    "Consciousness-Ego-Mirror",
+    "CEM framework",
+    "resonance regime"
+  ],
+  "framework": "Consciousness-Ego-Mirror (CEM)",
+  "core_equations": [
+    {
+      "name": "Spectral Differentiation",
+      "symbol": "Omega",
+      "description": "Spectral entropy measuring internal differentiation/structured complexity"
+    },
+    {
+      "name": "Causal Integration",
+      "symbol": "kappa",
+      "description": "Transfer entropy measuring regional causal closure"
+    },
+    {
+      "name": "Product Measure",
+      "latex": "C = \\Omega \\times \\kappa",
+      "status": "FALSIFIED (F1)"
+    },
+    {
+      "name": "Balance Constraint",
+      "latex": "\\text{corr}(\\Omega, \\kappa) < 0",
+      "description": "Trade-off between complexity and binding"
+    }
+  ],
+  "key_results": {
+    "differentiation_effect": {
+      "measure": "Omega (full band)",
+      "cohens_d": 1.50,
+      "p_value": 0.073,
+      "interpretation": "Strong - primary marker of consciousness"
+    },
+    "integration_effect": {
+      "measure": "kappa (global TE)",
+      "cohens_d": 0.42,
+      "p_value": 0.530,
+      "interpretation": "Weak, not significant"
+    },
+    "product_test_F1": {
+      "measure": "C = Omega(4-40 Hz) x kappa",
+      "cohens_d": 0.63,
+      "p_value": 0.432,
+      "status": "FALSIFIED - no improvement over Omega alone"
+    },
+    "regional_posterior": {
+      "measure": "C(parietal)",
+      "cohens_d": 2.10,
+      "p_value": 0.018,
+      "status": "Exploratory - candidate for replication"
+    },
+    "balance_signal": {
+      "measure": "corr(Omega, kappa)",
+      "value": -0.27,
+      "interpretation": "Trade-off: higher differentiation = lower integration"
+    },
+    "double_dissociation": {
+      "responsive": "+0.054 (p=0.001)",
+      "drowsy": "-0.063 (p=0.016)",
+      "interpretation": "Drug does not determine direction - consciousness does"
+    }
+  },
+  "empirical_pillars": [
+    "Pillar 1: Differentiation is primary (Omega d=1.50, double dissociation)",
+    "Pillar 2: Global integration not detected; regional integration candidate (kappa d=0.42, Parietal C d=2.10)",
+    "Pillar 3: Balance, not maximisation (negative Omega-kappa correlation r=-0.27)"
+  ],
+  "revised_model": {
+    "falsified": "Consciousness = Omega x kappa (both maximised globally)",
+    "supported": "Consciousness = differentiation-dominant resonance regime, constrained by sufficient regional feedback, in a balance regime"
+  },
+  "resonance_continuum": {
+    "stone": {"field": "thermodynamic", "resonance": "near zero"},
+    "cell": {"field": "metabolic", "resonance": "low"},
+    "anaesthetised_brain": {"field": "neural", "resonance": "reduced", "omega": "0.52-0.72"},
+    "waking_brain": {"field": "neural", "resonance": "extreme", "omega": "0.78-0.88"}
+  },
+  "testable_predictions": [
+    {"id": "R1", "prediction": "Posterior C(P_L) outperforms global C", "test": "DOC patients, sleep, ketamine"},
+    {"id": "R2", "prediction": "kappa shows threshold/sigmoid relation", "test": "kappa vs hit-rate; linear wins = fails"},
+    {"id": "R3", "prediction": "Negative corr(Omega, kappa) generalises", "test": "Sleep, ketamine, DOC datasets"},
+    {"id": "R4", "prediction": "Frontal kappa irrelevant", "test": "C(frontal) d near 0 across paradigms"}
+  ],
+  "data_source": {
+    "dataset": "Chennu et al. 2016",
+    "subjects": 20,
+    "overlap_cohort": 12,
+    "paradigm": "Propofol sedation EEG"
+  },
+  "files": {
+    "pdf": "EFC-C_Consciousness_Field_Resonance_FINAL.pdf"
+  },
+  "related_papers": [
+    "CEM-Consciousness-Ego-Mirror",
+    "L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism",
+    "validity-aware-ai"
+  ],
+  "conclusion": "Consciousness is best described as a high-differentiation resonance regime within a universal dynamical field, stabilised by regional feedback rather than global integration. The ego is not the origin of awareness but a structured expression within this regime. Consciousness is becoming a physics problem, not a metaphysical one."
+}

--- a/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/schema.json
+++ b/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/schema.json",
+  "title": "EFC-C Consciousness Field Resonance Schema",
+  "type": "object",
+  "required": ["id", "title", "doi", "author", "key_results"],
+  "properties": {
+    "id": {"type": "string", "pattern": "^efc-c-consciousness-field-resonance$"},
+    "title": {"type": "string"},
+    "doi": {"type": "string", "pattern": "^10\\.6084/m9\\.figshare\\.\\d+$"},
+    "author": {
+      "type": "object",
+      "required": ["name", "orcid"],
+      "properties": {
+        "name": {"type": "string"},
+        "orcid": {"type": "string", "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{4}$"}
+      }
+    },
+    "key_results": {
+      "type": "object",
+      "required": ["differentiation_effect", "integration_effect", "product_test_F1"],
+      "properties": {
+        "differentiation_effect": {
+          "type": "object",
+          "properties": {
+            "cohens_d": {"type": "number", "minimum": 0}
+          }
+        },
+        "integration_effect": {
+          "type": "object",
+          "properties": {
+            "cohens_d": {"type": "number", "minimum": 0}
+          }
+        },
+        "product_test_F1": {
+          "type": "object",
+          "properties": {
+            "status": {"type": "string", "pattern": "FALSIFIED.*"}
+          }
+        }
+      }
+    },
+    "empirical_pillars": {
+      "type": "array",
+      "minItems": 3,
+      "items": {"type": "string"}
+    },
+    "testable_predictions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "prediction", "test"],
+        "properties": {
+          "id": {"type": "string"},
+          "prediction": {"type": "string"},
+          "test": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/EFC-Phenomenology-vs-DESI-DR2-BAO.jsonld
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/EFC-Phenomenology-vs-DESI-DR2-BAO.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "name": "EFC Phenomenology vs DESI DR2 BAO: A Comparative Fit Analysis",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-01-22",
+  "abstract": "We test a phenomenological dark energy parameterization inspired by Energy-Flow Cosmology (EFC) against DESI DR2 BAO measurements. Within the models tested, the EFC-inspired form yields the lowest χ² (3.60), compared to w₀wₐCDM (4.49) and ΛCDM (23.71). This constitutes a necessary but not sufficient condition for EFC validation.",
+  "keywords": ["EFC", "DESI DR2", "BAO", "dark energy", "w(z)", "entropy transition"],
+  "result": {
+    "@type": "PropertyValue",
+    "name": "Best-fit χ²",
+    "value": "3.60 (EFC) vs 4.49 (w₀wₐ) vs 23.71 (ΛCDM)"
+  }
+}

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/citations.bib
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/citations.bib
@@ -1,0 +1,15 @@
+@article{magnusson2026desi,
+  title={{EFC Phenomenology vs DESI DR2 BAO: A Comparative Fit Analysis}},
+  author={Magnusson, Morten},
+  year={2026},
+  month={January},
+  note={Technical Note, Energy-Flow Cosmology Project},
+  keywords={EFC, DESI, BAO, dark energy}
+}
+
+@article{desi2024dr2,
+  title={{DESI DR2 BAO measurements}},
+  author={{DESI Collaboration}},
+  year={2024},
+  doi={10.5281/zenodo.14733025}
+}

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/index.json
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/index.json
@@ -1,0 +1,56 @@
+{
+  "id": "efc-phenomenology-desi-dr2-bao",
+  "title": "EFC Phenomenology vs DESI DR2 BAO: A Comparative Fit Analysis",
+  "short_title": "EFC vs DESI DR2 BAO",
+  "version": "1.0",
+  "date": "2026-01-22",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "technical_note",
+  "status": "published",
+  "abstract_short": "EFC-inspired w(z) yields lowest χ²=3.60 vs w₀wₐCDM (4.49) and ΛCDM (23.71) against DESI DR2 BAO.",
+  "keywords": [
+    "EFC",
+    "DESI DR2",
+    "BAO",
+    "dark energy",
+    "w(z)",
+    "CPL parameterization",
+    "entropy transition"
+  ],
+  "core_equations": [
+    {
+      "name": "EFC-inspired w(z)",
+      "latex": "w(z) = w_{late} + (w_{early} - w_{late}) \\cdot \\tanh[(z - z_{trans})/0.5]"
+    }
+  ],
+  "parameters": {
+    "w_late": {"value": -0.80, "description": "Dark energy EoS today"},
+    "w_early": {"value": -1.41, "description": "Dark energy EoS at high z"},
+    "z_trans": {"value": 1.07, "description": "Transition redshift"}
+  },
+  "results": {
+    "LCDM": {"chi2": 23.71, "assessment": "Poor fit"},
+    "w0waCDM": {"chi2": 4.49, "assessment": "Good fit"},
+    "EFC": {"chi2": 3.60, "assessment": "Best fit (within models tested)"}
+  },
+  "data_sources": [
+    {"survey": "DESI DR2", "type": "BAO", "N": 7, "z_range": [0.30, 2.33]}
+  ],
+  "limitations": [
+    "Diagonal errors only (no covariance)",
+    "BAO only (no CMB/SN)",
+    "Post-hoc fitting, not a priori prediction"
+  ],
+  "next_steps": [
+    "Derive w(z) from EFC field equations",
+    "Multi-probe analysis with full covariance",
+    "Bayesian model comparison"
+  ],
+  "files": {
+    "pdf": "EFC_Phenomenology_vs_DESI_DR2_BAO__A_Comparative_Fit_Analysis.pdf",
+    "tex": "EFC_DESI_Technical_Note.tex"
+  }
+}

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/schema.json
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO/schema.json",
+  "title": "EFC DESI DR2 BAO Comparison Schema",
+  "type": "object",
+  "properties": {
+    "w_z_model": {
+      "type": "object",
+      "properties": {
+        "form": {"type": "string", "enum": ["constant", "CPL", "tanh_transition"]},
+        "w_late": {"type": "number"},
+        "w_early": {"type": "number"},
+        "z_trans": {"type": "number"}
+      }
+    },
+    "chi2_result": {
+      "type": "object",
+      "properties": {
+        "model": {"type": "string"},
+        "value": {"type": "number"},
+        "N_data": {"type": "integer"}
+      }
+    }
+  },
+  "efc_analysis_type": "dark_energy_phenomenology",
+  "probe": "BAO"
+}

--- a/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/EFC-Regime-Transition-Framework.jsonld
+++ b/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/EFC-Regime-Transition-Framework.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31096951",
+  "identifier": {"@type": "PropertyValue", "propertyID": "DOI", "value": "10.6084/m9.figshare.31096951"},
+  "name": "Dynamical Regime Transitions in Cosmology: A CMB-Safe Framework",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-01-20",
+  "abstract": "Regime-dependent cosmological modifications can achieve CMB safety (G_CMB ≈ 10⁻¹²) through dynamical gating using Landau theory, rather than fine-tuning. Framework applicable beyond EFC.",
+  "keywords": ["EFC", "CMB safety", "Landau theory", "regime transition", "gating function"]
+}

--- a/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/citations.bib
+++ b/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/citations.bib
@@ -1,0 +1,16 @@
+@misc{magnusson2026regime,
+  author = {Magnusson, Morten},
+  title = {Dynamical Regime Transitions in Cosmology: A CMB-Safe Framework},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31096951},
+  note = {ORCID: 0009-0002-4860-5095}
+}
+
+@article{planck2018,
+  title={{Planck 2018 results. VI. Cosmological parameters}},
+  author={{Planck Collaboration}},
+  journal={A\&A},
+  volume={641},
+  pages={A6},
+  year={2020}
+}

--- a/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/index.json
+++ b/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/index.json
@@ -1,0 +1,44 @@
+{
+  "id": "efc-regime-transition-framework",
+  "title": "Dynamical Regime Transitions in Cosmology: A CMB-Safe Framework",
+  "short_title": "EFC CMB-Safe Framework",
+  "version": "1.0",
+  "date": "2026-01-20",
+  "doi": "10.6084/m9.figshare.31096951",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "theoretical_framework",
+  "status": "published",
+  "abstract_short": "Landau theory provides CMB safety through dynamical gating: G(z=1100)≈10⁻¹² (8 orders below threshold), G(z=0)≈0.9999.",
+  "keywords": ["EFC", "CMB safety", "Landau theory", "regime transition", "gating function", "CLASS integration"],
+  "key_results": {
+    "G_CMB": {"value": 1e-12, "description": "8 orders below 10⁻⁴ threshold"},
+    "G_z10": {"value": 9.2e-16, "description": "Intermediate-z suppressed"},
+    "G_z2": {"value": 0.25, "description": "Partial activation"},
+    "G_z0": {"value": 0.9999, "description": "Full activation today"}
+  },
+  "core_equations": [
+    {
+      "name": "Gating function",
+      "description": "G(z) computed from Landau equation via RK4 integration"
+    }
+  ],
+  "key_features": [
+    "CMB-safe by construction (dynamics, not tuning)",
+    "Fully reproducible (code included)",
+    "CLASS-compatible",
+    "Landau theory framework"
+  ],
+  "what_this_shows": [
+    "Regime-dependent modifications CAN be CMB-safe",
+    "Landau theory provides natural gating mechanism",
+    "Delayed activation (χ crosses χ_c at z≈50, effect at z<2)"
+  ],
+  "files": {
+    "paper": "paper/magnusson2026_efc_regime_transitions.pdf",
+    "code": "code/",
+    "data": "data/"
+  }
+}

--- a/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/schema.json
+++ b/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/EFC-Regime-Transition-Framework/schema.json",
+  "title": "EFC Regime Transition Framework Schema",
+  "type": "object",
+  "properties": {
+    "gating_function": {
+      "type": "object",
+      "properties": {
+        "z": {"type": "number"},
+        "G": {"type": "number", "minimum": 0, "maximum": 1}
+      }
+    },
+    "cmb_safety": {
+      "type": "object",
+      "properties": {
+        "G_CMB": {"type": "number"},
+        "threshold": {"type": "number", "default": 1e-4},
+        "margin_orders": {"type": "integer"}
+      }
+    }
+  },
+  "efc_analysis_type": "regime_transition",
+  "method": "Landau_theory"
+}

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/Empirical-Validation.jsonld
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/Empirical-Validation.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "name": "EFC Validation: Cluster Lensing and Galaxy Rotation Curves",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-01-29",
+  "abstract": "EFC passes both major empirical tests: Bullet Cluster lensing (κ follows galaxies, p=0.99) and galaxy rotation curves (χ²=4.5 vs Newton χ²=296, 98% improvement). λ scales with system size.",
+  "keywords": ["EFC", "Bullet Cluster", "rotation curves", "entropy coupling", "gravitational lensing"],
+  "result": [
+    {"@type": "PropertyValue", "name": "Bullet Cluster", "value": "κ follows galaxies (p=0.99)"},
+    {"@type": "PropertyValue", "name": "Rotation curves", "value": "χ²=4.5 vs 296 (98% improvement)"}
+  ]
+}

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/citations.bib
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/citations.bib
@@ -1,0 +1,16 @@
+@article{magnusson2026validation,
+  title={{EFC Empirical Validation: Cluster Lensing and Galaxy Rotation Curves}},
+  author={Magnusson, Morten},
+  year={2026},
+  month={January},
+  note={Energy-Flow Cosmology Project}
+}
+
+@article{clowe2006bullet,
+  title={{A Direct Empirical Proof of the Existence of Dark Matter}},
+  author={Clowe, D. and others},
+  journal={ApJL},
+  volume={648},
+  pages={L109},
+  year={2006}
+}

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/index.json
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/index.json
@@ -1,0 +1,38 @@
+{
+  "id": "efc-empirical-validation-cluster-rotation",
+  "title": "EFC Validation: Cluster Lensing and Galaxy Rotation Curves",
+  "short_title": "EFC Empirical Validation",
+  "version": "1.0",
+  "date": "2026-01-29",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "empirical_analysis",
+  "status": "published",
+  "abstract_short": "EFC passes both cluster lensing (Bullet Cluster) and galaxy rotation curve tests. Gas term statistically irrelevant (p=0.99). Rotation χ²=4.5 vs Newton χ²=296.",
+  "keywords": ["EFC", "Bullet Cluster", "cluster lensing", "rotation curves", "SPARC", "entropy coupling", "λ scaling"],
+  "key_results": [
+    {"test": "Bullet Cluster lensing", "result": "κ follows galaxies, not gas", "p_value": 0.99},
+    {"test": "MACS J0025 lensing", "result": "Same structure confirmed", "status": "pass"},
+    {"test": "Galaxy rotation", "result": "χ²=4.5 vs Newton χ²=296", "improvement": "98%"}
+  ],
+  "lambda_scaling": {
+    "bullet_cluster": {"lambda_kpc": 250, "system_size_kpc": 500, "ratio": 0.5},
+    "galaxy": {"lambda_kpc": 2.4, "system_size_kpc": 2.5, "ratio": 1.0},
+    "interpretation": "λ scales with system size, not universal constant"
+  },
+  "core_equations": [
+    {
+      "name": "Total velocity",
+      "latex": "v^2_{total}(r) = v^2_{baryon}(r) + v^2_{entropy}(r)"
+    },
+    {
+      "name": "Entropy contribution",
+      "latex": "v^2_{entropy} = v_h^2 \\cdot (1 - (r_h/r) \\cdot \\arctan(r/r_h))"
+    }
+  ],
+  "files": {
+    "key_figures": ["efc_rotation_corrected.png", "bullet_real_hsc_fit.png", "nested_test_result.png"]
+  }
+}

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/schema.json
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/Empirical-Validation/schema.json",
+  "title": "EFC Empirical Validation Schema",
+  "type": "object",
+  "properties": {
+    "lensing_result": {
+      "type": "object",
+      "properties": {
+        "cluster": {"type": "string"},
+        "kappa_source": {"type": "string", "enum": ["galaxies", "gas", "both"]},
+        "log_likelihood": {"type": "number"},
+        "p_value": {"type": "number"}
+      }
+    },
+    "rotation_curve": {
+      "type": "object",
+      "properties": {
+        "chi2_newton": {"type": "number"},
+        "chi2_efc": {"type": "number"},
+        "lambda_kpc": {"type": "number"}
+      }
+    },
+    "lambda_scaling": {
+      "type": "object",
+      "properties": {
+        "system": {"type": "string"},
+        "lambda": {"type": "number"},
+        "system_size": {"type": "number"},
+        "ratio": {"type": "number"}
+      }
+    }
+  },
+  "efc_analysis_type": "empirical_validation",
+  "probes": ["cluster_lensing", "rotation_curves"]
+}

--- a/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/L0-L3-Regime-Architecture.jsonld
+++ b/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/L0-L3-Regime-Architecture.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "TechArticle",
+  "@id": "doi:10.6084/m9.figshare.31112536",
+  "name": "L0–L3 Regime Architecture in Entropy-Bounded Empiricism",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "abstract": "Four operational regimes (L0 Latent, L1 Stable Active, L2 Complex Active, L3 Residual) and their transitions. Inference valid only within regime where data and dynamics remain consistent.",
+  "keywords": ["L0-L3", "regime architecture", "entropy-bounded empiricism", "phase transitions"]
+}

--- a/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/citations.bib
+++ b/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/citations.bib
@@ -1,0 +1,6 @@
+@techreport{magnusson2026l0l3,
+  author = {Magnusson, Morten},
+  title = {L0–L3 Regime Architecture in Entropy-Bounded Empiricism},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31112536}
+}

--- a/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/index.json
+++ b/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/index.json
@@ -1,0 +1,35 @@
+{
+  "id": "l0-l3-regime-architecture",
+  "title": "L0–L3 Regime Architecture in Entropy-Bounded Empiricism",
+  "short_title": "L0-L3 Regime Architecture",
+  "version": "1.0",
+  "date": "2026-01-21",
+  "doi": "10.6084/m9.figshare.31112536",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "foundational_framework",
+  "status": "published",
+  "abstract_short": "Four operational regimes (L0-L3) with transitions. Inference valid only within regime where data and dynamics remain consistent.",
+  "keywords": ["L0-L3", "regime architecture", "entropy-bounded empiricism", "EBE", "phase transitions", "dynamical inference"],
+  "regimes": {
+    "L0": {"name": "Latent", "description": "Configuration space without active dynamics"},
+    "L1": {"name": "Stable Active", "description": "Low-entropy, predictable operation"},
+    "L2": {"name": "Complex Active", "description": "Non-linear dynamics, structural formation"},
+    "L3": {"name": "Residual", "description": "Structure without process, information without flow"}
+  },
+  "transitions": {
+    "L0_L1": {"name": "Activation", "description": "Phase-extended crossing of critical thresholds"},
+    "L2_L3": {"name": "Deactivation", "description": "Decline below maintenance thresholds"},
+    "L3_L0": {"name": "Cyclical", "description": "Residual structure as new latent potential"}
+  },
+  "core_principle": "Inference is valid only within the regime where data and dynamics remain consistent.",
+  "applications": ["biology", "ecology", "economics", "cognition", "technology lifecycles"],
+  "files": {
+    "docs": "docs/",
+    "data": "data/",
+    "src": "src/",
+    "examples": "examples/"
+  }
+}

--- a/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/schema.json
+++ b/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/L0-L3-Regime-Architecture/schema.json",
+  "title": "L0-L3 Regime Schema",
+  "type": "object",
+  "properties": {
+    "regime": {
+      "type": "string",
+      "enum": ["L0", "L1", "L2", "L3"],
+      "description": "Current system regime"
+    },
+    "transition": {
+      "type": "object",
+      "properties": {
+        "from": {"type": "string", "enum": ["L0", "L1", "L2", "L3"]},
+        "to": {"type": "string", "enum": ["L0", "L1", "L2", "L3"]},
+        "mechanism": {"type": "string"}
+      }
+    }
+  },
+  "efc_framework": "entropy_bounded_empiricism"
+}

--- a/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/Structural-Constraints.jsonld
+++ b/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/Structural-Constraints.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31173850",
+  "name": "Structural Constraints on Entropy-Gradient Gravity from Cluster Merger Geometry",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "abstract": "Local entropy-gradient couplings falsified at cluster-merger scales. Required: non-local scale L₀~200 kpc, collisionless weighting w~20. Predictions for MACS J0025 and Abell 520.",
+  "keywords": ["EFC", "Bullet Cluster", "cluster mergers", "falsification", "non-local coupling"]
+}

--- a/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/citations.bib
+++ b/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/citations.bib
@@ -1,0 +1,13 @@
+@misc{magnusson2026constraints,
+  author = {Magnusson, Morten},
+  title = {Structural Constraints on Entropy-Gradient Gravity from Cluster Merger Geometry},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31173850}
+}
+
+@article{bradac2006bullet,
+  title={{Strong and Weak Lensing United}},
+  author={Brada{\v{c}}, M. and others},
+  journal={ApJ},
+  year={2006}
+}

--- a/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/index.json
+++ b/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/index.json
@@ -1,0 +1,43 @@
+{
+  "id": "structural-constraints-cluster-merger",
+  "title": "Structural Constraints on Entropy-Gradient Gravity from Cluster Merger Geometry",
+  "short_title": "EFC Cluster Merger Constraints",
+  "version": "1.0.0",
+  "date": "2026-01-28",
+  "doi": "10.6084/m9.figshare.31173850",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "constraint_study",
+  "status": "published",
+  "abstract_short": "Local entropy-gradient couplings falsified (0/42 pass). Required: non-local L₀~200 kpc, collisionless weighting w~20.",
+  "keywords": ["EFC", "Bullet Cluster", "cluster mergers", "entropy-gradient gravity", "falsification", "non-local coupling"],
+  "key_results": {
+    "BC-001": {
+      "claim": "Local gradient coupling falsified",
+      "result": "0/42 parameter combinations pass"
+    },
+    "BC-002": {
+      "claim": "Required structure",
+      "L0_kpc": 200,
+      "w_collisionless": 20
+    },
+    "BC-003": {
+      "claim": "Predictive model",
+      "eta": 66.2
+    }
+  },
+  "predictions": [
+    {"cluster": "Bullet", "w_pred": 20.0, "L0_kpc": 200, "status": "calibration"},
+    {"cluster": "MACS J0025", "w_pred": 23.9, "L0_kpc": 120, "status": "PASS (synthetic)"},
+    {"cluster": "Abell 520", "w_pred": 28.2, "L0_kpc": 160, "status": "PASS geometry"}
+  ],
+  "limitations": ["Synthetic κ-maps, not real FITS data"],
+  "files": {
+    "pdf": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry.pdf",
+    "tex": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry.tex",
+    "code": "code/",
+    "data": "data/"
+  }
+}

--- a/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/schema.json
+++ b/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/Structural-Constraints/schema.json",
+  "title": "Cluster Merger Constraints Schema",
+  "type": "object",
+  "properties": {
+    "constraint": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"},
+        "claim": {"type": "string"},
+        "status": {"type": "string", "enum": ["falsified", "required", "prediction"]}
+      }
+    },
+    "cluster_prediction": {
+      "type": "object",
+      "properties": {
+        "cluster": {"type": "string"},
+        "w_pred": {"type": "number"},
+        "L0_kpc": {"type": "number"}
+      }
+    }
+  },
+  "efc_analysis_type": "cluster_merger_constraints"
+}

--- a/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/Systematic-CMB-Constraints.jsonld
+++ b/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/Systematic-CMB-Constraints.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31095466",
+  "name": "Systematic CMB Constraints on EFC: Parameter Degeneracies and Null Results",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "abstract": "Both κ̇ and H(z) EFC mechanisms REJECTED against Planck 2018 CMB. 1D signal was parameter degeneracy artifact. CMB epoch is L0-L1 regime where standard physics expected to dominate.",
+  "keywords": ["EFC", "CMB", "Planck", "null result", "parameter degeneracy"]
+}

--- a/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/citations.bib
+++ b/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/citations.bib
@@ -1,0 +1,22 @@
+@misc{magnusson2026cmb,
+  author = {Magnusson, Morten},
+  title = {Systematic CMB Constraints on EFC: Parameter Degeneracies and Null Results},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31095466}
+}
+
+@article{planck2018vi,
+  title={{Planck 2018 results. VI. Cosmological parameters}},
+  author={{Planck Collaboration}},
+  journal={A\&A},
+  volume={641},
+  pages={A6},
+  year={2020}
+}
+
+@article{class2011,
+  title={{The Cosmic Linear Anisotropy Solving System (CLASS)}},
+  author={Blas, D. and Lesgourgues, J. and Tram, T.},
+  journal={JCAP},
+  year={2011}
+}

--- a/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/index.json
+++ b/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/index.json
@@ -1,0 +1,37 @@
+{
+  "id": "efc-cmb-constraints-null-results",
+  "title": "Systematic CMB Constraints on EFC: Parameter Degeneracies and Null Results",
+  "short_title": "EFC CMB Null Results",
+  "version": "1.0",
+  "date": "2026-01-20",
+  "doi": "10.6084/m9.figshare.31095466",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "constraint_analysis",
+  "status": "published",
+  "abstract_short": "Both κ̇ and H(z) EFC mechanisms REJECTED against Planck 2018 CMB. 1D 'signal' was parameter degeneracy artifact. CMB epoch = L0-L1 regime where standard physics expected.",
+  "keywords": ["EFC", "CMB", "Planck", "null result", "parameter degeneracy", "κ̇", "H(z)", "CLASS"],
+  "mechanisms_tested": {
+    "kappa_dot": {"status": "REJECTED", "chi2_min": "boost=0%", "delta_chi2": "+5.4 at ±1%"},
+    "Hz": {"status": "REJECTED", "true_min": "ε≈0, Δχ²≈-1", "1D_artifact": "ε≈+3% was degeneracy"}
+  },
+  "key_lesson": "Parameter degeneracies can create false signals. Multi-dimensional analysis essential.",
+  "regime_interpretation": {
+    "cmb_epoch": "L0-L1 regime",
+    "expected": "Standard physics dominant",
+    "result": "ΛCDM provides best fit",
+    "implication": "Consistent with EFC-R framework"
+  },
+  "data": {
+    "source": "Planck 2018 TT spectrum",
+    "N_points": 2507,
+    "ell_range": [2, 2508]
+  },
+  "tools": ["CLASS v3.2.0 (modified)", "Python"],
+  "files": {
+    "pdf": "EFC_CMB_Testing_Results.pdf",
+    "figures": ["kappa_sweep_final.png", "grid_2d_landscape.png", "efc_hz_corrected_final.png"]
+  }
+}

--- a/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/schema.json
+++ b/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/Systematic-CMB-Constraints/schema.json",
+  "title": "EFC CMB Constraints Schema",
+  "type": "object",
+  "properties": {
+    "mechanism_test": {
+      "type": "object",
+      "properties": {
+        "mechanism": {"type": "string"},
+        "status": {"type": "string", "enum": ["REJECTED", "ACCEPTED", "INCONCLUSIVE"]},
+        "chi2_baseline": {"type": "number"},
+        "delta_chi2": {"type": "number"}
+      }
+    }
+  },
+  "efc_analysis_type": "cmb_constraint"
+}

--- a/docs/papers/efc/efc-weak-lensing-phenomenology/citations.bib
+++ b/docs/papers/efc/efc-weak-lensing-phenomenology/citations.bib
@@ -1,0 +1,19 @@
+@article{magnusson2026wl,
+  title={{EFC Weak Lensing Phenomenology: A Testable $\mu(k,z)$ Framework and DES Y6 Validation Protocol}},
+  author={Magnusson, Morten},
+  year={2026},
+  month={January},
+  doi={10.6084/m9.figshare.31188193}
+}
+
+@article{des2024y6,
+  title={{Dark Energy Survey Year 6 Results}},
+  author={{DES Collaboration}},
+  year={2024}
+}
+
+@article{magnusson2025field,
+  title={{EFC Field Equations}},
+  author={Magnusson, Morten},
+  doi={10.6084/m9.figshare.30421807}
+}

--- a/docs/papers/efc/efc-weak-lensing-phenomenology/efc-weak-lensing-phenomenology.jsonld
+++ b/docs/papers/efc/efc-weak-lensing-phenomenology/efc-weak-lensing-phenomenology.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31188193",
+  "identifier": {"@type": "PropertyValue", "propertyID": "DOI", "value": "10.6084/m9.figshare.31188193"},
+  "name": "EFC Weak Lensing Phenomenology: A Testable μ(k,z) Framework and DES Y6 Validation Protocol",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-01",
+  "abstract": "Testable μ(k,z) framework for weak lensing observations. Addresses S₈ tension between DES Y6 (0.789) and Planck (0.83). Defines pass/fail criteria for DES Y6 validation. Introduces Postulate A as minimal operational closure.",
+  "keywords": ["EFC", "weak lensing", "μ(k,z)", "DES Y6", "S₈ tension", "modified gravity"]
+}

--- a/docs/papers/efc/efc-weak-lensing-phenomenology/index.json
+++ b/docs/papers/efc/efc-weak-lensing-phenomenology/index.json
@@ -1,0 +1,58 @@
+{
+  "id": "efc-weak-lensing-phenomenology",
+  "title": "EFC Weak Lensing Phenomenology: A Testable μ(k,z) Framework and DES Y6 Validation Protocol",
+  "short_title": "EFC Weak Lensing",
+  "version": "1.0",
+  "date": "2026-01",
+  "doi": "10.6084/m9.figshare.31188193",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "theoretical_framework",
+  "status": "published",
+  "abstract_short": "Testable μ(k,z) framework for weak lensing. Addresses S₈ tension (0.789 vs 0.83). Pass/fail criteria defined for DES Y6.",
+  "keywords": ["EFC", "weak lensing", "μ(k,z)", "DES Y6", "S₈ tension", "modified gravity", "Postulate A"],
+  "core_equations": [
+    {
+      "name": "μ(k,z) EFC form",
+      "latex": "\\mu(k,z) = 1 + A_\\mu \\times \\Theta(z_t - z) \\times 1/(1 + k^2/k_*^2)"
+    },
+    {
+      "name": "Postulate A coupling",
+      "latex": "\\delta\\Sigma(k,z) = \\xi \\rho_m(z) \\delta_m(k,z) g(z) h(k)"
+    }
+  ],
+  "parameters": {
+    "A_mu": {"description": "Free amplitude (constrained by data)"},
+    "z_t": {"value": 2, "description": "Redshift transition (preserves CMB)"},
+    "k_star": {"value": 0.1, "unit": "h/Mpc", "description": "Scale filter"}
+  },
+  "validation_protocol": {
+    "pass_criteria": [
+      {"metric": "Δχ²", "threshold": "≥ 6"},
+      {"metric": "A_μ significance", "threshold": "> 2σ from 0"},
+      {"metric": "AIC/BIC", "threshold": "prefers EFC"}
+    ],
+    "falsification": [
+      "A_μ = 0 (no improvement)",
+      "A_μ > 0 (wrong sign)",
+      "CMB lensing conflict",
+      "Nuisance degeneracy"
+    ]
+  },
+  "s8_tension": {
+    "DES_Y6": 0.789,
+    "Planck": 0.83,
+    "tension_sigma": 2.6
+  },
+  "dependencies": [
+    {"doi": "10.6084/m9.figshare.30421807", "title": "EFC Field Equations"},
+    {"doi": "10.6084/m9.figshare.30630500", "title": "EFC Master Specification"}
+  ],
+  "files": {
+    "docs": "docs/",
+    "src": "src/",
+    "tests": "tests/"
+  }
+}

--- a/docs/papers/efc/efc-weak-lensing-phenomenology/schema.json
+++ b/docs/papers/efc/efc-weak-lensing-phenomenology/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/efc-weak-lensing-phenomenology/schema.json",
+  "title": "EFC Weak Lensing Schema",
+  "type": "object",
+  "properties": {
+    "mu_kz": {
+      "type": "object",
+      "description": "Modified gravity parameter μ(k,z)",
+      "properties": {
+        "A_mu": {"type": "number", "description": "Amplitude"},
+        "z_t": {"type": "number", "description": "Transition redshift"},
+        "k_star": {"type": "number", "description": "Scale filter h/Mpc"}
+      }
+    },
+    "validation_result": {
+      "type": "object",
+      "properties": {
+        "delta_chi2": {"type": "number"},
+        "A_mu_significance": {"type": "number"},
+        "verdict": {"type": "string", "enum": ["pass", "fail", "inconclusive"]}
+      }
+    }
+  },
+  "efc_analysis_type": "weak_lensing_phenomenology",
+  "target_survey": "DES_Y6"
+}

--- a/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/citations.bib
+++ b/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/citations.bib
@@ -1,0 +1,16 @@
+@misc{magnusson2026ebe,
+  author = {Magnusson, Morten},
+  title = {Entropy-Bounded Empiricism: Regime-Dependent Validity in Galaxy Rotation Curves},
+  year = {2026},
+  publisher = {Figshare},
+  doi = {10.6084/m9.figshare.31047703}
+}
+
+@article{lelli2016sparc,
+  title={{SPARC: Mass Models for 175 Disk Galaxies}},
+  author={Lelli, F. and McGaugh, S.S. and Schombert, J.M.},
+  journal={AJ},
+  volume={152},
+  pages={157},
+  year={2016}
+}

--- a/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/entropy-bounded-empiricism.jsonld
+++ b/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/entropy-bounded-empiricism.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31047703",
+  "identifier": {"@type": "PropertyValue", "propertyID": "DOI", "value": "10.6084/m9.figshare.31047703"},
+  "name": "Entropy-Bounded Empiricism: Regime-Dependent Validity in Galaxy Rotation Curves",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-01-12",
+  "abstract": "EBE framework establishes regime-dependent model validity. 100% EFC success in FLOW regime (62/62). Mann-Whitney p<0.0001, effect size δ=0.371. CMB null test passes as predicted.",
+  "keywords": ["EBE", "entropy-bounded empiricism", "SPARC", "rotation curves", "regime validity"],
+  "mainEntity": {
+    "@type": "Dataset",
+    "name": "SPARC175 Master Dataset",
+    "description": "175 galaxies with regime classification and validation metrics"
+  }
+}

--- a/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/index.json
+++ b/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/index.json
@@ -1,0 +1,39 @@
+{
+  "id": "entropy-bounded-empiricism-ebe-sparc175",
+  "title": "Entropy-Bounded Empiricism: Regime-Dependent Validity in Galaxy Rotation Curves",
+  "short_title": "EBE SPARC175",
+  "version": "1.0",
+  "date": "2026-01-12",
+  "doi": "10.6084/m9.figshare.31047703",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "empirical_analysis",
+  "status": "published",
+  "abstract_short": "EBE framework: 100% EFC success in FLOW regime (62/62 galaxies). Mann-Whitney p<0.0001, Cliff's δ=0.371. CMB null test passes (p=0.251).",
+  "keywords": ["EBE", "entropy-bounded empiricism", "SPARC", "rotation curves", "regime validity", "L parameter", "S entropy"],
+  "key_results": {
+    "flow_success_rate": {"value": 1.0, "n": 62, "description": "100% EFC success in FLOW regime"},
+    "mann_whitney_p": {"value": "<0.0001", "description": "Highly significant"},
+    "kruskal_wallis_p": {"value": 0.012, "description": "Significant 3-way difference"},
+    "permutation_p": {"value": 0.016, "description": "Non-random structure"},
+    "effect_size": {"metric": "Cliff's δ", "value": 0.371, "interpretation": "medium-to-large"},
+    "cmb_null_p": {"value": 0.251, "description": "PASS - CMB shows no regime structure"}
+  },
+  "regime_distribution": {
+    "FLOW": {"n": 62, "pct": 35.4, "L_range": "<0.337", "S_range": "<0.25"},
+    "TRANSITION": {"n": 86, "pct": 49.1, "L_range": "0.337-0.427", "S_range": "0.25-0.65"},
+    "LATENT": {"n": 27, "pct": 15.4, "L_range": "≥0.427", "S_range": "≥0.65"}
+  },
+  "thresholds": {
+    "L1": 0.337,
+    "L2": 0.427,
+    "S_bounds": [0.1, 0.9]
+  },
+  "files": {
+    "dataset": "sparc175_master_dataset.csv",
+    "thresholds": "regime_thresholds_validation.txt",
+    "analysis": "statistical_analysis_summary.py"
+  }
+}

--- a/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/schema.json
+++ b/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/entropy-bounded-empiricism-EBE/schema.json",
+  "title": "EBE SPARC175 Schema",
+  "type": "object",
+  "properties": {
+    "galaxy": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "integer"},
+        "name": {"type": "string"},
+        "regime": {"type": "string", "enum": ["FLOW", "TRANSITION", "LATENT"]},
+        "L_value": {"type": "number", "minimum": 0, "maximum": 1},
+        "S_estimate": {"type": "number"},
+        "chi2_efc": {"type": "number"},
+        "chi2_lcdm": {"type": "number"},
+        "success_efc": {"type": "boolean"}
+      }
+    },
+    "regime_threshold": {
+      "type": "object",
+      "properties": {
+        "L1": {"type": "number"},
+        "L2": {"type": "number"}
+      }
+    },
+    "statistical_test": {
+      "type": "object",
+      "properties": {
+        "test_name": {"type": "string"},
+        "p_value": {"type": "number"},
+        "effect_size": {"type": "number"}
+      }
+    }
+  },
+  "efc_analysis_type": "regime_validity",
+  "framework": "entropy_bounded_empiricism"
+}

--- a/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/citations.bib
+++ b/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/citations.bib
@@ -1,0 +1,14 @@
+@misc{magnusson2026cosmos,
+  author = {Magnusson, Morten},
+  title = {Observed Galaxy Abundances at z > 6 Exceed Halo-Limited Predictions in COSMOS-Web},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31059964}
+}
+
+@article{shuntov2025cosmos,
+  title={{COSMOS2025: The COSMOS-Web DR1 Catalog}},
+  author={Shuntov, M. and others},
+  journal={A\&A},
+  year={2025},
+  note={submitted}
+}

--- a/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/cosmos-galaxy-abundances.jsonld
+++ b/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/cosmos-galaxy-abundances.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31059964",
+  "name": "Observed Galaxy Abundances at z > 6 Exceed Halo-Limited Predictions in COSMOS-Web",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "abstract": "8,447 massive galaxies at z > 5 from COSMOS-Web exceed ΛCDM halo-limited predictions, providing tension with standard cosmology at early times.",
+  "keywords": ["COSMOS-Web", "high-z galaxies", "JWST", "galaxy abundances"]
+}

--- a/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/index.json
+++ b/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/index.json
@@ -1,0 +1,37 @@
+{
+  "id": "cosmos-galaxy-abundances-z6",
+  "title": "Observed Galaxy Abundances at z > 6 Exceed Halo-Limited Predictions in COSMOS-Web",
+  "short_title": "COSMOS Galaxy Excess z>6",
+  "version": "1.0",
+  "date": "2026",
+  "doi": "10.6084/m9.figshare.31059964",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "observational_analysis",
+  "status": "published",
+  "abstract_short": "8,447 massive galaxies (log M*/Msun > 9) at z > 5 from COSMOS-Web exceed ΛCDM halo-limited predictions.",
+  "keywords": ["COSMOS-Web", "high-z galaxies", "galaxy abundances", "JWST", "stellar mass function", "halo mass function"],
+  "data": {
+    "sample_size": 8447,
+    "mass_cut": "log M*/Msun > 9",
+    "redshift_range": "z > 5",
+    "source": "COSMOS2025 catalog (Shuntov et al. 2025)"
+  },
+  "columns": [
+    {"name": "id", "description": "COSMOS2025 source identifier"},
+    {"name": "ra", "description": "Right ascension (J2000, degrees)"},
+    {"name": "dec", "description": "Declination (J2000, degrees)"},
+    {"name": "z_phot", "description": "Photometric redshift (LePhare)"},
+    {"name": "mass_med", "description": "Stellar mass, median (log Msun)"},
+    {"name": "sfr_med", "description": "Star formation rate, median (log Msun/yr)"},
+    {"name": "log_ssfr", "description": "Specific SFR = SFR/M* (log Gyr^-1)"}
+  ],
+  "files": {
+    "pdf": "Magnusson_2026_COSMOS_Galaxy_Excess.pdf",
+    "data": "supplementary_data.csv",
+    "code": "analysis_code.py",
+    "figure": "figure1_stress_test.png"
+  }
+}

--- a/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/schema.json
+++ b/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/cosmos-galaxy-abundances/schema.json",
+  "title": "COSMOS Galaxy Abundances Schema",
+  "type": "object",
+  "properties": {
+    "galaxy": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"},
+        "ra": {"type": "number"},
+        "dec": {"type": "number"},
+        "z_phot": {"type": "number"},
+        "mass_med": {"type": "number"},
+        "sfr_med": {"type": "number"}
+      }
+    }
+  },
+  "efc_analysis_type": "high_z_galaxy_abundances"
+}

--- a/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/citations.bib
+++ b/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/citations.bib
@@ -1,0 +1,21 @@
+@article{magnusson2026regime,
+  author = {Magnusson, Morten},
+  title = {Regime-Dependent Breakdown of LCDM Across Cosmic Time},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31061665}
+}
+
+@article{lelli2016sparc,
+  title={{SPARC: Mass Models for 175 Disk Galaxies}},
+  author={Lelli, F. and McGaugh, S.S. and Schombert, J.M.},
+  journal={AJ},
+  volume={152},
+  pages={157},
+  year={2016}
+}
+
+@article{shuntov2025cosmos,
+  title={{COSMOS2025}},
+  author={Shuntov, M. and others},
+  year={2025}
+}

--- a/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/index.json
+++ b/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/index.json
@@ -1,0 +1,40 @@
+{
+  "id": "regime-dependent-breakdown-lcdm",
+  "title": "Regime-Dependent Breakdown of ΛCDM Across Cosmic Time",
+  "short_title": "ΛCDM Regime Breakdown",
+  "version": "1.0",
+  "date": "2026-01",
+  "doi": "10.6084/m9.figshare.31061665",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "statistical_analysis",
+  "status": "published",
+  "abstract_short": "ΛCDM deviations cluster systematically across redshifts (χ²=47.3, df=4, p<10⁻⁸). JWST/COSMOS galaxies exceed predictions by 23-529× depending on redshift.",
+  "keywords": ["ΛCDM", "regime breakdown", "SPARC", "COSMOS-Web", "JWST", "high-z galaxies"],
+  "key_result": {
+    "chi2": 47.3,
+    "df": 4,
+    "p_value": 1.3e-9,
+    "confidence": ">99.99%"
+  },
+  "high_z_excess": [
+    {"z_range": "5-6", "ratio_behroozi": "23x", "ratio_halo": "3.1x"},
+    {"z_range": "7-8", "ratio_behroozi": "124x", "ratio_halo": "7.7x"},
+    {"z_range": "8-9", "ratio_behroozi": "259x", "ratio_halo": "10.4x"},
+    {"z_range": "9-10", "ratio_behroozi": "529x", "ratio_halo": "10.6x"}
+  ],
+  "disclaimers": [
+    "Does NOT falsify ΛCDM",
+    "Does NOT propose alternative dynamics",
+    "Does NOT identify unique mechanism"
+  ],
+  "data_sources": [
+    {"name": "SPARC", "N": 175, "z": "~0"},
+    {"name": "COSMOS2025", "N": 26288, "z": ">5"}
+  ],
+  "files": {
+    "pdf": "Regime_Dependent_Breakdown.pdf"
+  }
+}

--- a/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/regime-dependent-breakdown.jsonld
+++ b/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/regime-dependent-breakdown.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "ScholarlyArticle",
+  "@id": "doi:10.6084/m9.figshare.31061665",
+  "name": "Regime-Dependent Breakdown of ΛCDM Across Cosmic Time",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "abstract": "ΛCDM deviations cluster systematically (χ²=47.3, p<10⁻⁸). JWST/COSMOS high-z galaxies exceed predictions by 23-529× depending on redshift bin.",
+  "keywords": ["ΛCDM", "regime breakdown", "SPARC", "COSMOS-Web", "JWST", "high-z galaxies"]
+}

--- a/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/schema.json
+++ b/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/regime-dependent-breakdown/schema.json",
+  "title": "ΛCDM Regime Breakdown Schema",
+  "type": "object",
+  "properties": {
+    "chi2_test": {
+      "type": "object",
+      "properties": {
+        "chi2": {"type": "number"},
+        "df": {"type": "integer"},
+        "p_value": {"type": "number"}
+      }
+    },
+    "excess_ratio": {
+      "type": "object",
+      "properties": {
+        "z_range": {"type": "string"},
+        "ratio": {"type": "number"},
+        "reference": {"type": "string"}
+      }
+    }
+  },
+  "efc_analysis_type": "lcdm_tension_analysis"
+}

--- a/docs/papers/efc/validity-aware-ai/citations.bib
+++ b/docs/papers/efc/validity-aware-ai/citations.bib
@@ -1,0 +1,18 @@
+@techreport{magnusson2026validityaware,
+  author = {Magnusson, Morten},
+  title = {Validity-Aware AI: An Entropy-Bounded Architecture for Regime-Sensitive Inference},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31122970}
+}
+
+@misc{magnusson2026l0l3,
+  title = {L0-L3 Regime Architecture},
+  author = {Magnusson, Morten},
+  doi = {10.6084/m9.figshare.31112536}
+}
+
+@misc{magnusson2025symbiosis,
+  title = {Symbiosis Architecture},
+  author = {Magnusson, Morten},
+  doi = {10.6084/m9.figshare.30773684}
+}

--- a/docs/papers/efc/validity-aware-ai/index.json
+++ b/docs/papers/efc/validity-aware-ai/index.json
@@ -1,0 +1,49 @@
+{
+  "id": "validity-aware-ai",
+  "title": "Validity-Aware AI: An Entropy-Bounded Architecture for Regime-Sensitive Inference",
+  "short_title": "Validity-Aware AI",
+  "version": "1.0",
+  "date": "2026",
+  "doi": "10.6084/m9.figshare.31122970",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095"
+  },
+  "type": "architectural_framework",
+  "status": "published",
+  "abstract_short": "AI architecture with pre-inference entropy measurement, regime classification (L1/L2/L3), and response protocols. Hallucination defined as protocol violation.",
+  "keywords": ["validity-aware AI", "entropy-bounded", "regime-sensitive", "L0-L3", "hallucination", "epistemic honesty", "RAG"],
+  "core_principle": "No system may generate confident claims outside the regime where such claims are empirically valid.",
+  "problem": "Standard LLMs are epistemically blind - no mechanism to detect regime boundaries or degrade epistemic status.",
+  "solution": [
+    "Pre-inference entropy measurement in knowledge structures",
+    "Regime classification (L1/L2/L3) before generation",
+    "Response protocols that constrain output based on epistemic conditions",
+    "Hallucination as protocol violation, not just quality issue"
+  ],
+  "regime_architecture": {
+    "L0": {"state": "Latent", "validity": "None (system inactive)"},
+    "L1": {"state": "Stable Active", "validity": "High confidence, reliable"},
+    "L2": {"state": "Complex Active", "validity": "Requires uncertainty quantification"},
+    "L3": {"state": "Residual", "validity": "Historical retrieval only"}
+  },
+  "graph_entropy": {
+    "formula": "H(G) = H_V + H_E + H_VE",
+    "components": ["Node entropy", "Edge entropy", "Structural entropy"]
+  },
+  "documents": [
+    {"id": "A", "title": "Entropy, Validity, and Regimes"},
+    {"id": "B", "title": "Regime-Aware RAG"},
+    {"id": "C", "title": "Beyond the Black Box"}
+  ],
+  "dependencies": [
+    {"doi": "10.6084/m9.figshare.31112536", "title": "L0-L3 Regime Architecture"},
+    {"doi": "10.6084/m9.figshare.30773684", "title": "Symbiosis Architecture"}
+  ],
+  "files": {
+    "docs": "docs/",
+    "src": "src/",
+    "data": "data/",
+    "examples": "examples/"
+  }
+}

--- a/docs/papers/efc/validity-aware-ai/schema.json
+++ b/docs/papers/efc/validity-aware-ai/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/validity-aware-ai/schema.json",
+  "title": "Validity-Aware AI Schema",
+  "type": "object",
+  "properties": {
+    "regime": {
+      "type": "string",
+      "enum": ["L0", "L1", "L2", "L3"]
+    },
+    "graph_entropy": {
+      "type": "object",
+      "properties": {
+        "H_V": {"type": "number", "description": "Node entropy"},
+        "H_E": {"type": "number", "description": "Edge entropy"},
+        "H_VE": {"type": "number", "description": "Structural entropy"},
+        "total": {"type": "number"}
+      }
+    },
+    "response_protocol": {
+      "type": "string",
+      "enum": ["standard", "uncertainty_aware", "refuse", "archive"]
+    }
+  },
+  "efc_framework": "validity_aware_ai"
+}

--- a/docs/papers/efc/validity-aware-ai/validity-aware-ai.jsonld
+++ b/docs/papers/efc/validity-aware-ai/validity-aware-ai.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": "https://schema.org/",
+  "@type": "TechArticle",
+  "@id": "doi:10.6084/m9.figshare.31122970",
+  "name": "Validity-Aware AI: An Entropy-Bounded Architecture for Regime-Sensitive Inference",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "abstract": "AI architecture enabling systems to recognize and report their own epistemic limits. Extends EBE and L0-L3 regimes to knowledge-graph inference. Hallucination defined as protocol violation.",
+  "keywords": ["validity-aware AI", "entropy-bounded", "L0-L3 regimes", "epistemic honesty", "RAG"]
+}


### PR DESCRIPTION
Added index.json, schema.json, citations.bib, and .jsonld for:
- EFC-C_Consciousness_Field_Resonance (DOI: 10.6084/m9.figshare.31289806)
  - Key result: Omega d=1.50, product test F1 FALSIFIED
  - Differentiation-dominant resonance model supported
- EFC-Phenomenology-vs-DESI-DR2-BAO
- EFC-Regime-Transition-Framework
- Empirical-Validation (Cluster/Galaxy)
- L0-L3-Regime-Architecture
- Structural-Constraints (Cluster Mergers)
- Systematic-CMB-Constraints
- efc-weak-lensing-phenomenology
- entropy-bounded-empiricism-EBE-SPARC175
- observed-galaxy-abundances-z>6
- regime-dependent-breakdown-LCDM
- validity-aware-ai

https://claude.ai/code/session_01RNKSig9vLiuRDZMEJGHT1o