### PR TITLE
Add SOTA metadata for ISW Cross-Correlation predictions paper

### DIFF
--- a/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/citations.bib
+++ b/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/citations.bib
@@ -1,0 +1,64 @@
+@article{magnusson2025isw,
+  author = {Magnusson, Morten},
+  title = {ISW Cross-Correlation Predictions for Energy-Flow Cosmology with DESI DR1 Tracers},
+  year = {2025},
+  doi = {10.6084/m9.figshare.31301953}
+}
+
+@article{eisenstein1998baryonic,
+  author = {Eisenstein, D. J. and Hu, W.},
+  title = {Baryonic Features in the Matter Transfer Function},
+  journal = {ApJ},
+  volume = {496},
+  pages = {605},
+  year = {1998},
+  doi = {10.1086/305424}
+}
+
+@article{hang2021isw,
+  author = {Hang, Q. and Alam, S. and Peacock, J. A. and Cai, Y.-C.},
+  title = {Galaxy clustering in the DESI Legacy Survey and its imprint on the CMB},
+  journal = {MNRAS},
+  volume = {501},
+  pages = {1481},
+  year = {2021},
+  doi = {10.1093/mnras/staa3738}
+}
+
+@article{ansarinejad2020atlas,
+  author = {Ansarinejad, B. and Mackenzie, R. and Shanks, T. and Metcalfe, N.},
+  title = {Cross-correlation of the Planck CMB lensing map with ATLAS DR4},
+  journal = {MNRAS},
+  volume = {493},
+  pages = {4830},
+  year = {2020},
+  doi = {10.1093/mnras/staa592}
+}
+
+@article{adame2025desi,
+  author = {{DESI Collaboration}},
+  title = {DESI 2024 III: Baryon Acoustic Oscillations from Galaxies and Quasars},
+  journal = {JCAP},
+  volume = {2025},
+  number = {09},
+  pages = {008},
+  year = {2025},
+  doi = {10.1088/1475-7516/2025/09/008}
+}
+
+@article{planck2016isw,
+  author = {{Planck Collaboration}},
+  title = {Planck 2015 results. XXI. The integrated Sachs-Wolfe effect},
+  journal = {A\&A},
+  volume = {594},
+  pages = {A21},
+  year = {2016},
+  doi = {10.1051/0004-6361/201525831}
+}
+
+@article{magnusson2025efc,
+  author = {Magnusson, Morten},
+  title = {Energy-Flow Cosmology (EFC v2.1): Modular Synthesis across Structure, Dynamics, and Cognition},
+  year = {2025},
+  doi = {10.6084/m9.figshare.30455237}
+}

