### PR TITLE
Add SOTA metadata for Structural Coherence and RSD-to-Clusters papers

### DIFF
--- a/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/citations.bib
+++ b/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/citations.bib
@@ -1,0 +1,68 @@
+@article{magnusson2026structural,
+  author = {Magnusson, Morten},
+  title = {Structural Coherence Evaluation for Physical Theories: A Theory-Agnostic Framework with Observation-Native Ontology and Self-Imposed Falsifiability},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31293745}
+}
+
+@book{popper1959logic,
+  author = {Popper, Karl},
+  title = {The Logic of Scientific Discovery},
+  publisher = {Hutchinson Co.},
+  year = {1959}
+}
+
+@book{kuhn1962structure,
+  author = {Kuhn, Thomas S.},
+  title = {The Structure of Scientific Revolutions},
+  publisher = {University of Chicago Press},
+  year = {1962}
+}
+
+@book{lakatos1978methodology,
+  author = {Lakatos, Imre},
+  title = {The Methodology of Scientific Research Programmes},
+  publisher = {Cambridge University Press},
+  year = {1978}
+}
+
+@article{quine1951dogmas,
+  author = {Quine, W. V. O.},
+  title = {Two Dogmas of Empiricism},
+  journal = {The Philosophical Review},
+  volume = {60},
+  number = {1},
+  pages = {20--43},
+  year = {1951}
+}
+
+@article{trotta2008bayes,
+  author = {Trotta, R.},
+  title = {Bayes in the sky: Bayesian inference and model selection in cosmology},
+  journal = {Contemporary Physics},
+  volume = {49},
+  number = {2},
+  pages = {71--104},
+  year = {2008}
+}
+
+@article{magnusson2026ebe,
+  author = {Magnusson, Morten},
+  title = {Entropy-Bounded Empiricism: Core Principles},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31222903}
+}
+
+@article{magnusson2026l0l3,
+  author = {Magnusson, Morten},
+  title = {L0--L3 Regime Architecture in Entropy-Bounded Empiricism},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31112536}
+}
+
+@article{magnusson2026rcmp,
+  author = {Magnusson, Morten},
+  title = {The Regime-Consistent Measurement Principle (RCMP)},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31222900}
+}

