### PR TITLE
Add SOTA metadata for Four-Channel Consistency Test paper

### DIFF
--- a/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/citations.bib
+++ b/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/citations.bib
@@ -1,0 +1,119 @@
+@article{magnusson2026fourchannel,
+  author       = {Magnusson, Morten},
+  title        = {A One-Parameter, Four-Channel Consistency Test for {EFC} Background Coupling ($\beta \cdot T(a)$)},
+  year         = {2026},
+  month        = {February},
+  doi          = {10.6084/m9.figshare.31304980},
+  publisher    = {Figshare},
+  note         = {Four independent cosmological probes, one parameter, zero kills}
+}
+
+@article{alam2017boss,
+  author       = {Alam, Shadab and others},
+  collaboration = {BOSS},
+  title        = {The clustering of galaxies in the completed {SDSS-III} {Baryon} {Oscillation} {Spectroscopic} {Survey}: cosmological analysis of the {DR12} galaxy sample},
+  journal      = {MNRAS},
+  volume       = {470},
+  pages        = {2617},
+  year         = {2017},
+  eprint       = {1607.03155},
+  archiveprefix = {arXiv}
+}
+
+@article{desi2024,
+  author       = {{DESI Collaboration}},
+  title        = {{DESI} 2024 {VI}: Cosmological Constraints from the Measurements of Baryon Acoustic Oscillations},
+  year         = {2024},
+  eprint       = {2404.03002},
+  archiveprefix = {arXiv}
+}
+
+@article{qu2025cmblensing,
+  author       = {Qu, Frank J. and others},
+  title        = {Combined {ACT}+{SPT}+{Planck} {CMB} lensing},
+  year         = {2025},
+  eprint       = {2504.20038},
+  archiveprefix = {arXiv},
+  note         = {S8 = 0.825 ± 0.014}
+}
+
+@article{brout2022pantheon,
+  author       = {Brout, Dillon and others},
+  collaboration = {Pantheon+},
+  title        = {The {Pantheon+} Analysis: Cosmological Constraints},
+  journal      = {ApJ},
+  volume       = {938},
+  pages        = {110},
+  year         = {2022},
+  eprint       = {2202.04077},
+  archiveprefix = {arXiv}
+}
+
+@article{tristram2024pr4,
+  author       = {Tristram, Matthieu and others},
+  title        = {{Planck} {PR4} constraints on primordial cosmology},
+  journal      = {A\&A},
+  volume       = {682},
+  pages        = {A37},
+  year         = {2024},
+  eprint       = {2309.10034},
+  archiveprefix = {arXiv},
+  note         = {Planck PR4 reanalysis}
+}
+
+@article{alvey2020bbn,
+  author       = {Alvey, James and others},
+  title        = {Improved {BBN} constraints on the variation of the gravitational constant},
+  journal      = {Eur. Phys. J. C},
+  volume       = {80},
+  pages        = {148},
+  year         = {2020},
+  eprint       = {1910.10730},
+  archiveprefix = {arXiv}
+}
+
+@article{andrade2024,
+  author       = {Andrade, Ulises and others},
+  title        = {Cosmological constraints from galaxy clustering},
+  journal      = {MNRAS},
+  volume       = {529},
+  pages        = {831},
+  year         = {2024},
+  eprint       = {2309.15781},
+  archiveprefix = {arXiv}
+}
+
+@article{planck2020vi,
+  author       = {{Planck Collaboration}},
+  title        = {{Planck} 2018 results. {VI}. {Cosmological} parameters},
+  journal      = {A\&A},
+  volume       = {641},
+  pages        = {A6},
+  year         = {2020},
+  eprint       = {1807.06209},
+  archiveprefix = {arXiv}
+}
+
+@misc{magnusson2026efc1,
+  author       = {Magnusson, Morten},
+  title        = {{EFC} Core Framework},
+  year         = {2026},
+  doi          = {10.6084/m9.figshare.31223668},
+  publisher    = {Figshare}
+}
+
+@misc{magnusson2026efc2,
+  author       = {Magnusson, Morten},
+  title        = {{EFC} Distance Coupling},
+  year         = {2026},
+  doi          = {10.6084/m9.figshare.31224538},
+  publisher    = {Figshare}
+}
+
+@misc{magnusson2026efc3,
+  author       = {Magnusson, Morten},
+  title        = {{EFC} Growth Suppression},
+  year         = {2026},
+  doi          = {10.6084/m9.figshare.31223908},
+  publisher    = {Figshare}
+}

