### PR TITLE
Add EFC vs Stage-III State Assessment with SOTA metadata

### DIFF
--- a/docs/papers/efc/efc_state_vs_stageIII/efc_state_vs_stageIII.pdf
+++ b/docs/papers/efc/efc_state_vs_stageIII/efc_state_vs_stageIII.pdf
@@ -1,0 +1,212 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R /F4 5 0 R /F5 6 0 R /F6 12 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Symbol /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+13 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+14 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/PageMode /UseNone /Pages 17 0 R /Type /Catalog
+>>
+endobj
+16 0 obj
+<<
+/Author (Morten Magnusson) /CreationDate (D:20260210124647+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260210124647+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (SCE Validation Update for Energy-Flow Cosmology) /Title (EFC vs Stage-III Cosmology: State Assessment) /Trapped /False
+>>
+endobj
+17 0 obj
+<<
+/Count 7 /Kids [ 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 13 0 R 14 0 R ] /Type /Pages
+>>
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2377
+>>
+stream
+Gatm<?!$&G&q/qEeC1#]/iK$VYOjjP!$U_&$u@^F42#\^r?,o&n_i%;a[o7if5HrA3"@4l)//jX&@-EH<Sa[<)*%E1b4!^Zi+`Z:2[gOYnJ%@+].gsQiV;d61HY(nT*JbNIEjtQjFW4R^r*q4R-h`P/;(aC6f2N/"<k*=0,1VjO5hEZ^GV=okcEVfTO#EH'AJ<-^Rig]<b#p2oj$5`b_,EeH?XCqXc1@XR.Ro+rQ-FSE.iH6ouguUNpSp%Ha2ehdq!(Q;C`^63hGLpT4%R9N;lZM[J')0DKG4fmVsmm$<ZTp4(KD4!-TbQNgto%aBd3o8K::ZfB]dXfF<rC5G=e\5CY&M?V;(b:.u5tAceP0F'.=4Yl>+PdHAj*F20(W(H3=98:#>PEqb;I"'?KZ'hHdLo&U5fEjNj9I(!l(rojOqk'\'V"AgMV1e&@h:g)1SGGkIq9[4^9.q-WE';K1Vi49cDXq:BOalDpgDsZcpX=]@rj$2>hg#mEZ=C?K@15l:dX.37,UK:<tdPAejR4GDF8AT6se!2Hs%"4P_n?YfP\GGm5bF#Z,jr/uBd^-&uPNJA5_*X;N0ipGjHhY'"XKfnV4oA$r-gR(Ia_#LM/"9'^e_@"\]=oj8dKdua7>t)m5WX#ZjiOuZ%_^%c1!fOUE[-a?SC)u$>SelB`o\:l#k9Mif;RL5(mJ2TLKi!e!.[0""+[B:q>MBjfdT<an1I*n.o!;=&s_ilg>/Ze<>Ba^V+MX`q=HR#YOB15fm(,VH!#7t6Rf0)4j+Ga7GAh?a9rj2<N`f5/USP"BSo.@WC1An[9TY)Y+Ic5a(k;hr1hdT[8jIe03I#q":[J.L4-(_;m>c'JR3R\h'iT2U,I!<[77T?792&tr18D.7k739V?8nEHl'EL,XOaL%qmZ$Y'pC&K,l(Zrp.\WoC`dg>$^k$A<o_q2<u<U+PJaB>5Z=Aq";i.?Icd5X3p_$E\MrH%M>;VZ:lrUS(l"$ZPAEXFnm0=bM@!s]7K"WpahC]:J;E?YgiJ0_4UqaC(-i6Iaf,_E[i:]C<V>l$gbn,Ogei`&2`/11RHQd4ksk.NjI\17C;lF.Ss;M+KZhmi),gkR&[Xm0tA@AXd[@f[eZeaft7;bJ5#?O\1G,RrN5q+`$Rb-+S3Hk9&^m9U2'MmdGPRr)tl!o#gP()2G#WYler+0V^mC6!KgJf`Fb]8$YTRXm0E61\O;e'$@\)i>&P?*;ZACQJ*%euKS<+0%=jU0[2/#9[s2<Pb2Qs3"-`HuP;eRPKUJK#8'pM':ug5FUlNbu\9JaNJkG;b;&VE*3`3(/lM.FV$ZigR4USf;;T^`(]<[T9W\c=:1S&H'$j4;H*\I(u(/<=_V8gM="!Pgmh)dS&UrE5&?\J]<&Ehh6rb.O&Q^VCt[*26BjmjrlAgjBNF\iuc:'mGh-\VSlVj,U#"j&B?PdE2k\tV'$e0Q=2f-Nmj@\/?)8&kr,1*JFM<\2B093!6+Y3g7lDj5)HSYPVQ1sYD])]$`8&>K9D^W<0472iI^3&(S'?R5nJ*PfI4l1tH#7tT.:_oeuQs8,E#LaGF>:3p9L<,Ru@j\+ls4BAErX///!csgUp=@`j#K2":A(st-`bqnFB=A=uQ]eBbrA=1Nh,h#.FU::S&#+/QTa^WU6<1S?]1,iV.fj!,\dDH<OL<Jdo\4h3EkC6/hfi5'3;+==uH$JPOrG%bKU.<g]4<AhK"NP[>&#=LCUuFaVJ`*9ns5Olt0#*\W+mI&`(o8abb*%#[gI.mC3POn.M!sWphXNHN4:oQdi!n0*Wa$11X9c:/T&`mL*llj!QV!rQ$HFS0O;*Dp_Q-1&k,X*X<ESiT!ZD#macC]$*=A![ZKYr5l4kjL5Oa*[Pr<h9EU]8p?$/nLPG%ZFg1!,Z2a*>5H`2.gpi(V$eBIVZon=D+b24aK+2BKhPYY3mC-oC5YE9FW@BHu8)Et)h1k;t;Y_\N.T.2%?d[*n[UZeX3\]T%me;G@.Rp?e,XXlf&G*P)(dStM*9MSJ5AiJgB_T9'XV:K^SFuXM$I(_l[DX7<#JZY>Zhfq@03;X*P-'#EG&&Xmq_sfmCiM_AOVlj1(?G*l#mrH:7@K.kT%UH]9lLgK6WNmP+'H'Jqbm&=l*F+Pg\)#MVH?6n@jVh#YT"SM,GNdm+[5cYWqSrsGrR$<f-pErNp^Uf1V3)_MJA7^p%CN9Q)m8]L`6Q38eE6C-,Xr00VA?UO=<qZKFc,EM+ujSKr2[Zp+pgpKR/[sM_oWEL%Z6o'i=^uoCb;D0\:8J0JG/g]X1\1Ts6AeF[?nJ;0*9a@?36nsKAleRhZ^S1Hn9BS1\?4j=jVbLHa7(+^.J4eE;5c*j4&XipgDDQ?&;XdY?JjT/tpUb_qG%jMu>e(~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3337
+>>
+stream
+GatlRflGh:nss.8O&RYsR),o,g8^.6A<iE#8#50]R=9\%&NMQU)?;58&,YbK4W&^""GgUJnc@%dfCV379`2fXs%rjeis[Ph@_atI*e;pu%C99KSrLIC%+"TPmXa="S2pB+(:-+2mX?33_h#j*$D(u,Y01YNHtN/6Da=F77j)EjRYtT8dV(b[i\sC:(TP7GP'/NR>6EH]%F\brbRtc-$('nR.'aQL@r?=2IKjkRjLtQcjq=%q\>F1O,_>J.Qc1GuKn7aBNoQL>0`)Mq57kOE%`dW7kAD*V]5T3L[gj6=F&33Opm/g[-Xt0[2TYrek_R%)E*<mQVapg&TgTk!gfeO&(/^<T%-DQM%`#=@f-]`D,argciONK0>JB(K((K8cD4:_gR>1k`_5MWk=>k6p@g"o/#2E+SlB,qnNc.8eL?#f_55pR3l4]489`/`cLJ.abND(IVArTi@BGP`+Zl2+*J1T0Al?Y+4icn<mca[#+eqN%PY:h%PENCeepFqnkY`sCu[plTV3F&In^2)P$^K`@kO_at$dq^jhBiBT$)bLp6da<q_RX"mcR4N;[lg($@^l^Vos*d$QSXc'p_TYZ?.K\k=?_*`I#0.ehN;[@fL23f7\.-nU&VY!$='<*Lq,4#N!1\`.T<@*IXKt6V+Cr(MYi!Wrle+Z'0dUC`frjZ$2*:q=**9cW'r.r!RI7C70fmM>'!L7lF2=jiA!iQq3g6&&)gIHY(rKsFf-UhqZE8Xt-/_XRT-pm7$`(P"%oR3la"su[Y';d2/XuXA&@"n4Jpe(!`Ap>e0O5;:!hEu/3#Ud<%X/)tPb_O,dj/plPADCOBSkJ'6Ja:]mZf^i>]_9*7&LAs.76^l4HoSWQ"QTJ.bg3N-aU!(X_P/=BKYH!n*Y+[L5luHqi<&"LB`[K"#S6B"%7MrSqs1<*Z(\^c-HgnJBF==Y_4"`/MG(pglN7^aZXCr!e8r9ASG$(ThNW2_C3RtL!mkt<:PehM/nk5Z8c(V+F?qb)G,MuU4qq@=e%jJPn5.0'K8.q8>>36GubUm_L_p39qi2nh/!F#kLj;XQ,i*``Em_<0&nO;*EKtY0&*2ENS6-\ao9oh6KDA4U`74l(p,n%TLYBA>n.Lkn>7b4")Q$HcncXLl(#Z,Em_:hs+Lc6U0KrFeu1aeDsag>hI?[&cRggPc"U!_d&-rSmna6CV@9B?`I0DUe\TX7;J"0aUPH/KWo07WpAurc($\S4R#,;Fr8uLUFX[]cq?-VCDKtl(s4[s1GQ1_3=bc=RH]%70K?,KB[F:uhondMR-!#.Dp)j*VMG\j@7_=+IE3#rp')b.]'o@mB=G\`(T,j#N7UT,;G@53=i0A#Dbe7]f:Q'eoUi@jN=ZjLQ+>(">)d5A)(O"16><)jiPSb8J^t/uWb&R[Si\6?U+1bNJd0GX&WtGOrW7\%hDJ+cprF(]R,Ps<>B5$>4j58<9pocQ^al?RkYHOi_P6eM1qcmiS3Zij@T,kLON<:idFO5YMZ:;<I5l()HpF=-I9p-#5CkiEmT@%bTd_ui_e!HG:A>Ja#Xg7U<o8eTU?c$oS%k)^EX@CaR&,=3N-&l5/+k"aG526Y8ZqW,iZFO$bo2j#T+X(XjA46SOf/jr@A41$KU(K-OO:aWePa#IN0;$WKL%ug2Hc[;J0V)jBIGb`Q9IJ\f7WuZ)Z(OGUk"!cio:S6(*`+45LV-tj?Q2JU`]!Sm2\L4\4f69jOR&kOHcU50k1O7T3oi>R^Ed"_#g#uYnI,?no8%_,atAj*\>CDan>X:[=ti%eAntmlb5`[-:>/?#XHtUEBs$<l?GOLS[=G#u!V;0!!fj:7^r?3E!_6,8%/*XScVaF)bOt?&.X0]@^pMl*lLj%h&l7<UEoLfB9(PfSA4%)V(oq_%Vt'rp<iRe3Ieoo+L_>tG*S96*SIH\.:R15uRZb_mQPrUu!d(FR%:0i=;4M&596pI&FK3LO>[Xjs,qS0FVnjk)@^B%!'8oO1q(%CQ&JgZD.PdWB^aHOSe"&]=ml$+`!`j!/YSQJtjYXt]O\75ZW`G!07`<n4.\R:>Z$[>:<]QnYY^Fd$"r\j_G>=)>0E]H-:G$_,9d,<PFb.l]h4"Q5T.RYKodVJuaZ$0I!b.!=CqFU$c,VT!if,G4<!ko3KEY]Q#'6X]B.%r9>#3L4Fm:l\h[Xb-5#u[m*+Y%5-</M01>0SQ'@q,U>'sW9LG6)K6<XpN@Sj2.FcL*U)=J\!b?WnB.%NYHX$LrF8'LGE4GucLD32^Hktgem;uf[q87P_'4m(bI7M9'iMFS?lQ3L3+b]TZ3YeEmNGUEj/fO+l][=>^MgLGI&ak3T+=eTIKoQ0/?cmfne*b6_rL/]^6\WioMgS4BUo5;:uL@_L;;*dE.7[W!-/*ns.OIp6Q#[Q_h,:Z;'a1='X+"cn)$0-8.TU)6WP3>QLQ/tc?V.sS(<\+A6"H)!t+H1_=CO@5d].B5p72lYMe3Y1n3*`;e<,\#\/*c[qldHH?^tALS7=eK5FHA03$"CYL'WC#Gbe.fNh^Yt5;fh%>d1jY$_lJ!$ai1H=WBuX=KR?7Y*&F(I]E+F"PM;%S9th@_\45=qNVsg1T<V6d(``kWn$#(5-k`?SLc,XIh$s`E[okC244Im,DjVO.L@hrO3cP+J_o/Y!=HXA@Mc12uji)dZg)b0-eBJV@.h<ntJVcsSm5@J3AQWj(V;gBIJ5c^3e,&:B^CbE,7\;EMhP?'Y>$JE,$2k&-=b]h`LTQ"\<2i#cH>!oVde?I<7Op=8W-[Z(0*9Dq6("``=`,"1A?TE99/PBL7`&+58t`3<Sh`+hj^^RSI/XT2_L\^[=*3Y[f@6BT^pbp8hkAYbKh;eb\4e]#kYXG?(c\X;.Gm7e4h6FM0Apa/UiG;>,DjQfL?54(YaOd]+T/'0#,'Rj=4;mBlI#"$X+L<A*P$(3GB1iY?mV-ipiaa$Wh]#]p$1!Ls2<%i+gn@'*$/272&ccM],%(.<k^;P=-?MT=ZtE4ikAEL7ho_1TO&]kd$S[a*2OKbh^_=4%<KZr[mIh:*0Cjhe*X=l0KZ4?ApO?^UE<PHf*XJ^g?cW9oKF5hVQEIJ5AEF6]Yoh;?ba4b^A?IJqXqS>W7TO7%n-o6XXr>'M[H0.QE>=1ptLh81Z*M96`0M)'7]iYk',[2l[k6?Qk%<\$V3[Qg[rRC3C?-5?`e1k[k7M-1LWmJs*QGqX7pg^f5G<>,/OjD>1!SGq.?al`gmh66G7(jXrQ03k85Y>,eX6*h-edH,9<pjD=f<7<,ZkQ<,-HhI<;JrYiGSfrZ=MkVZXHp!-=3=0MracZLg^3@M+mOK*+7/qcNi+MG"iRo,'n7"/GkuFH*$U~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1041
+>>
+stream
+Gatn%?#S^^'Sc)P($@>X'fU;F-WJfb=urb3Fu1:Pn$m@iPBnQq1:CnpoBYR!:]q/>6)m0e)<[Oa4QjUYM"*q2c_:HMS\`j0!bF&9JYj]Hffa_M%=S^V-??pX+FM*Ua-@r-aV+CFpOEkd0*;;Z9QD:i$<^+qcLV/Wi!bU`UTM3J*X6C==n%SmS.G_%\#mLR]%4;Eb>T$$Pf'SRkbG6'd^drE4CU#Yo*^pAP]uk9H4;\X,0nZ<Ajf6s\L2)+6+&H14MH@!2jjOUr,)8f0dDX6>p#\MV'+H;JE2q>"X&*-)9*?lb#oW"?k>C*`7iKPJ[_`]i!U1R`$aEGEP=b=2#-[.3[u6q]r$mYqjq(72G,)KVB\BXUfj99\G"&n,)"#ef<rUIJn3<30YSNHTB7*eLC^W:Q9IW(R`,Qm5O34X@Ru.>WsODU?W0N%+M'#7`nY:3)L$U]1n#C1e(\5th0:r_%3eDjIt;$X2M/,IBU8qSgW>K&LY]l6h0JYkne[TsWP&C:8SsuQJ+VR7n6T,#G_LkD&hEP^POKrS;n'_i[=Dn6NYj1H;Y(7tj0n3Ve.4cj<ud6R$$HV6e+"a>:<2Gq;^"W`];:,HV.*W"'tJ3CgHMZ-)%W:D:-3q.h4/J)fLD^];B#f)B3._NI;<2`G`p(F)DgRq=k?#BaBF/dG$4U:%BrV.oeu<r!EAW]TSg1\A`qRrUs<uT,-`jD?#(OiWM$S4=DB'r5`kiib.dc/X2FqWmtEiWV`6j\cfLS_nbfl6Q;rIWL/)2,JMuAnMe,,N*;C;N.Vi%/Gjor0%&_Q'Ji(fr@f7#+'`EkJWh3m9#/Ks7R)n"G;AUjjKuMGS[=ek,+s)6HKj#?1;K4CImSFPn)k-F!"GUX#D&bt>m_QEjKYQ*Ij@Nt$]P8D\0H&1iY+^uddKWDB!a\r(-lO.n*a;?K-;<aA>?t7OWl5q9kf?jH*cr0]N1Qa1[*E:R]2bTX9B=?,YuP;W<F(o-l]Ho/Kc"Q(rPVQgl+AKMl^s'Cl+8J\Xp[Ti.JPHr#IY]b%"8<6G[`3~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3019
+>>
+stream
+Gau0DflGig'n,7HgdcZ7_E_V-Vrkg2U;U"(=@u;a/3btB-J8tH%N:S+H-!JXgdVAkBQ56.'&-tK7!IPMgiJg4I/FH?s*7'*lC+<Z$RcR.]quqC,.`5!Dm*fgc+GmT&s8=n01?H4.`*<%6i-H<=l@8@5H?7+]dua,LsdjDZ8`5kU0(e:IsL[hUoTnF-KS13nIR@Ira3:r0*3NU\8<42IMg"F?.&R_\Z,>C1c=+5KeJUYB65@@hO>%B0.?>'`6Y1@e^@[fNS2HTH'$U<j4JiNfDhZ4+8ELD1La^966t#950AkZk\,O6"Ym)D?5CN^3jD#>LtDo.@Uar-m;lfhi>!<i(Kbe/0,_tL3>:N)=`_J;odn%mC)2Mk(IoW5Pd;e/4lHVp*[5E1hZmI)"j,^@)pcM/&_^7&;rf6E(=BXO^q*s(gugJ?.;*Noh#$+UT/Xr+54Os<E3-\@>@;6TSZRBlb5A_mn+1`)Nj:VX%KK!/_7RoOU$YDCcM]/8Whh52G8cKke&lfWjIO>.)MY"]+90,P`t*^k^^l`&5_j.;LJ)W=8Ef,;M"Eat4\#lq0o)F\gNThmf@4XPI;DTd\5p"GM;QLf0KGB58's`q7n$(:^)%hYM\>pg&l,T.d@u8,0j>30EHnd"n!]R97^6JcCIh`TD,]eJCZ<B$RiF0%:StV+pB2Z<n4:WWO]'#I!;5S3N?Q2&"^s%l#QKs@o7A5[rT("p]:o$JQ)hKkWt&RJ\@fJMrN;6Q1:3<jMTf,)4&o+6=,TgTGgj(IA`'N,VJYb5/`f]dG7nX/XM's;6*8#u)U#aIP\eNu5s_-^'4)Y*6(7<Ar*IM"7EM.%2cs_dAS4-:L/6F4Q6lK(^U^*5C*W<TS7F+?0?b2YP/OO77N3o42(d+fZA2Q!o.7.!+uY(IGrGY2Xl8$$oFq&E1gmaVq48ZRceVZ2s4(Mqq-pp]I#g]?\9W6PdEP=:3/AcZ)B2/8NidZ3@Ao6`XRfYZSV=06V;[gUc']6E<-P@<cbUEY?:+,."O3D7EqPn#_0-.^_qr&>\m2>4Ja`/M%k1[!GgWP.H?:?Pi'hVu4.0ZZ=08i3IF+uF^=05Klm`S"Ct\.Vc75pD7KPmA(B<8NmHs*u$.i3.>sm6H%Zc`,[BVA?hp4b2pY]O+HliJX#6B>M*=rL(jM]C(MoDc;!<\<b"[<^$I"8uD<j23:70j-(mFp\4pUb:k23l$sq;Z@\pjrs"LZbC]`7llBV;"W?">g%cf<)%iBkoCrXmWGWOHH"[:^\Z4lu?d^ih#8EBF4!Xhom\(>C[A>\l7uce[_EK!O:-KB:Z)<!el9&KqXdUDo!fJW0p#P>*V=87\Jti('.qsGk+btb+i;]hNA]kV-<42UC$F]66qGp1_$N(O10$#]98$5Aq%bKX)juT;"6>p43Ka>`j`qUdrBYFh]":J``M`aR(Im']$>H73a*G0]<uB=&n#?t!knk>>0ncR[9$;U"dqo7[2ah%Hl2QD6Mi^)n@*ER_U:J`#k//Z+2ZVkVt=,Qge1"GPM]iqeH<L2q11>;-Q-N]P%NSVKK5_e56Em3<kY!uWt/95o]B'p&AsO&OL<hT-TBJmCS0[:Zo\-"gq?)Qlb5R04W2fT+`/IDRElN/!Qe9$-"5l/F'^_X?L-CP`.a1-7#KtHkr>G]I;1XML2$EM;UoY83JT;^.'U`_@I(A$\0)2A='$P,2s$WTk/*"8_nQ]SJ1OJI*@@3D;_-Ba6!jB(L<rHpNkHQK.7"VHBiE,+hspeJK//$If:>e#qLZMX.&`6QA3jT*@m@8+YB>aAY\B"/.[[h'790]mDI7p\\%5Q*Ae\eb6<%Af?1^cC%eWO^Kt>aaP&)/\P#d_R:'I#e9(`=)NPtBmfbS4\>CAa4*cA[PaqoL_Wp?=sKnYAA.jPh8@h9)[H4IMfB7fG]IXCTHJtbT3E_+8UbqMG^WqMJ#"%9s"E,Da04:7'[&Tp'G*D=hY8NRfQp1dskIWM[#i'9>7gZqc;Y)3V-DQ&F<1*6S;$o)k=<Am-<a9K1RZFjuN+H&SXa.P])$HOHGg8VZ6?708#7^3?'FfSIB6b&EaW.QCHkN&Rf[77nriSVK\qiXTZi]=i;V)uc@#.,UO<S=,XX+><ITtj)X8'A\J,CL':GUHpk+q+-FZV@MOi3lNW(j<4h,/j.j^c(\=kaaee]ON=hZOD!m#"Wse;PTOpgR%VSea0n&&(@Cl<\PjV_RFga&?(V%]Vi/S@<*>kk9FOVFcl"D:,G\l@RjkTZdm5]#8aUJ%m@k@@r$4@IY8rj`kUb@&eSLjSg2Z;H@t[*CL3Mtb9`@1';A0a+H(Q\WqoK":!JO\B\B)0^S"N0&S`i&2cMoh'$V"n:e>0nMVG8.^0q'kesZW\:&[^OQ3>(tNcRH*,WEM\/C841#(Kh6O*-[3G&p?BQ7^A^mJRoq]mfQ/i;<Qn53DA;B29E$&jD>*!We'r3hk^*&&Mu]UK#1ZP.].I,9@B7Il*Np]"(5]8(-&(r8"g/oWDmhA3';c;1n4[7.S*[6bnb_m5_Euoe4Z!XS*W*^>"6#X93`9@:&kUl,8^T]VVs[1@`gE_DM\1T=7`TFOYJM-Bb./RE3CQ))C2^Cc4E1Z.\W.EoU"<4f;Uo#A:qD.;-us%/Z:\dIs`5!EaMhq\Y-/4l=9X\&-G<E#Ajoi@mj0)RrYu+3\5KS&\tG6'^7enbTfV_1&>H''E*M*-lQfKbcW,cCYSL@UNop"ejVQ:a$]\h_@,ShCp0[\fhoa]GnmNrI!bHA?%E1:GVc\^qos(B]N-iTel[O=uRM=*l#/=`K<Kq-p83WLcMXm6+LT<d\)QJMoXrq`cYU_S1O;6o*1`\HJ@e0!'SK<^WQDUI@))5Qbcp]*bsuZ.B@/Ep-,Og3NIHqB,;SrE*o_gG5!.%omQFBI+6jF69h"kqSpcSb$]mr7X##W?]Wl#,JM^2<4"FtZYfEtfKdY^>X:sY9kiEo)ieXehKM2>6N>+l`qj[,9/F!s>Ucu5jA7MuCT]u_W]9,+?Y2.l&)pgPG5~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2567
+>>
+stream
+Gatm=>Bei3&Ur?8R("R"L^*>/T!Jr14&4VOS#iHp07&1@8E,@?Pp#HT^V2KH8<G>Mb,s\L14[2K0UH]i+;5UkR-O]""8I!@=19ND(2S/%3eda+cgYq\pt*CP]tgt%0\k#1?2V'Ge+RX'pp;^a(S2F'prj"+cZHr59I"KY)_u@aAAZ4?>RKeN5/sL!K'j2fKB@*_-ONeqf!0?<KA!+0RgbVWI%T"g(--2t(:1[@44m^bhT_D!T>>&m`rbER$]SGtQNph("/TS3l`t`=q#`N>d<WD]>\4k>jUKQ2b4btmh?G2Y?.8omJaHWc-b<,^3MZbi`'=Ktk0qdE4%0MO*AuR,cYM(nBGEth_QZ@=L3SrbrW'7n"32b=j9lq$AIHNg%+hauO=hN.)&>#V*&u#/c'sITR,2P9N#1<cZIQ+$j;=I-37+q8E*pd1IubB1,@+uSpcIe"0k(nM(_B?k*ihM=(4Bt<=R:LR/(7:(hQ'ig%Aj!HdLOV[#gNV-#\A]@P]?_PN-Q^Ypiq,p?ON9$8WbCr*nGJ"na`MhWH%mjG,O5;!qc8R!'T32*1ro2IeXn/-gI2^Ut^Rf1,`EMH&[FDMt.%OP37h#57cfo'u11Z_sRXESmj+G1i<*eN9@arH.,[.o!U*Tk#@3r7D:$Ag)na8PW>q1-NR?^M\N/nY<`$_R.;Mh^nDAhFcdoRF+Mu84!h>7XCrMIaSZTLoDH0=Cl6icTCFBl#RRfrH-FGKU-`H\>3oSr=*I4b.k&PBP^r(=/4H's'p=KRaQ$:,,-/#0Wk.8*HZ)AO04XO:E&+3$:ab[&-fY?<f2LE'j_X7_'`#I(84[dB`A=<758j!d\A[P]2JtX/NlL0!F.)X^g7#_dg0jV>`5ePhodp"Bb[A9^QEB7pj1@e&jVY,B15<q`.ht>_QGJZEWC\C-^td4jcm>8O\L2Vfd,FJa</73NTW/<=/l4'>?>\P"j$-jPWV'1m4BDcLoar3G;K)\`,lFKfHqX_18p'/_V8K5[9+bShM!2YG6tYn]SVe*WTX]G0Ifmo3DgR*i\`gjQm-;4qH*^e*a8EV(:uMO@BaU]h-Q-)r]?CXB2C>t*B&@o=R=D?&Zs$m?Bs\u_J6d^c&b/i%@W<*-/FlCVMTDEQZH+gApK#4MLJ!mL#k,JK&^C`59DF<pY=P2s+VSq[Ni+Yc-'?&"Lroju'E0'D6<P\hmtpB4@@cmM^:?.K.t"rmTMH]IM>mn?>gmt&J9qiI*MFsh!Y\D*`uSbq=EhQ$)<C!$Mb[S!KZ\)NZG9kn.)S<%M(,3HQ^9\G'>AIjNah@$*01D=E_O?\&@'1+>s7^7M&X_/4]N12e@KgMjAMdF/hVqb-[=ZZ^9:Cq=C`8dLdRFEB)[74A&j,^_)d1PQ(T4n)Bgr@Y3KLrA8PAWi""T_a7NQ2]+mpi.A.8YW"sjCdC4O,e-J>CR+8_:5*$WNqW<6\:mO5,6=PUV=X@clb"H-XEW,J_5[D;I_8+sH$YD)LR"Y`0mm87\N@7H$/*b[QrW/bSgNV,>?t/eC@u1_^47K@.h3KO"Z$GoE)e*sr.r9CU48RclU@D?H`jR^`&Q6Z**(,/5d'jQI]3SGk[VNYrja'("Ch;f)ip8Z<h4b(q!9ScTBKf`_<%Zf.NA03iLVD_'oRi0g]_)tOj."7()s,p'o&H;USKAAQ,<qd]C^#jXLT]HiF$l4`/F"u'rAO\WP>VCO;i9Tcf'?am0J3p"gR]VH2q?`%]DVC%qZ-+UeYs)TQrdj=Hs,i0*[d/LS@7\"Y[sh5IYe44QV$b9l^[\5K=4F)H=#l_DX(OU]<q=4,>96KkG\&&2]pXqE:[I5l<(gaI&;:LT^a9T.@C7/Ac.__$u;XQgAs<#IF;lJr^Sn1ji[Sh$(Cat>K\tGa\D&*e)GZGI6nl#0sp;IBP>Q;$->tTHBmR+J2tYGM]f6cIsF4c+ZX1$D4/E#&>_6aWH-SZqOE?;0puuh*tYcJ&/j!Y`Y>t%.<7#WYf.P[GK9\_&_N[ArE'_aF#MJ0r)WI%MjZa)PVu^?3A]kT`5@r7h<"h;H%oS1Di?TN:Y/Q6GO'`fP>Ol]U,u.chdMD2B?)j.l?GYR:5t_<293>*l)=fXg")\aUUt06mX@#3W8k77R^%V`GMPGUTi,K%XEQ('_brA/TRa.]q(pd4)S]a.'RdUiE4qYB\gIG_2r5&B&Sjm#kpX8pMu@M)]Y>^R29bNI(`Q1#q4$.t(JedAq^+!%1uU]nF!9$]KjIJSlf]Ic"5\;5@`!RbbQ1U__YWS1AUj!-;Vh.Mr:e58h]+IQAp,ZG9`86gXq'bLYe`0^&b\aB(f?RP?h-t9W"eVPiNQV)$FI9oUNQ[=bh`D]g''#THODfJ(.+n#9i?(cPCR9')r5g!33?E!h^G#G]0X(.qc&bg3R7FI`A7D`&(lWs\_%M,rr!`Sq_k"VPKs<ui)r=[4;)OAq=.0Me`1'rQVd%!pE'aHG"n*"]bf#t<*!B=h]ib2U0\\*2fdHhdd'KZfa_B!A[9@ZWl?_ir7!YX=<1K&Ls8"E]Z>ma*'G@j.qr99eI0&0@7slgkC%"k1Vi!7bjNu8~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3362
+>>
+stream
+Gatm=gN)%.&q/A5oV7q](u@ipC:5U%a'%"RRnToceCJ:S+;0hKo:k^u`V]=T!0@m@MiR1qZHJCZT[B+Th5=\>9`/#XDj1n52P[b5(0NQ?Q=RO\9=%iK59#"m)1`n+G!Ld@[4Mom[UV=K6XN$9/An7=.&4R76Jo7W$:;oA^!NI;4<$W2C%#1kGGF;f5b8U3LDW5>hdRm5=H.3h=O/iua7<o0deG%kAT_/<)9p41C&@KXRbL[-lI3u]=f1/IU&-a=)G@=bf<!m7Zo("m1XBb.NFm+iH+c!rdl)$s5<Rs^>B04\)iW/7hutl&a0T3<1ao_:klVcBhu^ZUe+5j%835Z>GdOg'Dr'P6/rJ)>iQ.3&1+XDuE#8VgD0s\gfuV"DFQ>KViOP!HOGmGr1i1VJnA0eqp"V;BfCJ[.+aDLbYT:-PrT"m2(V8+QZ*CKtO8%$m]d0@B-Jk6J-;t807OC]hAp\@c,+ep@U\/<r"t%M8*T"9W2?K^oAiB_R"U*/g-4!%/Xq'mUja6i/jAd8_E$C>mU#Q)(YD\>cPCg.9@=Hc8fP*9+:?Ucg$d>8J!8q(Y2>&QT^P8UA[?!Q[1C]$VD3fQ&'1a$"^8m,PWp50^FIB=X_6\sHq^kHUVC^q)>36!:jm7G:bHk)W.kFITX:To-H!o/o[IFL#C"5Dsc-ja;L?5reJiDGHV%gXDM)^dS)OBgrVZ5kf=OHp0RV*=KD4oL\?s?JWm9ru%k'8+pM)VN11loWH!DDuh[6CKVRrV9.D8Drn4Kl)Ypl>m%(O:0V\'s2&Xdu?=&XKtNT[Y!SFPV<Q9Ha(r"\\YD0CJ(#mk60cpKA956IFYHpnlgH2sSU]O[m&`I`C+oc^5E<0+TlVa1Msf*n0kPAX03%VL]QrgME#XL_6K=XM\-$9(#GDYVDX8PVcD,$rp7SY&o"^j08DMH/DR3$(A_oMAO3'i#t\_?"lDGp@`SVp./d5Gt5p/rctS`f`R7q&dI5E7ALo?W8)0\_6\K4ON<[F"m;,kXX,QpB=K?<jr9o2.VK*R_?mCgZA\8j!paqQO!lZ1DPe3SVp.W'EQl.fcbT2.$3Fsod(!ZbBqe9\%*]VCqm7bsYuSN*r!P/^:7kp<P-7]%0'JA048=l:?r7*K/;lWeQrT)gU0:JF16K$0U>5h,D<f9:lb)FD,2q!_blsAJc3gRpq.,],d/\5bn3hnY=_F`;QE:m^elV`Vr8Z.]]k<@f34F>%'H$#nPB+F1Ouo8-SO9r(bDVXCpEnbu74R%!7[JaATV9_[P".A;)R9&2a#f>+XAqD2QGoC&X$"X(U,Hd!d6_ACb#26Vj3L:Cc`m^0juRto`]al@lm%CFX;S>GV%JC]IQRfNC/%r'^_Tga_fYE`0WU=j4O!-ARTS_]e75(Dg.\S],;qXr))kl,Ro&EQ7ZI8(.b+]ZC0tq,ktGoUf=KD=`UKH8),FZ)LG,3ET6$]>*$cq3T:Z>Zh+>u@Y@L5_l"5S=ZW"_4g5!&gn,baaTsI1ah1Js\WXWCo20rApZ7MbX>4%?X\36h1jjcjM2A*!4-/Gk8X0t)5,60oq[rMX+8h$fOFml4uSKc>3L=8E)%A$1W7*6-og/9UhHOdneB+X$Wh;X\*T+)rkVIBO/PI3*,pn"nk+]?Y^0uP?=<#5eV8ml!d[9tD<Z56/GZ:DNeE\",:.E9[[RRIFX+f\FK2f4_`O)1C?GT9'aTjZE:Hl;K-]7(e*GNsB\35*,uL73Erb:pIr#bGddLNMr%/RAV]$)\-<,b:r)oSAZM*4g>E[.dOc&"*:C]!:2DN[%0bY:il_*.qKHrYXeBEs_K+V`O#Vn!L=kLjnR`c;[ZKO-?O(L_mG>;%PclfMt[`A0hut-V5P.W>r_;_j<q*@Yf0LJ>98g(dKP8T.GNukCZXD[ccC;JW*5gaVt(cT<-rbXa,"a$e3$EYAdBB00uWA=5>usL$n&!U>4'$ZCXBG'qj-+/^9#"]DOo#a"T6tBNdXgfpo@'c>Fe`^Z$4d%Gu%T'$6Gb/:_`9!r2^l]")S.8Y;2_<-cYZ<*:9I]&YM,Y%Nr:\l2af?rIl0P"M+Wp[.;e]dGGa@TiAr8X/a].uHHQT^?kdOhoMGel<;`_uhnDr/gSa2,_)37M7e3fUEUO%UHMO9rH5Mo:df'F3]GWOeG$iodDar5'tYm<79I0jh71]*:6Sb%l)n*)r@7?B>7._k*P15Tgj757W7A0\Xn+FNn2Yu$2^5c_]f]e.#$tLO%VgCjnb'?,_'$M+1K:&d3E\Y4I>\jP!$>=0kNgMe$;0=*jT(MZLmE,k2Z@1s/H*aF7cbN!64^/QOD:)R\tLT/LsXV?l;[*q<N>mF+%O"la2&7j;oGgeNaKss+aP!PIAHTjhohgT;MHC@e_,LDJm\iOedGiUqn3?%seZ?n(hm:+)fsWll0Q8:7c2tics_F,5#0LZn\qe>JKm9G&SNZGC9:4:\,=?"+-c9%=`gIG+CUp=W_2#3X#5(ifjK@?ZXBE+dWZ+Z$lL&_V\a7kM6e5gZ26/57^rm(`i-#3f\T\%VW1hEgS"G,cTU4?GeYsA/[Wa&j+3-L+;)E`N.oo0'efK,$E-I(d-n/%e[.`26^q8#M+tT(5[-s..X8RZ)j;Z6mqHP,aWmJVmJU&W)J#9p71*QSubI9D3WX'fj@`V"RZd!IY,Q<>BM*7@qaUTI*.Z7"NKPdnL_-W[Le:o,]+/s,[e*qT4G4hBqS7=X,n&\c;R@$Z8ufiNoc^(cWos&KiGb])ck-$[.mK7^0.nNKVU*fs3^L]0;:ErYEtIe-Hc3[,sFQU'Luuj[R4,s^2Mo%EXs:mII8q+SBNZs_^Xkg@SkIQBF'm%!Kc"[`#rS'n":DJq/S>8m+oo4rI`>7pBNq9pRC$;DsPmuGN9CoT:/^'6bD++;NC?=^kfN@P"Nl`*B"b_4r37CD=^)K*);`f8sN7B(LhNDbe^9`8.QVo/-X-rGLtN].3ZsPnMKIA@$gNf#cm5_:NekVLdKL<^(oo[p)0iE"l[hdfqtcd"G(?(\%F+jheb8CS#M3e<#9;4OI'%0neIEZB56nT-H^*0GUb?^_ZeQnF[0P$#bJtqDbZ^Djlu`i+..e@X>?Z@BnW@-hA^NsGrTDmWF[t4?>n3@=3D4Uc/l#&VaJF(Hua:Le(*[cd)4q?m[/G>=*Jc0="J[-O9\uLpn)bsoH37_X7pfs(QC2j=l>[=,[>X6>DN]4rd(UK3:epnN?N>bl<d-*Gt%c!%e(7!RN?grCZSo%hAS0LWh-6_fnne"oM+00Ind2lnJ!ljpuQIt*aR8!X%q/nhB,If>u0ge5VD(B"YAs"SeuJiq&(8KS>do6>,/JV#*=oo>CF]L'Q3uD-"9a8s2H%T0TH&:VuiRL~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2780
+>>
+stream
+Gat=,flGh<&q&kDe0@+$_Ed.W2s.rBO&:QNelpe[NEGU9'53OGiGo#3Xnhh<C)f?0a>9+r!W`AY<EWI-<H-%!Y@IRP3RO=CHMQD@8'q3h*7+3>rZf+gT7*85@1WSd,g0O%a2_&eNZ5S%jho<II+lmR$>h:#!lq&iEid?C>ft/)=N"Me?-DGLeo)5m0%%1c'i=Y&[sWt[gGU\MH^=%[52GBYs!5'B>M!FPX1>H'Y^/Sc!V>/s^3N/-D$>+D^!)ho-Jd67WKdX&D;Y*T(NfZ^h>b@h*UVh?_@e%Ph;_OR'no-g=HVVG"gT?((\!8%MM0"e^ki^1Jps78"GTPX^d!D6k[-$Zk4K;)q96,Jmm36Y$K&`uKV%Wd1<%JVA,4>i,Kogd507E.B3W5r6C`:&`E[U<f5lP]3S'a\-c.`:%;27IplS),1'5c2lf3%K1P]etYDLU!plNaY`A=!.8UK*u5O_ZLCUT^LIY#Q;gI:kuH\"-oRYa6-8+FC&W/lLIaR<U852EYNdC$'EZn.6sEZ%U'*RVNI")'IFnF_$IfPDE03%eFTQ7i!ML+K6``XilGF2E]*2".RDO%"9EmjOAq8lM8%\kY1u/D4J^2q71.m?N'$A?)TW@S:pb&)JN6o<H?QZ`rG;:%N&rWo)YkQ`6-Ok,M;43l0aKPJ63_mU[adh_S#2[O40VE:3fhDtMF&B/I+<GbH.*G@['/iQPT&gULt*bilXn.BSJ0dCVo:[@PXE3T*/GDV4*"W?4T+<)$_(=Ysj1+4j;I9rb2@AZTX!%6ctU6Lp"g!4ZJ,fJ_kq^:T?@-%DN,4.-QiQWc6H4X9=Ck(YKGC%\l.[7[AH.8`-S<.&HkbK??^gf#C9C!d34&&A,7_?@3[4p!NqCJ@r;d8hbtXBrQ6Ea:3oB\Zo.3'<d9CYALQ>\!,_j.0?>DGajpq3X'P$!;+.H0Td\G=lUbp>r"ue"WPGe66FhF02pr*Gc\S3<+/>ol5Z$Oe-Nd,MYlocM7P_k>q2r/\Xts0jhW(JsjTQdTaVHWn\gHl:T$TQ?58RpRN=mq._nN:&A/7V&pc(T>!SHcL`WM7<1j:7td#^dAAAa&u\mD1o<,9<&=A.fMc.M_P_)t`2Z'l@^CHa1p\>Y'9t-^<N.1YGEg:N18IYqQ)+YJ:Gt@"9hddo$jk7^NEk60NO=T?5i1Rp"#0Cc)U7Jd8>f%c&tt[$lL\TZhr<@$X"Kk$MI;l_e&;1Yhm+WEN7(AREhQfRc!lpE0jnXVUD?/G-h7?#q='(B=b"Go]4l)2,DVJ;f)\7751:%_'s-*H_,cp"Ap6]4FfLU0('UgOr.(iPb9S*AbT^K:597%jPGVU"rNteaV:.Zfp$HMnE:rDZKgfpc<h[70<E<%%,[B,$dgR_phHr)-NOYV7NeA'5`h@/>ama'!ZtYbN6_<E.G;=?WfR_GI$kK%X:qBKVeR3Vg^UNNOVGJ)WfT`VtVfN4U:LmPA8J`ej[I6G%42$s6CaRa0NG_SrK(,\b&qT8+3Ko^V#X^O)+ZWTc2Rhn&<_l)=lWq%[Y5B8t:3&bEGW,t<h5G':b*U'?ITgR>AHUc&_UAgep69:4OjNV'VNmTc/13iTRsL.AH%c]C"M0q@.bgh8)d#_%[%Ts`?8\tN2-9LA[2\o>KYX`jZU\eMBROVdGL!auOYZT43';-D7?4YMdioi;WR\Z%$Q\9&b)@jL:\a>a3O"7k7G.[aYmY&,d=1W's"Fp)[jBiK/+b[Y%TinS2!9j`B=kk.0OU9@C-!u4>s"4G&#a'OZ:sOi&V!^O#Xtt8T4qhb/-d*s$_CA#Y)p<^nf)Ap^Pl%FJI3R9AX.*JBjR'\re\N#)r921>C-!f,;X46jZ:Z7jpB2&(3,43Y=O*%en&5CDjd8DbhK]p[-8)@3se23RhhJkk8ioo:/Rle8_BMZ>!o<&9#TIUDdVC,?VR:PrS3m3CLDgMj'2hDp9sEF%m8!-FKf$]0=);i9$20][i:8^.I@'b_hSN;iFCl%_i4<EE8A37i.ppA4DR_gd_=a+5Po`Rnn@a'*8=U#%NURlm4QB2H\cYmlpfSJ@.Wqurafc^GA5%f`Og'D6\6Le&T;4aG5iC32\;1Z=r57"L"$cZ,YXB4LN[;*j&$9E9?Ob%e4WE01[Bcr<@4Cp8EMH,$.rL>dGq3<8`ohd;mq"'fr?Gq`Q*c=3;hq3BDRn-gqC],lVDFo\0W[fJA$\L6aclX5!Fu(2.dAJbiQq&e*D,A]OgZ.I'T>X[7t_MOKmalP&4;>)HFU=$lTO6rAXKn0',2164_Oup1^l!.Nuf*mdi)f^_.<L)276DZAEC"bM%(*4Xs]&3Zrc;gF?W+2[6-A$/gh]NapESkQVic4f!.SH_<T>D4<D[^:)^o+]`93DAVC0RdZK_/$ne4"[brT7HhAg/WVAX_oS'22ekUrRoF"Qdu`953U)/cpkEJN:_;5`^eeW;kKBmV$!;3`B@la&0C6gbY[2,*q@u)^F_1<oT)t+_b.@CT-%1hs,_i55Y:l+!Y@B8k/t,1PMJop<ffg63!e<1QR,\/g!kLsGD?)]5_6^eN%FOLbVO;hV4.\oZe`,`RL2nU+<ZD#+RD^b:!,5BOA]DqSR5.h!q_&Jg0^NKTL.O.C,s*1]*?i#^!A42O9ZjHlRTCW&\f1jHCh;EQ#Ado@8&64e'j/;ONtN!t_"D[K/+2o<"sL+Z_b5p.14*Q002/?X-G.,0*Qd3J:"t^>-?k6HJ>JaL%r+iB$kRO*>cT`S?VXWH)8iQVqR#`d]qRT64a2-JF'e<Kp4$`M>Hn~>endstream
+endobj
+xref
+0 25
+0000000000 65535 f 
+0000000061 00000 n 
+0000000143 00000 n 
+0000000250 00000 n 
+0000000362 00000 n 
+0000000439 00000 n 
+0000000558 00000 n 
+0000000673 00000 n 
+0000000878 00000 n 
+0000001083 00000 n 
+0000001288 00000 n 
+0000001494 00000 n 
+0000001700 00000 n 
+0000001806 00000 n 
+0000002012 00000 n 
+0000002218 00000 n 
+0000002288 00000 n 
+0000002635 00000 n 
+0000002735 00000 n 
+0000005204 00000 n 
+0000008633 00000 n 
+0000009766 00000 n 
+0000012877 00000 n 
+0000015536 00000 n 
+0000018990 00000 n 
+trailer
+<<
+/ID 
+[<35dc149f684a96fd15320a4eb9f2ad7e><35dc149f684a96fd15320a4eb9f2ad7e>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 16 0 R
+/Root 15 0 R
+/Size 25
+>>
+startxref
+21862
+%%EOF

--- a/docs/papers/efc/efc_state_vs_stageIII/index.json
+++ b/docs/papers/efc/efc_state_vs_stageIII/index.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "./schema.json",
+  "id": "efc-state-vs-stageIII",
+  "title": "EFC vs Stage-III Cosmology State Assessment",
+  "subtitle": "Structural Coherence Evaluation and Validation Update for Energy-Flow Cosmology in the Post-Tension Weak-Lensing Landscape",
+  "description": "Stage-III cosmology update to the EFC validation program addressing recent weak-lensing recalibrations (KiDS Legacy, HSC Y3 with DESI clustering-z). Reframes EFC's role from 'tension resolution' to 'precision structural competitor' and introduces SCE protocol for O-layer/M-layer distinction.",
+  "version": "1.0.0",
+  "date": "2026-02-10",
+  "doi": "10.6084/m9.figshare.31305550",
+  "type": "Methodology note / Validation update / Theory-data interface framework",
+  "supersedes": "Prior S8-tension narrative in EFC validation documents",
+  "license": "CC-BY 4.0",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "S8 tension",
+    "weak lensing",
+    "Stage-III surveys",
+    "KiDS Legacy",
+    "HSC Y3",
+    "DESI clustering-redshift",
+    "modified gravity",
+    "structural coherence evaluation",
+    "cosmological model comparison",
+    "observation-native ontology",
+    "lensing response"
+  ],
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Independent researcher"
+  },
+  "stage_III_observational_update": {
+    "kids_legacy": {
+      "probe": "cosmic shear",
+      "S8": 0.815,
+      "S8_error_plus": 0.016,
+      "S8_error_minus": 0.021,
+      "planck_consistency": "0.73σ",
+      "reference": "Wright et al. (2025), A&A 703, A158"
+    },
+    "hsc_y3_desi": {
+      "probe": "DESI-calibrated n(z)",
+      "S8": 0.805,
+      "S8_error": 0.018,
+      "note": "Upward shift vs earlier HSC Y3",
+      "reference": "Choppin de Janvry et al. (2025), arXiv:2511.18134"
+    },
+    "combined_wl": {
+      "probe": "KiDS+DES+HSC",
+      "S8": 0.813,
+      "S8_error_plus": 0.009,
+      "S8_error_minus": 0.010,
+      "reference": "Choppin de Janvry et al. (2025), arXiv:2511.18134"
+    },
+    "cmb_lensing": {
+      "probe": "combined",
+      "S8": 0.828,
+      "S8_error": 0.012,
+      "note": "Reference point for growth",
+      "reference": "Choppin de Janvry et al. (2025), arXiv:2511.18134"
+    },
+    "cause_of_shift": "Improved photo-z calibration and validation (including DESI-based clustering-redshifts for HSC), improved image simulations, and expanded calibration datasets — primarily attributed to improved control of calibration systematics rather than requiring new physics"
+  },
+  "efc_impact_assessment": {
+    "beta_background": {
+      "sigma8": 0.805,
+      "updated_role": "Matches converging Stage-III amplitude",
+      "status": "Strengthened"
+    },
+    "sigma_kz_lensing": {
+      "updated_role": "Precision diagnostic for scale-dependent response",
+      "status": "Role shifted"
+    },
+    "Tz_regime": {
+      "updated_role": "GR recovery at high z",
+      "status": "Unchanged"
+    }
+  },
+  "narrative_update": {
+    "deprecated": "EFC resolves a 3σ S8 tension",
+    "current": "EFC's background coupling yields an amplitude (σ8 ≈ 0.805) consistent with the converging Stage-III lensing landscape; Σ(k,z) becomes a model-selection diagnostic for scale-dependent matter-lensing response"
+  },
+  "category_transition": {
+    "from": "Alternative model that explains a tension",
+    "to": "Alternative model that matches standard cosmology at first order and predicts second-order structural deviations"
+  },
+  "sce_layer_classification": {
+    "O_layer": {
+      "name": "Observation-Native Ontology",
+      "description": "Quantities extracted from data with minimal theoretical input",
+      "weak_lensing_examples": ["shear two-point correlations ξ±(θ)", "convergence power spectra Clκκ", "tomographic bin statistics"]
+    },
+    "M_layer": {
+      "name": "Mapping Transparency",
+      "description": "Quantities produced by passing O-layer data through a model-dependent pipeline",
+      "S8_assumptions": [
+        "GR lensing kernel (Σ = 1)",
+        "GR linear perturbation theory",
+        "Friedmann + ΛCDM background",
+        "constant c",
+        "ΛCDM transfer function"
+      ]
+    },
+    "T_layer": {
+      "name": "Theory Consumption",
+      "description": "Theories consume M-layer products as compressed constraints"
+    }
+  },
+  "observation_level_test": {
+    "equation": "Clκiκj = ∫ dχ [Wi(χ) Wj(χ) / χ²] · Σ²(k,z) · Pδ(k,z)",
+    "lcdm_case": "Σ = 1 (locked)",
+    "efc_case": "Σ(k,z) free",
+    "falsification_criterion": "Additional mapping freedom must be statistically justified at O-layer (ΔAIC, ΔBIC)"
+  },
+  "strengths_in_new_landscape": [
+    "β = 0.08 → σ8 = 0.805 matches converging data without tuning",
+    "Growth suppression via Hubble friction (correct mechanism, correct direction)",
+    "One transition function T(z) governs all regimes (no patches)",
+    "Built-in predictions for scale-dependent and environment-dependent effects",
+    "Five pre-registered falsification criteria, none triggered"
+  ],
+  "challenges_in_new_landscape": [
+    "Reduced motivation from S8 tension (the 'problem' is smaller)",
+    "Σ channel needs re-validation against updated baselines",
+    "Must demonstrate second-order predictions are testable with current/upcoming data",
+    "Self-consistent EFC background (not ΛCDM-calibrated) still needed"
+  ],
+  "stage_IV_discriminating_tests": [
+    {
+      "test": "Scale-dependent growth f(k,z)",
+      "efc_prediction": "Entropy-gradient modulation",
+      "lcdm_prediction": "Scale-independent (linear regime)",
+      "data_source": "Euclid, DESI DR3"
+    },
+    {
+      "test": "Lensing vs dynamical mass",
+      "efc_prediction": "Σ ≠ 1 at low-z, small scales",
+      "lcdm_prediction": "Σ = 1 everywhere",
+      "data_source": "Euclid clusters, Rubin"
+    },
+    {
+      "test": "Environment-dependent clustering",
+      "efc_prediction": "Entropy-gradient correlations",
+      "lcdm_prediction": "No environment dependence",
+      "data_source": "eROSITA + Euclid"
+    },
+    {
+      "test": "ISW cross-correlation amplitude",
+      "efc_prediction": "Cancellation from μ/μ'",
+      "lcdm_prediction": "Standard ISW",
+      "data_source": "DESI tracers × Planck/ACT"
+    },
+    {
+      "test": "Cluster abundance N(M,z)",
+      "efc_prediction": "Modified growth function",
+      "lcdm_prediction": "Standard Press-Schechter",
+      "data_source": "eROSITA, SPT-3G"
+    }
+  ],
+  "action_items": [
+    "Re-run Σ(k,z) fits against KiDS-Legacy data (Σ = 1 locked vs Σ free)",
+    "Compare Δχ², AIC, BIC for model selection",
+    "Update all paper introductions to reflect Stage-III convergence",
+    "Add Stage-III update footnote to all existing/forthcoming papers"
+  ],
+  "stage_III_update_footnote": "Since submission, the Stage-III weak-lensing landscape has shifted upward: KiDS Legacy reports S8 = 0.815 (+0.016/−0.021) (Wright et al. 2025), and HSC Y3 recalibrated with DESI clustering-redshifts yields S8 = 0.805 ± 0.018 (Choppin de Janvry et al. 2025). The EFC background-coupling prediction (σ8 ≈ 0.805) is consistent with these updated values. The S8 tension motivation discussed in this work should be read in light of this convergence; the structural predictions and falsification criteria remain unchanged.",
+  "references": [
+    {"id": 1, "citation": "Wright et al., A&A 703, A158 (2025). KiDS Legacy cosmic shear."},
+    {"id": 2, "citation": "Choppin de Janvry et al., arXiv:2511.18134 (2025). HSC Y3 + DESI clustering-z."},
+    {"id": 3, "citation": "Terasawa et al., Phys. Rev. D 111, 063509 (2025). Small-scale HSC Y3 tension."},
+    {"id": 4, "citation": "Tristram et al., A&A 682, A37 (2024). Planck PR4."},
+    {"id": 5, "citation": "Magnusson, DOI: 10.6084/m9.figshare.31293745 (2026). SCE framework."},
+    {"id": 6, "citation": "Magnusson, DOI: 10.6084/m9.figshare.31271917 (2026). Lensing response Σ(k,z)."}
+  ],
+  "related_papers": [
+    {"id": "efc-four-channel-consistency-test", "relationship": "Validates against same β = 0.08"},
+    {"id": "efc-regime-consistency-lya-bao-rsd-sce", "relationship": "Uses same SCE framework"}
+  ],
+  "files": {
+    "paper": "efc_state_vs_stageIII.pdf",
+    "schema": "schema.json"
+  }
+}