--- a/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/index.json
+++ b/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/index.json
@@ -1,0 +1,118 @@
+{
+  "id": "structural-coherence-evaluation",
+  "title": "Structural Coherence Evaluation for Physical Theories: A Theory-Agnostic Framework with Observation-Native Ontology and Self-Imposed Falsifiability",
+  "doi": "10.6084/m9.figshare.31293745",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Independent Researcher, Norway"
+  },
+  "keywords": [
+    "theory evaluation",
+    "structural coherence",
+    "falsifiability",
+    "observation-native ontology",
+    "philosophy of science",
+    "model comparison",
+    "graph database",
+    "forbidden patterns"
+  ],
+  "abstract": "A theory-agnostic evaluation framework for assessing structural coherence and falsifiability of physical theories. Introduces four operational principles and five structural metrics for cross-paradigm comparison without privileging any specific ontology.",
+  "four_principles": {
+    "I": {
+      "name": "Observation-Native Ontology",
+      "description": "Phenomena defined as measured observables, not theory-laden constructs",
+      "metric": "Ontology Dependence Score (ODS 0-3)"
+    },
+    "II": {
+      "name": "Declared Structural Vulnerability",
+      "description": "Theories must specify forbidden observational patterns from internal constraints",
+      "metric": "Forbidden Pattern Coverage"
+    },
+    "III": {
+      "name": "Priced Adaptation",
+      "description": "Survival through modification carries explicit epistemic cost",
+      "metric": "Model Plasticity, Cumulative Structural Drift"
+    },
+    "IV": {
+      "name": "Primitive Transparency",
+      "description": "Independent explanatory assumptions declared explicitly",
+      "metric": "Explanatory Compression, FDOF"
+    }
+  },
+  "five_metrics": [
+    {
+      "name": "Explanatory Compression",
+      "formula": "C = |tested phenomena| / |primitive assumptions|",
+      "principle": "IV"
+    },
+    {
+      "name": "Anomaly Burden",
+      "components": ["Mismatch Rate", "Coverage Penalty"],
+      "principle": "I, III"
+    },
+    {
+      "name": "Model Plasticity",
+      "indicators": ["Variant Proliferation Rate", "Parameter Growth", "Special-Case Rule Count"],
+      "principle": "III"
+    },
+    {
+      "name": "Layer Consistency",
+      "dimensions": ["Mechanism unity", "Parameter coherence", "Transition smoothness"],
+      "principle": "I, II"
+    },
+    {
+      "name": "Forbidden Pattern Coverage",
+      "formula": "EffectiveCoverage = Σ tested_i / w(ORL_i)",
+      "levels": ["Core patterns", "Module patterns"],
+      "principle": "II"
+    }
+  ],
+  "forbidden_patterns_structure": {
+    "components": ["Scope", "Description (observation-native)", "Violation condition", "Test procedure"],
+    "hierarchy": ["Core (invalidate framework)", "Module (revise specific application)"],
+    "key_property": "Ontological independence from competing frameworks"
+  },
+  "framework_forbidden_patterns": {
+    "TCS-F1": "Robustness Failure - rankings change under reasonable counting variations",
+    "TCS-F2": "Epistemic Divergence - systematic opposition to expert assessment",
+    "TCS-F3": "Performative Falsifiability - rewards trivial over deep forbidden patterns"
+  },
+  "case_studies": [
+    {
+      "name": "ΛCDM",
+      "type": "Empirically Mature",
+      "primitives": "3-5",
+      "profile": "High coverage, moderate anomaly burden, limited self-declared falsifiability"
+    },
+    {
+      "name": "Entropy-Gradient (EFC)",
+      "type": "Emergent",
+      "primitives": "2-3",
+      "profile": "High declared falsifiability, limited coverage, low plasticity"
+    },
+    {
+      "name": "MOND/Modified Gravity",
+      "type": "Intermediate",
+      "primitives": "2-6",
+      "profile": "High galactic compression, declining consistency in extensions"
+    }
+  ],
+  "implementation": {
+    "type": "Property Graph Database",
+    "node_types": ["Theory", "PrimitiveAssumption", "ObservablePhenomenon", "Mapping", "Assessment", "ForbiddenPattern", "CoherenceProfile", "InferenceLayer"],
+    "key_features": ["Snapshot-based versioning", "No retroactive credit", "Temporal tracking"]
+  },
+  "key_innovations": [
+    "Self-imposed falsifiability as operational, machine-checkable property",
+    "Forbidden patterns derived from constitutive laws",
+    "Theory comparison across ontological boundaries",
+    "Reflexive application of framework standards"
+  ],
+  "relationship_to_existing": {
+    "Bayesian_evidence": "Complementary - operates at theory level, not model level",
+    "Information_criteria": "Counts primitives not parameters",
+    "Lakatos": "Operationalizes prospectively rather than retrospectively",
+    "Pre-registration": "Extends from experiments to theoretical frameworks"
+  }
+}