--- a/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/index.json
+++ b/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/index.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "./schema.json",
+  "id": "efc-four-channel-consistency-test",
+  "title": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling (β · T(a))",
+  "description": "Consistency test of EFC's background coupling against four independent cosmological probes: BAO distances, redshift-space distortions, CMB lensing, and Type Ia supernovae. Demonstrates that Poisson-channel modification is excluded while background coupling shows mild preference.",
+  "version": "1.0.0",
+  "date": "2026-02",
+  "doi": "10.6084/m9.figshare.31304980",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "EFC",
+    "modified Friedmann equation",
+    "background coupling",
+    "BAO",
+    "RSD",
+    "CMB lensing",
+    "Type Ia supernovae",
+    "S8 tension",
+    "BOSS DR12",
+    "Pantheon+",
+    "consistency test"
+  ],
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Independent researcher"
+  },
+  "core_equations": {
+    "modified_friedmann": {
+      "latex": "H^2(a) = H_0^2 [\\Omega_m a^{-3} + \\Omega_\\Lambda (1 + \\beta \\cdot T(a))]",
+      "description": "EFC background modification with coupling amplitude β and transition function T(a)"
+    },
+    "transition_function": {
+      "latex": "g_D(z) = \\frac{1 - \\Omega_m(z)}{1+z} \\ln(1+z)",
+      "description": "Distance-coupling kernel, normalised to peak at unity"
+    },
+    "growth_ode": {
+      "latex": "\\ddot{\\delta} + 2H\\dot{\\delta} = 4\\pi G \\rho_m \\delta",
+      "description": "Growth equation with enhanced Hubble friction from modified H(a)"
+    }
+  },
+  "parameters": {
+    "beta": {
+      "value": 0.08,
+      "description": "Dimensionless background coupling amplitude"
+    },
+    "sigma_8_efc": {
+      "value": 0.805,
+      "description": "EFC prediction for σ₈"
+    },
+    "sigma_8_lcdm": {
+      "value": 0.811,
+      "description": "ΛCDM baseline σ₈"
+    }
+  },
+  "channel_comparison": {
+    "poisson": {
+      "alpha": 0.34,
+      "chi2_rsd": 18.2,
+      "sigma_8": 0.879,
+      "direction": "Enhanced",
+      "status": "Excluded"
+    },
+    "background": {
+      "beta": 0.08,
+      "chi2_rsd": 1.09,
+      "sigma_8": 0.805,
+      "direction": "Suppressed",
+      "status": "Favoured"
+    },
+    "lcdm": {
+      "chi2_rsd": 1.34,
+      "sigma_8": 0.811,
+      "status": "Baseline"
+    }
+  },
+  "four_channel_results": {
+    "bao_distances": {
+      "data": "BOSS DR12",
+      "redshifts": [0.38, 0.51, 0.61],
+      "chi2": 1.93,
+      "chi2_lcdm": 5.58,
+      "delta_chi2": -3.65,
+      "status": "PASS",
+      "role": "Detection"
+    },
+    "growth_rate": {
+      "data": "BOSS DR12 fσ₈",
+      "chi2": 1.09,
+      "chi2_lcdm": 1.34,
+      "delta_chi2": -0.25,
+      "status": "PASS",
+      "role": "Detection",
+      "measurements": [
+        {"z": 0.38, "fsigma8_efc": 0.464, "fsigma8_obs": "0.497 ± 0.045", "pull": "-0.73σ"},
+        {"z": 0.51, "fsigma8_efc": 0.463, "fsigma8_obs": "0.458 ± 0.038", "pull": "+0.13σ"},
+        {"z": 0.61, "fsigma8_efc": 0.460, "fsigma8_obs": "0.436 ± 0.034", "pull": "+0.71σ"}
+      ]
+    },
+    "cmb_lensing": {
+      "data": "ACT+SPT+Planck 2025",
+      "S8_observed": "0.825 ± 0.014",
+      "S8_efc": 0.815,
+      "S8_lcdm": 0.821,
+      "pull": "-0.71σ",
+      "status": "PASS",
+      "role": "Neutral"
+    },
+    "sn_ia": {
+      "data": "Pantheon+",
+      "max_delta_mu": 0.032,
+      "status": "PASS",
+      "role": "Neutral"
+    },
+    "combined_bao_rsd": {
+      "delta_chi2": -3.89,
+      "significance": "~2σ preference"
+    }
+  },
+  "regime_consistency": {
+    "boss": {"z": 0.51, "T_z": 0.990, "mu_minus_1": 0.340, "margin": "Detection channel"},
+    "lya_p1d": {"z": 3.0, "T_z": 0.107, "mu_minus_1": 0.037, "margin": "~10× suppressed"},
+    "cmb_recombination": {"z": 1100, "T_z": "9.7e-11", "mu_minus_1": "3.3e-11", "margin": ">10⁸× below bound"},
+    "bbn": {"z": "~10⁸", "T_z": "<10⁻³⁰", "mu_minus_1": "<10⁻²⁵", "margin": ">10²³× below bound"}
+  },
+  "sigma8_landscape": [
+    {"probe": "Planck 2018 primary", "sigma8": 0.811, "error": 0.006, "efc_pull": "-1.0σ", "z": 1100},
+    {"probe": "Planck PR4 primary", "sigma8": 0.807, "error": 0.006, "efc_pull": "-0.33σ", "z": 1100},
+    {"probe": "CMB lensing combined", "sigma8": 0.811, "error": 0.019, "efc_pull": "-0.32σ", "z": "0.5-5"},
+    {"probe": "BOSS RSD (derived)", "sigma8": 0.805, "error": 0.020, "efc_pull": "+0.00σ", "z": "~0.5"},
+    {"probe": "KiDS Legacy", "sigma8": 0.748, "error": 0.022, "efc_pull": "+2.6σ", "z": "~0.5"},
+    {"probe": "DES Y3", "sigma8": 0.765, "error": 0.023, "efc_pull": "+1.7σ", "z": "~0.5"},
+    {"probe": "EFC prediction", "sigma8": 0.805}
+  ],
+  "falsification_criteria": [
+    {"id": "F1", "observation": "Large μ − 1 at z > 2 where Ωₘ ≈ 1", "implication": "Coupling not epoch-governed", "type": "Hard kill"},
+    {"id": "F2", "observation": "Growth enhancement at z < 1", "implication": "Background channel wrong", "type": "Hard kill"},
+    {"id": "F3", "observation": "Poisson μ > 1 detected at α_L2 level", "implication": "Architecture violated", "type": "Hard kill"},
+    {"id": "F4", "observation": "BAO–growth β split > 3σ", "implication": "Single-channel fails", "type": "Hard kill"},
+    {"id": "F5", "observation": "CMB lensing σ₈ > 3σ from EFC", "implication": "Background inconsistent", "type": "Hard kill"}
+  ],
+  "falsification_status": {
+    "triggered": [],
+    "tightest_constraint": "F5 (CMB lensing at −0.71σ)"
+  },
+  "key_conclusions": [
+    "Poisson-equation coupling (μ > 1) is excluded by BOSS RSD",
+    "EFC enters through the Friedmann equation, not Poisson",
+    "β = 0.08 shows mild preference in combined BAO + RSD (Δχ² = −3.89, ~2σ)",
+    "Independently consistent with CMB lensing and SN Ia",
+    "Four channels, one parameter, zero kills",
+    "Regime passes at z = 3 and z = 1100 are automatic consequences of T(a) → 0"
+  ],
+  "architectural_constraint": "EFC behaves as a dynamical dark-energy-like background effect, not as classical modified gravity in the Poisson term",
+  "files": {
+    "paper": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling.pdf",
+    "schema": "schema.json",
+    "citations": "citations.bib"
+  }
+}

