### PR TITLE
Add AI-friendly package for ISW Revision Patch paper

### DIFF
--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/CITATION.cff
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.2.0
+message: "If you use this revision patch, please cite it as below."
+type: report
+title: "ISW Paper Revision Patch: Proposed Corrections to ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers"
+authors:
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+    affiliation: "Energy-Flow Cosmology Project"
+date-released: 2026-02-01
+doi: "10.6084/m9.figshare.31329082"
+url: "https://doi.org/10.6084/m9.figshare.31329082"
+repository: "https://github.com/supertedai/EFC"
+keywords:
+  - ISW effect
+  - integrated Sachs-Wolfe
+  - cross-correlation
+  - DESI DR1
+  - Energy-Flow Cosmology
+  - EFC
+  - revision patch
+  - consistency audit
+abstract: >-
+  The ISW Consistency Audit (v1.1) established that the published A_ISW values
+  (0.56 → 0.15) cannot be reproduced under any self-consistent channel—growth-driven,
+  potential-driven, or covariance-weighted. This patch proposes minimal, defensible
+  revisions to the ISW paper that preserve its core predictions while correcting
+  the quantitative A_ISW claims. Under the growth-driven interpretation, the revised
+  prediction is A_ISW ≈ 0.89 ± 0.03 across all DESI DR1 tracer bins, representing
+  a uniform ~11% suppression relative to ΛCDM with no significant z-dependence.
+references:
+  - type: article
+    title: "ISW Cross-Correlation Predictions for Energy-Flow Cosmology with DESI DR1 Tracers"
+    authors:
+      - family-names: "Magnusson"
+        given-names: "Morten"
+    doi: "10.6084/m9.figshare.31301953"
+    year: 2026
+    notes: "Original paper to which this revision patch applies"

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/LICENSE
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Morten Magnusson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/README.md
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/README.md
@@ -1,0 +1,203 @@
+# ISW Paper Revision Patch
+
+## AI-Friendly Package
+
+This package provides machine-readable data and reference implementations for:
+
+**"ISW Paper Revision Patch: Proposed Corrections to ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers"**
+
+- **Author**: Morten Magnusson
+- **DOI**: [10.6084/m9.figshare.31329082](https://doi.org/10.6084/m9.figshare.31329082)
+- **Date**: February 2026
+- **Type**: WP2 Internal Note
+- **Companion**: ISW Consistency Audit v1.1
+
+---
+
+## Summary
+
+The ISW Consistency Audit (v1.1) established that the originally published A_ISW values (0.56 → 0.15) cannot be reproduced under any self-consistent channel. This revision patch proposes corrections that preserve the core EFC predictions while correcting the quantitative claims.
+
+---
+
+## Key Corrections
+
+### Category 1: Retracted A_ISW Values
+
+| Tracer  | z_eff | Original (withdrawn) | Revised |
+|---------|-------|---------------------|---------|
+| LRGz0   | 0.510 | ~~0.56~~            | 0.87    |
+| LRGz1   | 0.706 | ~~0.43~~            | 0.87    |
+| LRGz2   | 0.930 | ~~0.33~~            | 0.89    |
+| LRG+ELG | 0.930 | ~~0.29~~            | 0.89    |
+| ELG     | 1.317 | ~~0.15~~            | 0.92    |
+| QSO     | 1.491 | ~~0.20~~            | 0.90    |
+
+**Key insight**: A_ISW is nearly z-independent (0.87–0.92), representing a uniform ~11% suppression relative to ΛCDM, not the 44–85% originally claimed.
+
+### Category 2: μ-Channel Interpretation
+
+Two distinct interpretations must be distinguished:
+
+1. **Growth-driven** (adopted):
+   - Φ ∝ D(a)/a
+   - μ affects ISW only through D(a) and f(a)
+   - ISW source: S ∝ H(a)(D/a)(1-f)
+   - Prediction: A_ISW ≈ 0.89 (positive)
+
+2. **Potential-driven** (MG-type):
+   - Φ ∝ μ(a)·D(a)/a
+   - ISW kernel contains explicit dμ/d ln a term
+   - Prediction: Anti-correlation (A < 0) for z_eff ≳ 0.6
+   - Disfavoured by existing positive ISW detections
+
+### Category 3: Cancellation Metric
+
+The cancellation index C is **not applicable** under growth-driven ISW:
+- No separate K_μ' channel exists
+- Observable discriminator is now the uniform 11% suppression
+
+---
+
+## Elements Preserved
+
+| Element | Status |
+|---------|--------|
+| Growth ODE, eq. (1) | Correct. μ(a) in growth equation is well-defined |
+| μ(a) parameterisation | Correct. β = 0.16, a_t = 0.55, σ = 0.25 unchanged |
+| Limber approximation | Valid. Exact non-Limber differs by < 3% |
+| Tracer definitions | Valid. DESI DR1 bins and bias values unchanged |
+| H(a) background | Valid. Fiducial ΛCDM background is correct |
+| Qualitative prediction | Valid. EFC predicts A_ISW < 1 for all tracers |
+
+---
+
+## Revised Falsification Criterion
+
+**Original**: C > 0.7, A < 0.5 at z_t
+
+**Revised**: If A_ISW = 1.00 ± 0.05 across all bins in a combined multi-tracer stack, the EFC growth-channel modification would be excluded at > 2σ.
+
+**Positive evidence**: A_ISW < 0.9 across multiple bins would constitute positive evidence for EFC.
+
+---
+
+## Validation Ledger Update
+
+| Field | Current (v1.6) | Revised |
+|-------|----------------|---------|
+| Status | Completed | Under revision |
+| A_ISW | 0.29–0.56 | 0.87–0.92 |
+| C | 0.59–0.96 | Not applicable |
+| Key discriminator | Tomographic C gradient | Uniform 11% suppression |
+
+---
+
+## Package Contents
+
+```
+ISW_Consistency_Audit_and_Revision_Patch/
+├── README.md                    # This file
+├── index.json                   # Machine-readable metadata
+├── isw_revision_patch.pdf       # Original paper
+├── src/
+│   └── isw_revision.py          # Reference implementation
+├── data/
+│   └── revised_predictions.json # Revised A_ISW values
+├── examples/
+│   └── isw_revision_demo.py     # Demonstration script
+├── CITATION.cff                 # Citation metadata
+└── LICENSE                      # MIT License
+```
+
+---
+
+## Quick Start
+
+```python
+from src.isw_revision import RevisedISWPredictions, ChannelComparison
+
+# Get revised predictions
+predictions = RevisedISWPredictions()
+
+# Compare original vs revised
+for tracer in predictions.tracers:
+    original = predictions.get_original(tracer)
+    revised = predictions.get_revised(tracer)
+    print(f"{tracer}: {original:.2f} → {revised:.2f}")
+
+# Channel comparison
+channels = ChannelComparison()
+print(f"Growth-driven: A_ISW ≈ {channels.growth_driven:.2f}")
+print(f"Potential-driven at z>0.6: A_ISW < 0 (anti-correlation)")
+```
+
+---
+
+## Core Equations
+
+### Growth-Driven ISW Source
+
+```
+S ∝ H(a) × (D/a) × (1 - f)
+
+where:
+  f = d ln D / d ln a  (growth rate)
+  D(a) = growth factor modified by μ(a)
+```
+
+### μ(a) Parameterisation (unchanged)
+
+```
+μ(a) = 1 + β × exp[-(a - a_t)² / (2σ²)]
+
+Parameters:
+  β = 0.16
+  a_t = 0.55
+  σ = 0.25
+```
+
+### Revised A_ISW Prediction
+
+```
+A_ISW^EFC ≈ 0.89 ± 0.03  (all tracers)
+
+Suppression relative to ΛCDM: ~11%
+z-dependence: negligible
+```
+
+---
+
+## Key Findings
+
+1. **Original A_ISW values cannot be reproduced** under any self-consistent channel
+2. **Revised prediction**: Uniform ~11% suppression (A_ISW ≈ 0.89)
+3. **No z-dependence** in growth-driven interpretation
+4. **Cancellation metric C is not applicable** under growth-driven ISW
+5. **Falsification threshold revised** to A_ISW = 1.00 ± 0.05
+
+---
+
+## Citation
+
+```bibtex
+@misc{magnusson2026isw_revision,
+  author       = {Magnusson, Morten},
+  title        = {{ISW Paper Revision Patch: Proposed Corrections to
+                  ISW Cross-Correlation Predictions for EFC with
+                  DESI DR1 Tracers}},
+  year         = {2026},
+  month        = feb,
+  publisher    = {Figshare},
+  doi          = {10.6084/m9.figshare.31329082},
+  note         = {WP2 Internal Note, Companion to ISW Consistency Audit v1.1}
+}
+```
+
+---
+
+## Related Papers
+
+- ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers (DOI: 10.6084/m9.figshare.31301953)
+- ISW Consistency Audit v1.1 (companion document)
+- EFC Regime-Transition Fit to DESI DR2 BAO (DOI: 10.6084/m9.figshare.31230703)

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/data/revised_predictions.json
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/data/revised_predictions.json
@@ -1,0 +1,149 @@
+{
+  "metadata": {
+    "description": "Revised ISW cross-correlation predictions following Consistency Audit v1.1",
+    "paper_doi": "10.6084/m9.figshare.31329082",
+    "original_paper_doi": "10.6084/m9.figshare.31301953",
+    "channel": "growth-driven",
+    "multipole_range": [2, 60],
+    "date": "2026-02"
+  },
+  "mu_parameters": {
+    "beta": 0.16,
+    "a_t": 0.55,
+    "sigma": 0.25,
+    "equation": "μ(a) = 1 + β × exp[-(a - a_t)² / (2σ²)]",
+    "status": "unchanged"
+  },
+  "tracers": {
+    "LRGz0": {
+      "z_eff": 0.510,
+      "A_ISW_original": 0.56,
+      "A_ISW_revised": 0.87,
+      "original_suppression_percent": 44,
+      "revised_suppression_percent": 13,
+      "cancellation_index_original": null,
+      "cancellation_index_revised": null,
+      "original_status": "withdrawn"
+    },
+    "LRGz1": {
+      "z_eff": 0.706,
+      "A_ISW_original": 0.43,
+      "A_ISW_revised": 0.87,
+      "original_suppression_percent": 57,
+      "revised_suppression_percent": 13,
+      "cancellation_index_original": null,
+      "cancellation_index_revised": null,
+      "original_status": "withdrawn"
+    },
+    "LRGz2": {
+      "z_eff": 0.930,
+      "A_ISW_original": 0.33,
+      "A_ISW_revised": 0.89,
+      "original_suppression_percent": 67,
+      "revised_suppression_percent": 11,
+      "cancellation_index_original": null,
+      "cancellation_index_revised": null,
+      "original_status": "withdrawn"
+    },
+    "LRG+ELG": {
+      "z_eff": 0.930,
+      "A_ISW_original": 0.29,
+      "A_ISW_revised": 0.89,
+      "original_suppression_percent": 71,
+      "revised_suppression_percent": 11,
+      "cancellation_index_original": null,
+      "cancellation_index_revised": null,
+      "original_status": "withdrawn"
+    },
+    "ELG": {
+      "z_eff": 1.317,
+      "A_ISW_original": 0.15,
+      "A_ISW_revised": 0.92,
+      "original_suppression_percent": 85,
+      "revised_suppression_percent": 8,
+      "cancellation_index_original": null,
+      "cancellation_index_revised": null,
+      "original_status": "withdrawn"
+    },
+    "QSO": {
+      "z_eff": 1.491,
+      "A_ISW_original": 0.20,
+      "A_ISW_revised": 0.90,
+      "original_suppression_percent": 80,
+      "revised_suppression_percent": 10,
+      "cancellation_index_original": null,
+      "cancellation_index_revised": null,
+      "original_status": "withdrawn"
+    }
+  },
+  "summary": {
+    "A_ISW_revised_mean": 0.89,
+    "A_ISW_revised_uncertainty": 0.03,
+    "A_ISW_revised_range": [0.87, 0.92],
+    "suppression_percent": 11,
+    "z_dependence": "negligible",
+    "A_ISW_original_range": [0.15, 0.56],
+    "original_suppression_range_percent": [44, 85]
+  },
+  "channel_interpretations": {
+    "growth_driven": {
+      "adopted": true,
+      "potential_relation": "Φ ∝ D(a)/a",
+      "mu_role": "μ affects ISW only through D(a) and f(a)",
+      "isw_source": "S ∝ H(a)(D/a)(1-f)",
+      "prediction": "A_ISW ≈ 0.89 ± 0.03 (positive, z-independent)",
+      "cancellation_metric": "not applicable"
+    },
+    "potential_driven": {
+      "adopted": false,
+      "potential_relation": "Φ ∝ μ(a)·D(a)/a",
+      "additional_term": "dμ/d ln a in ISW kernel",
+      "prediction": "Anti-correlation (A < 0) for z_eff ≳ 0.6",
+      "status": "Disfavoured by existing positive ISW detections"
+    }
+  },
+  "preserved_elements": {
+    "growth_ODE": {
+      "status": "correct",
+      "note": "μ(a) in growth equation is well-defined"
+    },
+    "mu_parameterisation": {
+      "status": "correct",
+      "values": {"beta": 0.16, "a_t": 0.55, "sigma": 0.25}
+    },
+    "limber_approximation": {
+      "status": "valid",
+      "deviation": "< 3% from exact non-Limber"
+    },
+    "tracer_definitions": {
+      "status": "valid",
+      "note": "DESI DR1 bins and bias values unchanged"
+    },
+    "background_cosmology": {
+      "status": "valid",
+      "note": "Fiducial ΛCDM H(a) is correct"
+    },
+    "qualitative_prediction": {
+      "status": "valid",
+      "note": "EFC predicts A_ISW < 1 for all tracers"
+    }
+  },
+  "falsification": {
+    "original": {
+      "criterion": "C > 0.7, A < 0.5 at z_t",
+      "status": "deprecated",
+      "reason": "Cancellation metric not applicable under growth-driven ISW"
+    },
+    "revised": {
+      "criterion": "A_ISW = 1.00 ± 0.05 across all bins",
+      "exclusion_level": "> 2σ",
+      "key_test": "Combined multi-tracer analysis",
+      "positive_evidence": "A_ISW < 0.9 across multiple bins"
+    }
+  },
+  "validation_ledger": {
+    "current_version": "v1.6",
+    "target_version": "v1.7",
+    "status_change": "Completed → Under revision"
+  }
+}

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/examples/isw_revision_demo.py
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/examples/isw_revision_demo.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+ISW Revision Patch - Demonstration
+
+This script demonstrates the key corrections from:
+Magnusson (2026) "ISW Paper Revision Patch: Proposed Corrections to
+ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers"
+DOI: 10.6084/m9.figshare.31329082
+"""
+
+import sys
+sys.path.insert(0, '..')
+
+from src.isw_revision import (
+    RevisedISWPredictions, ChannelComparison, FalsificationCriteria,
+    ValidationLedgerUpdate, MuParameters
+)
+
+
+def demo_revised_predictions():
+    """
+    Demonstrate the revised A_ISW predictions.
+
+    Key finding: Original z-dependent suppression (44-85%) is replaced
+    with uniform ~11% suppression across all tracers.
+    """
+    print("=" * 60)
+    print("REVISED A_ISW PREDICTIONS")
+    print("=" * 60)
+
+    predictions = RevisedISWPredictions()
+
+    print("\nComparison of Original vs Revised:")
+    print("-" * 50)
+    print(predictions.comparison_table())
+
+    # Summary statistics
+    summary = predictions.summary()
+
+    print("\n" + "-" * 50)
+    print("Summary Statistics:")
+    print("-" * 50)
+    print(f"  Original A_ISW range:  {summary['A_ISW_original_range'][0]:.2f} – {summary['A_ISW_original_range'][1]:.2f}")
+    print(f"  Original suppression:  {summary['suppression_original_percent']:.0f}%")
+    print(f"  Revised A_ISW range:   {summary['A_ISW_revised_range'][0]:.2f} – {summary['A_ISW_revised_range'][1]:.2f}")
+    print(f"  Revised mean:          {summary['A_ISW_revised_mean']:.2f} ± {summary['A_ISW_revised_std']:.2f}")
+    print(f"  Revised suppression:   {summary['suppression_revised_percent']:.0f}%")
+    print(f"  z-dependence:          {summary['z_dependence']}")
+
+    print("\nKey insight:")
+    print("  The original claim of strong z-dependent suppression (0.56 → 0.15)")
+    print("  is NOT reproduced under self-consistent computation.")
+    print("  The revised prediction is a UNIFORM ~11% suppression.")
+
+
+def demo_channel_comparison():
+    """
+    Demonstrate the two channel interpretations.
+
+    The Audit revealed that growth-driven and potential-driven give
+    qualitatively different predictions.
+    """
+    print("\n" + "=" * 60)
+    print("μ-CHANNEL INTERPRETATION")
+    print("=" * 60)
+
+    channels = ChannelComparison()
+    comparison = channels.comparison_summary()
+
+    print("\n1. GROWTH-DRIVEN (adopted interpretation):")
+    print("-" * 50)
+    gd = comparison["growth_driven"]
+    print(f"  Potential:        {gd['potential_relation']}")
+    print(f"  μ role:           {gd['mu_role']}")
+    print(f"  ISW source:       {gd['isw_source']}")
+    print(f"  A_ISW prediction: {gd['A_ISW']}")
+    print(f"  z-dependence:     {gd['z_dependence']}")
+    print(f"  Cancellation C:   {gd['cancellation_metric']}")
+
+    print("\n2. POTENTIAL-DRIVEN (MG-type, disfavoured):")
+    print("-" * 50)
+    pd = comparison["potential_driven"]
+    print(f"  Potential:        {pd['potential_relation']}")
+    print(f"  Additional term:  {pd['additional_term']}")
+    print(f"  Low-z prediction: {pd['prediction_low_z']}")
+    print(f"  High-z prediction:{pd['prediction_high_z']}")
+    print(f"  Status:           {pd['status']}")
+
+    print("\nKey insight:")
+    print("  The potential-driven interpretation predicts ANTI-CORRELATION")
+    print("  at z > 0.6, which contradicts existing positive ISW detections.")
+
+
+def demo_mu_parameterisation():
+    """
+    Demonstrate the μ(a) parameterisation (unchanged).
+    """
+    print("\n" + "=" * 60)
+    print("μ(a) PARAMETERISATION (unchanged)")
+    print("=" * 60)
+
+    mu = MuParameters()
+
+    print(f"\nParameters:")
+    print(f"  β   = {mu.beta}")
+    print(f"  a_t = {mu.a_t}")
+    print(f"  σ   = {mu.sigma}")
+
+    print(f"\nEquation:")
+    print(f"  μ(a) = 1 + β × exp[-(a - a_t)² / (2σ²)]")
+
+    print(f"\nSample values:")
+    print(f"  {'a':>6}  {'z':>6}  {'μ(a)':>8}  {'dμ/dlna':>10}")
+    print(f"  {'-'*6}  {'-'*6}  {'-'*8}  {'-'*10}")
+
+    for a in [0.3, 0.4, 0.5, 0.55, 0.6, 0.7, 0.8, 1.0]:
+        z = 1/a - 1
+        mu_val = mu.mu(a)
+        dmu = mu.dmu_dlna(a)
+        print(f"  {a:>6.2f}  {z:>6.2f}  {mu_val:>8.4f}  {dmu:>10.4f}")
+
+    print(f"\n  Peak μ occurs at a = a_t = {mu.a_t} (z ≈ {1/mu.a_t - 1:.2f})")
+    print(f"  Peak value: μ_max = 1 + β = {1 + mu.beta:.2f}")
+
+
+def demo_falsification():
+    """
+    Demonstrate the revised falsification criteria.
+    """
+    print("\n" + "=" * 60)
+    print("FALSIFICATION CRITERIA")
+    print("=" * 60)
+
+    criteria = FalsificationCriteria()
+    summary = criteria.summary()
+
+    print("\n1. ORIGINAL CRITERIA (deprecated):")
+    print("-" * 50)
+    orig = summary["original_deprecated"]
+    print(f"  C threshold: > {orig['C_threshold']}")
+    print(f"  A threshold: < {orig['A_threshold']} at z_t")
+    print(f"  Note: {orig['note']}")
+
+    print("\n2. REVISED CRITERIA:")
+    print("-" * 50)
+    rev = summary["revised"]
+    print(f"  Exclusion: {rev['exclusion']}")
+    print(f"  Level:     {rev['exclusion_level']}")
+    print(f"  Positive:  {rev['positive_evidence']}")
+    print(f"  Key test:  {rev['key_discriminator']}")
+
+    # Test some scenarios
+    print("\n3. SCENARIO TESTS:")
+    print("-" * 50)
+
+    scenarios = [
+        (1.02, 0.05, "Consistent with ΛCDM"),
+        (0.95, 0.05, "Marginal"),
+        (0.88, 0.05, "Consistent with EFC"),
+        (0.85, 0.03, "Strong EFC evidence"),
+    ]
+
+    for A_obs, unc, label in scenarios:
+        excluded, msg1 = criteria.is_excluded(A_obs, unc)
+        positive, msg2 = criteria.is_positive_evidence(A_obs)
+
+        if excluded:
+            result = "EFC EXCLUDED"
+        elif positive:
+            result = "EFC SUPPORTED"
+        else:
+            result = "Inconclusive"
+
+        print(f"  A_ISW = {A_obs:.2f} ± {unc:.2f}: {result}")
+
+
+def demo_ledger_update():
+    """
+    Demonstrate the validation ledger update.
+    """
+    print("\n" + "=" * 60)
+    print("VALIDATION LEDGER UPDATE")
+    print("=" * 60)
+
+    changes = ValidationLedgerUpdate.changes()
+
+    print(f"\nVersion: {changes['version_from']} → {changes['version_to']}")
+    print("-" * 50)
+    print(f"{'Field':<20} {'From':<30} {'To':<30}")
+    print("-" * 80)
+
+    for field, values in changes['field_changes'].items():
+        from_val = values['from'][:28] if len(values['from']) > 28 else values['from']
+        to_val = values['to'][:28] if len(values['to']) > 28 else values['to']
+        print(f"{field:<20} {from_val:<30} {to_val:<30}")
+
+
+def demo_key_findings():
+    """
+    Summarize the key findings of the revision patch.
+    """
+    print("\n" + "=" * 60)
+    print("KEY FINDINGS SUMMARY")
+    print("=" * 60)
+
+    findings = [
+        ("1. Original values withdrawn",
+         "A_ISW = 0.56 → 0.15 cannot be reproduced under self-consistent computation"),
+        ("2. Revised prediction",
+         "A_ISW ≈ 0.89 ± 0.03 (uniform ~11% suppression, z-independent)"),
+        ("3. Channel clarification",
+         "Growth-driven (adopted) vs potential-driven (disfavoured)"),
+        ("4. Cancellation metric",
+         "Not applicable under growth-driven interpretation"),
+        ("5. Falsification revised",
+         "A_ISW = 1.00 ± 0.05 → EFC excluded at >2σ"),
+        ("6. Preserved elements",
+         "Growth ODE, μ(a) params, Limber approx, tracers, H(a)"),
+    ]
+
+    for title, detail in findings:
+        print(f"\n{title}:")
+        print(f"  {detail}")
+
+
+def main():
+    """Run all demonstrations."""
+    print("\n" + "#" * 60)
+    print("# ISW REVISION PATCH DEMONSTRATION")
+    print("# DOI: 10.6084/m9.figshare.31329082")
+    print("#" * 60)
+
+    demo_revised_predictions()
+    demo_channel_comparison()
+    demo_mu_parameterisation()
+    demo_falsification()
+    demo_ledger_update()
+    demo_key_findings()
+
+    print("\n" + "=" * 60)
+    print("CONCLUSION")
+    print("=" * 60)
+    print("The ISW Consistency Audit revealed that the original paper's")
+    print("strong z-dependent suppression was not reproducible.")
+    print("\nThe CORRECTED EFC prediction is:")
+    print("  • A_ISW ≈ 0.89 ± 0.03 across ALL DESI DR1 tracer bins")
+    print("  • Uniform ~11% suppression relative to ΛCDM")
+    print("  • NO significant z-dependence")
+    print("\nThis is testable with combined multi-tracer ISW analysis.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/index.json
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/index.json
@@ -1,0 +1,194 @@
+{
+  "paper": {
+    "title": "ISW Paper Revision Patch: Proposed Corrections to ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers",
+    "short_title": "ISW Revision Patch",
+    "authors": [
+      {
+        "name": "Morten Magnusson",
+        "orcid": "0009-0002-4860-5095",
+        "affiliation": "Energy-Flow Cosmology Project"
+      }
+    ],
+    "date": "2026-02",
+    "doi": "10.6084/m9.figshare.31329082",
+    "type": "internal_note",
+    "note_type": "WP2 Internal Note",
+    "companion_to": "ISW Consistency Audit v1.1",
+    "applies_to_doi": "10.6084/m9.figshare.31301953"
+  },
+  "summary": {
+    "purpose": "Proposes minimal corrections to ISW paper preserving core predictions while correcting quantitative A_ISW claims",
+    "key_finding": "Original A_ISW values (0.56→0.15) cannot be reproduced; revised prediction is A_ISW ≈ 0.89 ± 0.03 (uniform ~11% suppression)",
+    "status": "Under revision"
+  },
+  "revision_categories": {
+    "category_1": {
+      "name": "Retract specific A_ISW values",
+      "description": "Original z-dependent suppression (44-85%) replaced with uniform ~11% suppression",
+      "original_claim": "A_ISW = 0.56 → 0.15 (strong z-dependence)",
+      "revised_claim": "A_ISW ≈ 0.89 ± 0.03 (z-independent)"
+    },
+    "category_2": {
+      "name": "Clarify μ-channel interpretation",
+      "description": "Distinguish growth-driven vs potential-driven interpretations",
+      "growth_driven": {
+        "potential": "Φ ∝ D(a)/a",
+        "mu_role": "μ affects ISW only through D(a) and f(a)",
+        "isw_source": "S ∝ H(a)(D/a)(1-f)",
+        "prediction": "A_ISW ≈ 0.89 (positive)"
+      },
+      "potential_driven": {
+        "potential": "Φ ∝ μ(a)·D(a)/a",
+        "additional_term": "dμ/d ln a in ISW kernel",
+        "prediction": "Anti-correlation (A < 0) for z_eff ≳ 0.6",
+        "status": "Disfavoured by positive ISW detections"
+      }
+    },
+    "category_3": {
+      "name": "Revise cancellation metric",
+      "description": "Cancellation index C not applicable under growth-driven ISW",
+      "original_metric": "C = 1 - |Σ C_tot| / (|Σ C_Kμ| + |Σ C_Kμ'|)",
+      "revised_status": "Not applicable (no K_μ' channel exists)"
+    }
+  },
+  "revised_predictions": {
+    "description": "Growth-driven channel; ℓ ∈ [2, 60]",
+    "tracers": [
+      {
+        "name": "LRGz0",
+        "z_eff": 0.510,
+        "A_ISW_original": 0.56,
+        "A_ISW_revised": 0.87,
+        "original_status": "withdrawn"
+      },
+      {
+        "name": "LRGz1",
+        "z_eff": 0.706,
+        "A_ISW_original": 0.43,
+        "A_ISW_revised": 0.87,
+        "original_status": "withdrawn"
+      },
+      {
+        "name": "LRGz2",
+        "z_eff": 0.930,
+        "A_ISW_original": 0.33,
+        "A_ISW_revised": 0.89,
+        "original_status": "withdrawn"
+      },
+      {
+        "name": "LRG+ELG",
+        "z_eff": 0.930,
+        "A_ISW_original": 0.29,
+        "A_ISW_revised": 0.89,
+        "original_status": "withdrawn"
+      },
+      {
+        "name": "ELG",
+        "z_eff": 1.317,
+        "A_ISW_original": 0.15,
+        "A_ISW_revised": 0.92,
+        "original_status": "withdrawn"
+      },
+      {
+        "name": "QSO",
+        "z_eff": 1.491,
+        "A_ISW_original": 0.20,
+        "A_ISW_revised": 0.90,
+        "original_status": "withdrawn"
+      }
+    ],
+    "summary": {
+      "A_ISW_range": [0.87, 0.92],
+      "A_ISW_mean": 0.89,
+      "A_ISW_uncertainty": 0.03,
+      "suppression_percent": 11,
+      "z_dependence": "negligible"
+    }
+  },
+  "preserved_elements": [
+    {
+      "element": "Growth ODE",
+      "status": "Correct",
+      "note": "μ(a) in growth equation is well-defined"
+    },
+    {
+      "element": "μ(a) parameterisation",
+      "status": "Correct",
+      "parameters": {
+        "beta": 0.16,
+        "a_t": 0.55,
+        "sigma": 0.25
+      }
+    },
+    {
+      "element": "Limber approximation",
+      "status": "Valid",
+      "note": "Exact non-Limber differs by < 3%"
+    },
+    {
+      "element": "Tracer definitions",
+      "status": "Valid",
+      "note": "DESI DR1 bins and bias values unchanged"
+    },
+    {
+      "element": "H(a) background",
+      "status": "Valid",
+      "note": "Fiducial ΛCDM background is correct"
+    },
+    {
+      "element": "Qualitative prediction",
+      "status": "Valid",
+      "note": "EFC predicts A_ISW < 1 for all tracers"
+    }
+  ],
+  "falsification": {
+    "original": {
+      "criterion": "C > 0.7, A < 0.5 at z_t",
+      "key_discriminator": "Tomographic C gradient"
+    },
+    "revised": {
+      "criterion": "A_ISW = 1.00 ± 0.05 across all bins",
+      "exclusion_level": "> 2σ",
+      "key_discriminator": "Uniform 11% suppression in multi-tracer stack",
+      "positive_evidence": "A_ISW < 0.9 across multiple bins"
+    }
+  },
+  "validation_ledger_update": {
+    "current_version": "v1.6",
+    "target_version": "v1.7",
+    "changes": {
+      "status": {
+        "from": "Completed (no observational conflict)",
+        "to": "Under revision"
+      },
+      "A_ISW": {
+        "from": "0.29–0.56 (bias-calibrated)",
+        "to": "0.87–0.92 (growth-driven, self-consistent)"
+      },
+      "C": {
+        "from": "0.59–0.96",
+        "to": "Not applicable (growth-driven)"
+      }
+    }
+  },
+  "implementation": {
+    "applies_to": "DOI: 10.6084/m9.figshare.31301953",
+    "code_files": [
+      "isw_channel_test.py",
+      "isw_amplitude_fit.py"
+    ],
+    "revised_version_suffix": "v2—corrected"
+  },
+  "keywords": [
+    "ISW effect",
+    "integrated Sachs-Wolfe",
+    "cross-correlation",
+    "DESI DR1",
+    "Energy-Flow Cosmology",
+    "EFC",
+    "revision patch",
+    "consistency audit",
+    "growth-driven",
+    "A_ISW"
+  ]
+}

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/src/isw_revision.py
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/src/isw_revision.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""
+ISW Revision Patch - Reference Implementation
+
+Reference implementation for the revised ISW cross-correlation predictions
+following the ISW Consistency Audit v1.1.
+
+Paper: "ISW Paper Revision Patch: Proposed Corrections to ISW Cross-Correlation
+       Predictions for EFC with DESI DR1 Tracers"
+DOI: 10.6084/m9.figshare.31329082
+"""
+
+import numpy as np
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+from enum import Enum
+
+
+class ISWChannel(Enum):
+    """ISW channel interpretation."""
+    GROWTH_DRIVEN = "growth_driven"
+    POTENTIAL_DRIVEN = "potential_driven"
+
+
+@dataclass
+class MuParameters:
+    """μ(a) parameterisation (unchanged from original)."""
+    beta: float = 0.16
+    a_t: float = 0.55
+    sigma: float = 0.25
+
+    def mu(self, a: float) -> float:
+        """
+        Compute μ(a) = 1 + β × exp[-(a - a_t)² / (2σ²)]
+
+        Parameters
+        ----------
+        a : float
+            Scale factor
+
+        Returns
+        -------
+        float
+            μ(a) value
+        """
+        return 1.0 + self.beta * np.exp(-(a - self.a_t)**2 / (2 * self.sigma**2))
+
+    def dmu_dlna(self, a: float) -> float:
+        """
+        Compute dμ/d ln a (needed for potential-driven channel).
+
+        Parameters
+        ----------
+        a : float
+            Scale factor
+
+        Returns
+        -------
+        float
+            dμ/d ln a value
+        """
+        delta = a - self.a_t
+        return -self.beta * (a * delta / self.sigma**2) * np.exp(-delta**2 / (2 * self.sigma**2))
+
+
+@dataclass
+class TracerPrediction:
+    """ISW prediction for a single tracer."""
+    name: str
+    z_eff: float
+    A_ISW_original: float
+    A_ISW_revised: float
+    original_status: str = "withdrawn"
+    cancellation_index: Optional[float] = None
+
+    @property
+    def suppression_original(self) -> float:
+        """Original claimed suppression relative to ΛCDM."""
+        return (1 - self.A_ISW_original) * 100
+
+    @property
+    def suppression_revised(self) -> float:
+        """Revised suppression relative to ΛCDM."""
+        return (1 - self.A_ISW_revised) * 100
+
+    def to_dict(self) -> Dict:
+        """Convert to dictionary."""
+        return {
+            "name": self.name,
+            "z_eff": self.z_eff,
+            "A_ISW_original": self.A_ISW_original,
+            "A_ISW_revised": self.A_ISW_revised,
+            "original_status": self.original_status,
+            "suppression_original_percent": self.suppression_original,
+            "suppression_revised_percent": self.suppression_revised
+        }
+
+
+class RevisedISWPredictions:
+    """
+    Revised ISW predictions following the Consistency Audit.
+
+    Key changes:
+    - A_ISW is nearly z-independent (0.87–0.92)
+    - Suppression is ~11% relative to ΛCDM, not 44–85%
+    - Cancellation metric C is not applicable under growth-driven ISW
+    """
+
+    def __init__(self):
+        self._predictions = self._load_predictions()
+        self.mu_params = MuParameters()
+
+    def _load_predictions(self) -> Dict[str, TracerPrediction]:
+        """Load revised predictions from Table 2."""
+        data = [
+            ("LRGz0", 0.510, 0.56, 0.87),
+            ("LRGz1", 0.706, 0.43, 0.87),
+            ("LRGz2", 0.930, 0.33, 0.89),
+            ("LRG+ELG", 0.930, 0.29, 0.89),
+            ("ELG", 1.317, 0.15, 0.92),
+            ("QSO", 1.491, 0.20, 0.90),
+        ]
+
+        predictions = {}
+        for name, z_eff, A_orig, A_rev in data:
+            predictions[name] = TracerPrediction(
+                name=name,
+                z_eff=z_eff,
+                A_ISW_original=A_orig,
+                A_ISW_revised=A_rev
+            )
+        return predictions
+
+    @property
+    def tracers(self) -> List[str]:
+        """List of tracer names."""
+        return list(self._predictions.keys())
+
+    def get_original(self, tracer: str) -> float:
+        """Get original (withdrawn) A_ISW value."""
+        return self._predictions[tracer].A_ISW_original
+
+    def get_revised(self, tracer: str) -> float:
+        """Get revised A_ISW value."""
+        return self._predictions[tracer].A_ISW_revised
+
+    def get_prediction(self, tracer: str) -> TracerPrediction:
+        """Get full prediction for a tracer."""
+        return self._predictions[tracer]
+
+    @property
+    def mean_revised(self) -> float:
+        """Mean revised A_ISW across all tracers."""
+        return np.mean([p.A_ISW_revised for p in self._predictions.values()])
+
+    @property
+    def std_revised(self) -> float:
+        """Standard deviation of revised A_ISW."""
+        return np.std([p.A_ISW_revised for p in self._predictions.values()])
+
+    def summary(self) -> Dict:
+        """
+        Get summary of revised predictions.
+
+        Returns
+        -------
+        Dict
+            Summary statistics
+        """
+        revised_values = [p.A_ISW_revised for p in self._predictions.values()]
+        original_values = [p.A_ISW_original for p in self._predictions.values()]
+
+        return {
+            "A_ISW_revised_mean": np.mean(revised_values),
+            "A_ISW_revised_std": np.std(revised_values),
+            "A_ISW_revised_range": [min(revised_values), max(revised_values)],
+            "A_ISW_original_mean": np.mean(original_values),
+            "A_ISW_original_range": [min(original_values), max(original_values)],
+            "suppression_revised_percent": (1 - np.mean(revised_values)) * 100,
+            "suppression_original_percent": (1 - np.mean(original_values)) * 100,
+            "z_dependence": "negligible" if np.std(revised_values) < 0.05 else "significant"
+        }
+
+    def comparison_table(self) -> str:
+        """
+        Generate comparison table of original vs revised predictions.
+
+        Returns
+        -------
+        str
+            Formatted table
+        """
+        lines = [
+            "Tracer    z_eff   Original  Revised   Change",
+            "-" * 50
+        ]
+
+        for tracer in self.tracers:
+            p = self._predictions[tracer]
+            change = p.A_ISW_revised - p.A_ISW_original
+            lines.append(
+                f"{p.name:8s}  {p.z_eff:.3f}   {p.A_ISW_original:.2f}      "
+                f"{p.A_ISW_revised:.2f}      {change:+.2f}"
+            )
+
+        return "\n".join(lines)
+
+
+class ChannelComparison:
+    """
+    Compare growth-driven and potential-driven ISW channels.
+
+    The key insight from the Audit is that these give qualitatively
+    different predictions that distinguish EFC interpretations.
+    """
+
+    def __init__(self):
+        self.mu_params = MuParameters()
+        self._growth_driven_A = 0.89
+        self._growth_driven_uncertainty = 0.03
+
+    @property
+    def growth_driven(self) -> float:
+        """Growth-driven A_ISW prediction."""
+        return self._growth_driven_A
+
+    @property
+    def growth_driven_uncertainty(self) -> float:
+        """Uncertainty on growth-driven prediction."""
+        return self._growth_driven_uncertainty
+
+    def potential_driven_prediction(self, z_eff: float) -> str:
+        """
+        Potential-driven prediction at given redshift.
+
+        Parameters
+        ----------
+        z_eff : float
+            Effective redshift
+
+        Returns
+        -------
+        str
+            Qualitative prediction
+        """
+        if z_eff >= 0.6:
+            return "Anti-correlation (A < 0)"
+        else:
+            return "Positive but enhanced"
+
+    def comparison_summary(self) -> Dict:
+        """
+        Summary comparison of channels.
+
+        Returns
+        -------
+        Dict
+            Channel comparison
+        """
+        return {
+            "growth_driven": {
+                "potential_relation": "Φ ∝ D(a)/a",
+                "mu_role": "μ affects ISW only through D(a) and f(a)",
+                "isw_source": "S ∝ H(a)(D/a)(1-f)",
+                "A_ISW": f"{self._growth_driven_A:.2f} ± {self._growth_driven_uncertainty:.2f}",
+                "z_dependence": "negligible",
+                "cancellation_metric": "not applicable"
+            },
+            "potential_driven": {
+                "potential_relation": "Φ ∝ μ(a)·D(a)/a",
+                "additional_term": "dμ/d ln a in ISW kernel",
+                "prediction_low_z": "Positive A_ISW",
+                "prediction_high_z": "Anti-correlation (A < 0) for z > 0.6",
+                "status": "Disfavoured by positive ISW detections"
+            }
+        }
+
+
+@dataclass
+class FalsificationCriteria:
+    """
+    Revised falsification criteria for EFC ISW predictions.
+    """
+
+    # Revised criteria
+    exclusion_threshold: float = 1.00
+    exclusion_uncertainty: float = 0.05
+    exclusion_significance: str = "> 2σ"
+
+    # Positive evidence
+    positive_evidence_threshold: float = 0.9
+
+    # Original criteria (now deprecated)
+    original_C_threshold: float = 0.7
+    original_A_threshold: float = 0.5
+
+    def is_excluded(self, A_ISW_observed: float, uncertainty: float) -> Tuple[bool, str]:
+        """
+        Check if EFC is excluded by observation.
+
+        Parameters
+        ----------
+        A_ISW_observed : float
+            Observed A_ISW value
+        uncertainty : float
+            Measurement uncertainty
+
+        Returns
+        -------
+        Tuple[bool, str]
+            (excluded, explanation)
+        """
+        if abs(A_ISW_observed - 1.0) < self.exclusion_uncertainty + uncertainty:
+            return True, f"A_ISW = {A_ISW_observed:.2f} ± {uncertainty:.2f} consistent with ΛCDM; EFC excluded at {self.exclusion_significance}"
+        return False, "EFC not excluded"
+
+    def is_positive_evidence(self, A_ISW_observed: float) -> Tuple[bool, str]:
+        """
+        Check if observation provides positive evidence for EFC.
+
+        Parameters
+        ----------
+        A_ISW_observed : float
+            Observed A_ISW value
+
+        Returns
+        -------
+        Tuple[bool, str]
+            (positive_evidence, explanation)
+        """
+        if A_ISW_observed < self.positive_evidence_threshold:
+            return True, f"A_ISW = {A_ISW_observed:.2f} < 0.9 constitutes positive evidence for EFC"
+        return False, "No positive evidence (within ΛCDM expectations)"
+
+    def summary(self) -> Dict:
+        """Get summary of falsification criteria."""
+        return {
+            "revised": {
+                "exclusion": f"A_ISW = {self.exclusion_threshold:.2f} ± {self.exclusion_uncertainty:.2f} across all bins",
+                "exclusion_level": self.exclusion_significance,
+                "positive_evidence": f"A_ISW < {self.positive_evidence_threshold:.1f} across multiple bins",
+                "key_discriminator": "Uniform 11% suppression in multi-tracer stack"
+            },
+            "original_deprecated": {
+                "C_threshold": self.original_C_threshold,
+                "A_threshold": self.original_A_threshold,
+                "note": "No longer applicable under growth-driven interpretation"
+            }
+        }
+
+
+class ValidationLedgerUpdate:
+    """
+    Track validation ledger changes from v1.6 to v1.7.
+    """
+
+    @staticmethod
+    def changes() -> Dict:
+        """Get ledger changes."""
+        return {
+            "version_from": "v1.6",
+            "version_to": "v1.7",
+            "field_changes": {
+                "Status": {
+                    "from": "Completed (no observational conflict)",
+                    "to": "Under revision"
+                },
+                "A_ISW": {
+                    "from": "0.29–0.56 (bias-calibrated)",
+                    "to": "0.87–0.92 (growth-driven, self-consistent)"
+                },
+                "C": {
+                    "from": "0.59–0.96",
+                    "to": "Not applicable (growth-driven)"
+                },
+                "Falsification": {
+                    "from": "C > 0.7, A < 0.5 at z_t",
+                    "to": "A_ISW = 1.00 ± 0.05 across all bins"
+                },
+                "Key_discriminator": {
+                    "from": "Tomographic C gradient",
+                    "to": "Uniform 11% suppression in multi-tracer stack"
+                }
+            }
+        }
+
+
+# Convenience functions
+def get_revised_prediction(tracer: str) -> float:
+    """Get revised A_ISW for a tracer."""
+    return RevisedISWPredictions().get_revised(tracer)
+
+
+def get_all_predictions() -> Dict[str, float]:
+    """Get all revised predictions."""
+    pred = RevisedISWPredictions()
+    return {t: pred.get_revised(t) for t in pred.tracers}
+
+
+def check_falsification(A_ISW_observed: float, uncertainty: float = 0.05) -> str:
+    """Check falsification status."""
+    criteria = FalsificationCriteria()
+    excluded, msg = criteria.is_excluded(A_ISW_observed, uncertainty)
+    if excluded:
+        return msg
+    positive, msg = criteria.is_positive_evidence(A_ISW_observed)
+    return msg
+
+
+if __name__ == "__main__":
+    # Quick demonstration
+    print("ISW Revision Patch - Quick Summary")
+    print("=" * 50)
+
+    predictions = RevisedISWPredictions()
+    print(predictions.comparison_table())
+
+    print("\n" + "=" * 50)
+    summary = predictions.summary()
+    print(f"Revised mean A_ISW: {summary['A_ISW_revised_mean']:.2f} ± {summary['A_ISW_revised_std']:.2f}")
+    print(f"Suppression: {summary['suppression_revised_percent']:.1f}%")
+    print(f"z-dependence: {summary['z_dependence']}")


### PR DESCRIPTION
Adds machine-readable package for "ISW Paper Revision Patch: Proposed Corrections to ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers" (DOI: 10.6084/m9.figshare.31329082)

Contents:
- README.md with revision categories and comparison tables
- index.json with metadata, original vs revised predictions
- src/isw_revision.py implementing revision analysis
- data/revised_predictions.json with corrected A_ISW values
- examples/isw_revision_demo.py demonstration script
- CITATION.cff and LICENSE

Key corrections:
- Original A_ISW (0.56→0.15) withdrawn; cannot be reproduced
- Revised: A_ISW ≈ 0.89 ± 0.03 (uniform ~11% suppression)
- Growth-driven vs potential-driven channel clarification
- Cancellation metric C not applicable under growth-driven ISW
- Falsification: A_ISW = 1.00 ± 0.05 excludes EFC at >2σ

https://claude.ai/code/session_01DU4ATUVjhJgkqLDz9ZdvzX