--- a/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/schema.json
+++ b/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/schema.json",
+  "title": "Structural Coherence Evaluation Framework Schema",
+  "type": "object",
+  "required": ["id", "title", "doi", "author", "four_principles", "five_metrics"],
+  "properties": {
+    "id": {"type": "string"},
+    "title": {"type": "string"},
+    "doi": {"type": "string", "pattern": "^10\\."},
+    "author": {
+      "type": "object",
+      "required": ["name", "orcid"],
+      "properties": {
+        "name": {"type": "string"},
+        "orcid": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$"}
+      }
+    },
+    "four_principles": {
+      "type": "object",
+      "properties": {
+        "I": {"$ref": "#/$defs/principle"},
+        "II": {"$ref": "#/$defs/principle"},
+        "III": {"$ref": "#/$defs/principle"},
+        "IV": {"$ref": "#/$defs/principle"}
+      }
+    },
+    "five_metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "principle"],
+        "properties": {
+          "name": {"type": "string"},
+          "formula": {"type": "string"},
+          "principle": {"type": "string"}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "principle": {
+      "type": "object",
+      "required": ["name", "description"],
+      "properties": {
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "metric": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/papers/efc/paper_rsd_to_clusters/citations.bib
+++ b/docs/papers/efc/paper_rsd_to_clusters/citations.bib
@@ -1,0 +1,58 @@
+@article{magnusson2026rsd,
+  author = {Magnusson, Morten},
+  title = {From RSD to Clusters: A Parameter-Locked Test of Late-Time Structure Growth},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31292827}
+}
+
+@article{bulbul2024erass1,
+  author = {Bulbul, E. and others},
+  title = {The eROSITA Final Equatorial-Depth Survey (eFEDS): X-ray observations of the eRASS1 cluster catalog},
+  journal = {A\&A},
+  volume = {685},
+  pages = {A106},
+  year = {2024}
+}
+
+@article{clerc2024erass1,
+  author = {Clerc, N. and others},
+  title = {eRASS1 cluster selection function},
+  journal = {A\&A},
+  volume = {687},
+  pages = {A238},
+  year = {2024}
+}
+
+@article{ghirardini2024erass1,
+  author = {Ghirardini, V. and others},
+  title = {eRASS1 cosmology constraints},
+  journal = {A\&A},
+  volume = {689},
+  pages = {A298},
+  year = {2024}
+}
+
+@article{tinker2008mass,
+  author = {Tinker, J. and others},
+  title = {Toward a Halo Mass Function for Precision Cosmology},
+  journal = {ApJ},
+  volume = {688},
+  pages = {709},
+  year = {2008}
+}
+
+@article{duffy2008concentration,
+  author = {Duffy, A. R. and others},
+  title = {Dark matter halo concentrations in the WMAP5 cosmology},
+  journal = {MNRAS},
+  volume = {390},
+  pages = {L64},
+  year = {2008}
+}
+
+@article{magnusson2026boss,
+  author = {Magnusson, Morten},
+  title = {Phenomenological constraints on entropy-flow modifications from BOSS DR12},
+  year = {2026},
+  doi = {10.6084/m9.figshare.31243828}
+}

--- a/docs/papers/efc/paper_rsd_to_clusters/index.json
+++ b/docs/papers/efc/paper_rsd_to_clusters/index.json
@@ -1,0 +1,85 @@
+{
+  "id": "rsd-to-clusters",
+  "title": "From RSD to Clusters: A Parameter-Locked Test of Late-Time Structure Growth",
+  "doi": "10.6084/m9.figshare.31292827",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Independent Researcher, Norway"
+  },
+  "keywords": [
+    "cosmology",
+    "dark energy",
+    "galaxy clusters",
+    "modified gravity",
+    "large-scale structure",
+    "redshift-space distortions",
+    "eROSITA",
+    "cross-probe test"
+  ],
+  "abstract": "A cross-probe test of late-time structure growth propagating RSD constraints on effective gravitational coupling into galaxy cluster abundance predictions with zero free parameters fit to cluster data.",
+  "methodology": {
+    "approach": "Parameter-locked cross-probe",
+    "inference_chain": "RSD → Growth history D(z) → Mass function → Cluster counts",
+    "key_feature": "No parameters fit to cluster data"
+  },
+  "input_constraint": {
+    "parameter": "α_L2",
+    "value": 0.34,
+    "uncertainty": 0.16,
+    "source": "BOSS DR12 RSD measurements",
+    "equation": "μ_EFC(a) = 1 + α_L2 × f_transition(a)"
+  },
+  "key_results": {
+    "total_abundance": {
+      "ratio": "N_EFC / N_ΛCDM = 1.064 ± 0.02",
+      "interpretation": "+6.4% more clusters than ΛCDM"
+    },
+    "growth_enhancement": {
+      "z_0": {"D_ratio": 1.016, "delta": "+1.6%"},
+      "z_0.2": {"D_ratio": 1.007, "delta": "+0.7%"},
+      "z_0.4": {"D_ratio": 1.002, "delta": "+0.2%"},
+      "z_0.6": {"D_ratio": 1.000, "delta": "+0.0%"}
+    },
+    "shape_signature": {
+      "description": "z-dependent tilt in cluster redshift distribution",
+      "gradient": "dR/dz < 0",
+      "z_0.15": "R(z) ≈ 1.05 (excess)",
+      "z_0.7": "R(z) ≈ 0.94 (deficit)",
+      "robustness": "Insensitive to uniform mass-calibration systematics"
+    }
+  },
+  "shape_observable": {
+    "definition": "R(z) = R_EFC(z) / R_ΛCDM(z), where R(z) = N(z)/N_total",
+    "advantage": "Robust against uniform multiplicative mass-calibration errors",
+    "statistical_power": "~2-3σ discrimination"
+  },
+  "falsification_criteria": {
+    "falsified_if": [
+      "Fewer total clusters than ΛCDM (after mass calibration)",
+      "Positive dR/dz (more high-z fraction than low-z)",
+      "Flat R(z) at ≤1% level"
+    ],
+    "consistent_if": [
+      "~5-8% cluster excess relative to ΛCDM",
+      "Negative dR/dz with amplitude ~0.05-0.10",
+      "Crossover near z ~ 0.3-0.4"
+    ]
+  },
+  "data_context": {
+    "target_survey": "eRASS1",
+    "cluster_sample": "N ≈ 5259 (cosmology sample)",
+    "mass_range": "M > 10^14 M_☉",
+    "redshift_range": "0.1 < z < 0.8",
+    "mass_calibration": "DES Y3, KiDS-1000, HSC weak lensing"
+  },
+  "normalization": {
+    "choice": "High-z (primordial) normalization",
+    "rationale": "Forward prediction from CMB, not retrodiction",
+    "A_s": "Fixed across models"
+  },
+  "systematic_considerations": {
+    "robust_against": ["Uniform mass-bias offsets", "Overall survey completeness", "Redshift-independent selection"],
+    "sensitive_to": "Strongly redshift-dependent systematics"
+  }
+}

--- a/docs/papers/efc/paper_rsd_to_clusters/schema.json
+++ b/docs/papers/efc/paper_rsd_to_clusters/schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/supertedai/EFC/docs/papers/efc/paper_rsd_to_clusters/schema.json",
+  "title": "RSD to Clusters Cross-Probe Test Schema",
+  "type": "object",
+  "required": ["id", "title", "doi", "author", "input_constraint", "key_results"],
+  "properties": {
+    "id": {"type": "string"},
+    "title": {"type": "string"},
+    "doi": {"type": "string", "pattern": "^10\\."},
+    "author": {
+      "type": "object",
+      "required": ["name", "orcid"],
+      "properties": {
+        "name": {"type": "string"},
+        "orcid": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{4}$"}
+      }
+    },
+    "input_constraint": {
+      "type": "object",
+      "required": ["parameter", "value", "source"],
+      "properties": {
+        "parameter": {"type": "string"},
+        "value": {"type": "number"},
+        "uncertainty": {"type": "number"},
+        "source": {"type": "string"}
+      }
+    },
+    "key_results": {
+      "type": "object",
+      "properties": {
+        "total_abundance": {"type": "object"},
+        "shape_signature": {"type": "object"}
+      }
+    },
+    "falsification_criteria": {
+      "type": "object",
+      "properties": {
+        "falsified_if": {"type": "array", "items": {"type": "string"}},
+        "consistent_if": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Structural_Coherence_Evaluation_for_Physical_Theories:
- DOI: 10.6084/m9.figshare.31293745
- Theory-agnostic framework with 4 principles, 5 metrics
- Self-imposed falsifiability via forbidden patterns
- Graph-based implementation for cross-paradigm comparison

paper_rsd_to_clusters:
- DOI: 10.6084/m9.figshare.31292827
- Parameter-locked cross-probe test (RSD → clusters)
- α_L2 = 0.34 from BOSS DR12, zero free parameters
- Key result: +6.4% cluster excess, dR/dz < 0 shape signature

https://claude.ai/code/session_01RNKSig9vLiuRDZMEJGHT1o