--- a/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/schema.json
+++ b/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://efc-project.org/papers/four-channel-consistency-test/schema.json",
+  "title": "Four-Channel Consistency Test for EFC Background Coupling",
+  "description": "Schema for one-parameter four-channel consistency test of EFC background coupling β·T(a)",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "const": "efc-four-channel-consistency-test"
+    },
+    "modified_friedmann": {
+      "type": "object",
+      "properties": {
+        "beta": {
+          "type": "number",
+          "description": "Dimensionless background coupling amplitude",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "T_a": {
+          "type": "string",
+          "description": "Transition function T(a) from normalised distance-coupling kernel"
+        }
+      },
+      "required": ["beta"]
+    },
+    "channel_results": {
+      "type": "object",
+      "properties": {
+        "bao_distances": {
+          "type": "object",
+          "properties": {
+            "chi2": {"type": "number"},
+            "delta_chi2": {"type": "number"},
+            "status": {"enum": ["PASS", "FAIL"]}
+          }
+        },
+        "growth_rate": {
+          "type": "object",
+          "properties": {
+            "chi2": {"type": "number"},
+            "delta_chi2": {"type": "number"},
+            "status": {"enum": ["PASS", "FAIL"]}
+          }
+        },
+        "cmb_lensing": {
+          "type": "object",
+          "properties": {
+            "pull": {"type": "string"},
+            "status": {"enum": ["PASS", "FAIL"]}
+          }
+        },
+        "sn_ia": {
+          "type": "object",
+          "properties": {
+            "max_delta_mu": {"type": "number"},
+            "status": {"enum": ["PASS", "FAIL"]}
+          }
+        }
+      },
+      "required": ["bao_distances", "growth_rate", "cmb_lensing", "sn_ia"]
+    },
+    "channel_comparison": {
+      "type": "object",
+      "properties": {
+        "poisson": {
+          "type": "object",
+          "properties": {
+            "alpha": {"type": "number"},
+            "chi2_rsd": {"type": "number"},
+            "status": {"enum": ["Excluded", "Favoured", "Baseline"]}
+          }
+        },
+        "background": {
+          "type": "object",
+          "properties": {
+            "beta": {"type": "number"},
+            "chi2_rsd": {"type": "number"},
+            "status": {"enum": ["Excluded", "Favoured", "Baseline"]}
+          }
+        }
+      },
+      "description": "Comparison of Poisson vs background coupling channels"
+    },
+    "regime_consistency": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "z": {"type": ["number", "string"]},
+          "T_z": {"type": ["number", "string"]},
+          "mu_minus_1": {"type": ["number", "string"]},
+          "margin": {"type": "string"}
+        }
+      },
+      "description": "Automatic regime recovery from T(a) → 0 when Ωₘ → 1"
+    },
+    "falsification_criteria": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string", "pattern": "^F[1-5]$"},
+          "observation": {"type": "string"},
+          "implication": {"type": "string"},
+          "type": {"enum": ["Hard kill", "Soft constraint"]}
+        },
+        "required": ["id", "observation", "type"]
+      },
+      "minItems": 5,
+      "maxItems": 5
+    },
+    "sigma8_landscape": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "probe": {"type": "string"},
+          "sigma8": {"type": "number"},
+          "error": {"type": "number"},
+          "efc_pull": {"type": "string"}
+        },
+        "required": ["probe", "sigma8"]
+      }
+    }
+  },
+  "required": ["id", "modified_friedmann", "channel_results", "falsification_criteria"]
+}


### PR DESCRIPTION
Adds AI-optimized metadata for EFC background coupling test:
- Modified Friedmann equation: H²(a) = H₀²[Ωₘa⁻³ + Ω_Λ(1 + β·T(a))]
- Parameter β = 0.08, single transition function T(a)
- Four channels tested: BAO, RSD, CMB lensing, SN Ia
- Combined BAO+RSD: Δχ² = −3.89 (~2σ preference)
- Poisson channel excluded, background channel favoured
- Five falsification criteria (F1-F5), none triggered

https://claude.ai/code/session_01RNKSig9vLiuRDZMEJGHT1o