--- a/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/index.json
+++ b/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/index.json
@@ -1,0 +1,91 @@
+{
+  "id": "isw-cross-correlation-desi-dr1",
+  "title": "ISW Cross-Correlation Predictions for Energy-Flow Cosmology with DESI DR1 Tracers",
+  "doi": "10.6084/m9.figshare.31301953",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Energy-Flow Cosmology Project"
+  },
+  "keywords": [
+    "integrated Sachs-Wolfe effect",
+    "ISW",
+    "CMB cross-correlation",
+    "DESI",
+    "modified gravity",
+    "large-scale structure",
+    "cosmological perturbations"
+  ],
+  "abstract": "Computes ISW-galaxy cross-correlation C_ℓ^Tg for EFC using linear perturbation theory, introducing the cancellation metric C to quantify opposite-sign contributions from standard and transition kernels.",
+  "core_equations": {
+    "growth_equation": "D_xx + (2 + d ln H/dx) D_x - (3/2) Ω_m(a) μ(a) D = 0",
+    "modified_poisson": "∇²Φ = 4πG μ(a) ρ̄ δ",
+    "mu_parameterization": "μ(a) = 1 + β S(a), S(a) = ½[1 + tanh((ln a - ln a_t)/σ_cos)]",
+    "isw_kernel": "K(a) ∝ d/d ln a [μ D/a] = K_μ + K_μ'",
+    "cancellation_metric": "C = 1 - |Σ_ℓ C_ℓ,tot^Tg| / (|Σ_ℓ C_ℓ,μ^Tg| + |Σ_ℓ C_ℓ,μ'^Tg|)"
+  },
+  "parameters": {
+    "beta": 0.16,
+    "a_t": 0.55,
+    "z_t": 0.82,
+    "sigma_cos": "[0.20, 0.30]",
+    "multipole_range": "[2, 60]"
+  },
+  "key_results": {
+    "cancellation_trend": {
+      "description": "C increases monotonically with tracer overlap with z_t",
+      "LRGz0": {"z_eff": 0.51, "C": 0.59, "A_ISW": 0.56},
+      "LRG_ELG": {"z_eff": 0.93, "C": 0.79, "A_ISW": 0.29},
+      "ELG": {"z_eff": 1.32, "C": 0.96}
+    },
+    "amplitude_suppression": {
+      "EFC_range": "A_ISW = 0.29-0.56",
+      "LCDM_expectation": "A_ISW = 1 for all tracers",
+      "current_status": "Consistent within 1.6σ"
+    },
+    "kernel_decomposition": {
+      "K_mu": "Standard ISW term (potential decay in accelerating universe)",
+      "K_mu_prime": "EFC transition term (temporal variation of μ)",
+      "signature": "Opposite-sign contributions near z_t cause suppression"
+    }
+  },
+  "predictions_vs_lcdm": {
+    "EFC": {
+      "cancellation": "C ≳ 0.6 for z_eff ≳ 0.5, monotonically increasing",
+      "amplitude": "Suppressed near z_t (A ≈ 0.3-0.6)",
+      "redshift_dependence": "Strong: suppression peaks at z_t ≈ 0.82"
+    },
+    "LCDM": {
+      "cancellation": "C = 0 by construction",
+      "amplitude": "A_ISW = 1 for all tracers",
+      "redshift_dependence": "Weak: varies only via Ω_Λ(z)"
+    }
+  },
+  "observational_benchmark": {
+    "desi_legacy_planck": {
+      "A_ISW": "0.984 ± 0.349",
+      "source": "Hang et al. 2021"
+    },
+    "atlas_lrg_planck": {
+      "note": "Null detected at z̄ = 0.68",
+      "source": "Ansarinejad et al. 2020"
+    }
+  },
+  "falsification_criteria": {
+    "EFC_falsified_if": "Tomographic bins overlapping z_t yield A_ISW = 1.0 ± 0.1 and C ≈ 0",
+    "LCDM_challenged_if": "A_ISW ≪ 1 with high C at z_t",
+    "decisive_test": "Tomographic C_ℓ^Tg in DESI spectroscopic bins overlapping z_t"
+  },
+  "methodology": {
+    "power_spectrum": "Eisenstein & Hu (1998) no-wiggle transfer function",
+    "angular_projection": "Extended Limber approximation, k = (ℓ + 1/2)/χ",
+    "tracer_windows": "DESI DR1-motivated W_g(z) = b_g(z) dN/dz",
+    "galaxy_bias": "From DESI DR1 full-shape analyses"
+  },
+  "caveats": [
+    "Limber approximation degrades for ℓ ≲ 10",
+    "Smooth parametric n(z) approximations used",
+    "No mask/pseudo-C_ℓ correction applied",
+    "σ_8,0 fitted as nuisance parameter"
+  ]
+}