--- a/docs/papers/efc/efc_state_vs_stageIII/schema.json
+++ b/docs/papers/efc/efc_state_vs_stageIII/schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://efc-project.org/papers/efc-state-vs-stageIII/schema.json",
+  "title": "EFC vs Stage-III Cosmology State Assessment Schema",
+  "description": "Schema for Stage-III validation update and SCE protocol for weak-lensing comparisons",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "const": "efc-state-vs-stageIII"
+    },
+    "stage_III_observational_update": {
+      "type": "object",
+      "properties": {
+        "kids_legacy": {
+          "type": "object",
+          "properties": {
+            "S8": {"type": "number"},
+            "planck_consistency": {"type": "string"}
+          }
+        },
+        "hsc_y3_desi": {
+          "type": "object",
+          "properties": {
+            "S8": {"type": "number"},
+            "S8_error": {"type": "number"}
+          }
+        },
+        "combined_wl": {
+          "type": "object",
+          "properties": {
+            "S8": {"type": "number"}
+          }
+        },
+        "cause_of_shift": {"type": "string"}
+      },
+      "required": ["kids_legacy", "hsc_y3_desi", "cause_of_shift"]
+    },
+    "efc_impact_assessment": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "updated_role": {"type": "string"},
+          "status": {"enum": ["Strengthened", "Role shifted", "Unchanged", "Weakened"]}
+        }
+      }
+    },
+    "narrative_update": {
+      "type": "object",
+      "properties": {
+        "deprecated": {"type": "string"},
+        "current": {"type": "string"}
+      },
+      "required": ["deprecated", "current"]
+    },
+    "category_transition": {
+      "type": "object",
+      "properties": {
+        "from": {"type": "string"},
+        "to": {"type": "string"}
+      },
+      "required": ["from", "to"]
+    },
+    "sce_layer_classification": {
+      "type": "object",
+      "properties": {
+        "O_layer": {
+          "type": "object",
+          "properties": {
+            "name": {"const": "Observation-Native Ontology"},
+            "description": {"type": "string"},
+            "weak_lensing_examples": {"type": "array", "items": {"type": "string"}}
+          }
+        },
+        "M_layer": {
+          "type": "object",
+          "properties": {
+            "name": {"const": "Mapping Transparency"},
+            "description": {"type": "string"},
+            "S8_assumptions": {"type": "array", "items": {"type": "string"}}
+          }
+        },
+        "T_layer": {
+          "type": "object",
+          "properties": {
+            "name": {"const": "Theory Consumption"},
+            "description": {"type": "string"}
+          }
+        }
+      },
+      "required": ["O_layer", "M_layer", "T_layer"],
+      "description": "SCE three-layer classification for derived quantities"
+    },
+    "stage_IV_discriminating_tests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "test": {"type": "string"},
+          "efc_prediction": {"type": "string"},
+          "lcdm_prediction": {"type": "string"},
+          "data_source": {"type": "string"}
+        },
+        "required": ["test", "efc_prediction", "lcdm_prediction"]
+      }
+    },
+    "stage_III_update_footnote": {
+      "type": "string",
+      "description": "Standard footnote for insertion in existing/forthcoming papers"
+    }
+  },
+  "required": ["id", "stage_III_observational_update", "narrative_update", "sce_layer_classification"]
+}


### PR DESCRIPTION
Adds validation update document addressing Stage-III weak-lensing recalibrations (KiDS Legacy, HSC Y3+DESI). Key updates:
- EFC σ8 ≈ 0.805 matches converging Stage-III values
- Narrative shift: "tension resolution" → "precision structural competitor"
- Introduces SCE O-layer/M-layer protocol for weak-lensing comparisons
- Includes Stage-IV discriminating tests table

https://claude.ai/code/session_01RNKSig9vLiuRDZMEJGHT1o