--- a/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/schema.json
+++ b/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/schema.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://efc-project.org/papers/isw-cross-correlation-desi-dr1/schema.json",
+  "title": "ISW Cross-Correlation Predictions for EFC with DESI DR1",
+  "description": "Schema for ISW-galaxy cross-correlation C_ℓ^Tg predictions in Energy-Flow Cosmology using DESI DR1 tracer windows",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "const": "isw-cross-correlation-desi-dr1"
+    },
+    "efc_parameters": {
+      "type": "object",
+      "properties": {
+        "beta": {
+          "type": "number",
+          "description": "Gravitational enhancement amplitude β in μ(a) = 1 + β S(a)",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "a_t": {
+          "type": "number",
+          "description": "Transition scale factor",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "z_t": {
+          "type": "number",
+          "description": "Transition redshift z_t = 1/a_t - 1",
+          "minimum": 0
+        },
+        "sigma_cos": {
+          "type": "array",
+          "items": {"type": "number"},
+          "description": "Transition width parameter range",
+          "minItems": 2,
+          "maxItems": 2
+        }
+      },
+      "required": ["beta", "a_t", "z_t"]
+    },
+    "isw_kernel": {
+      "type": "object",
+      "properties": {
+        "K_total": {
+          "type": "string",
+          "description": "Total ISW kernel expression"
+        },
+        "K_mu": {
+          "type": "string",
+          "description": "Standard μ-weighted potential decay term"
+        },
+        "K_mu_prime": {
+          "type": "string",
+          "description": "EFC transition term from dμ/dt"
+        }
+      },
+      "required": ["K_total", "K_mu", "K_mu_prime"]
+    },
+    "cancellation_metric": {
+      "type": "object",
+      "properties": {
+        "C": {
+          "type": "number",
+          "description": "Cancellation metric C ∈ [0, 1]",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "definition": {
+          "type": "string",
+          "description": "C = 1 - |Σ C_ℓ,tot| / (|Σ C_ℓ,μ| + |Σ C_ℓ,μ'|)"
+        }
+      }
+    },
+    "tracer_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "tracer": {
+            "type": "string",
+            "enum": ["LRGz0", "LRGz1", "LRGz2", "LRG_ELG", "ELG", "QSO"]
+          },
+          "z_eff": {
+            "type": "number",
+            "description": "Effective redshift of tracer sample"
+          },
+          "C": {
+            "type": "number",
+            "description": "Cancellation metric value"
+          },
+          "A_ISW": {
+            "type": "number",
+            "description": "ISW amplitude relative to ΛCDM"
+          }
+        },
+        "required": ["tracer", "z_eff", "C"]
+      }
+    },
+    "predictions_vs_lcdm": {
+      "type": "object",
+      "properties": {
+        "EFC": {
+          "type": "object",
+          "properties": {
+            "cancellation": {"type": "string"},
+            "amplitude": {"type": "string"},
+            "redshift_dependence": {"type": "string"}
+          }
+        },
+        "LCDM": {
+          "type": "object",
+          "properties": {
+            "cancellation": {"type": "string"},
+            "amplitude": {"type": "string"},
+            "redshift_dependence": {"type": "string"}
+          }
+        }
+      }
+    },
+    "falsification_criteria": {
+      "type": "object",
+      "properties": {
+        "EFC_falsified_if": {
+          "type": "string",
+          "description": "Condition under which EFC is falsified"
+        },
+        "LCDM_challenged_if": {
+          "type": "string",
+          "description": "Condition under which ΛCDM is challenged"
+        },
+        "decisive_test": {
+          "type": "string",
+          "description": "Key observational test"
+        }
+      },
+      "required": ["EFC_falsified_if", "decisive_test"]
+    }
+  },
+  "required": ["id", "efc_parameters", "isw_kernel", "cancellation_metric", "falsification_criteria"]
+}


### PR DESCRIPTION
Adds AI-optimized metadata structure for ISW-galaxy cross-correlation predictions using DESI DR1 tracers:
- Cancellation metric C quantifying opposite-sign kernel contributions
- Kernel decomposition K_μ (standard) + K_μ' (EFC transition)
- Parameters: β=0.16, a_t=0.55, z_t≈0.82
- Falsification criteria: A_ISW = 1.0 ± 0.1 at z_t would falsify EFC

https://claude.ai/code/session_01RNKSig9vLiuRDZMEJGHT1o