### PR TITLE
Update EFC Validation Ledger v2.1 – ISW Consistency Audit v1.1

### DIFF
--- a/docs/public/EFC_Validation_Ledger.html
+++ b/docs/public/EFC_Validation_Ledger.html
@@ -9,7 +9,7 @@
 <body>
 
 <!-- ✅ Energy-Flow Cosmology (EFC) – Complete Validation Ledger
-     Canonical Regime-Aware Version – February 2026 (v2.0.1) -->
+     Canonical Regime-Aware Version – February 2026 (v2.1) -->
 
 <h1>Energy-Flow Cosmology (EFC) – Complete Validation Ledger</h1>
 
@@ -280,7 +280,7 @@ with defined methodologies to ensure transparency and falsifiability.
     <tr style="background-color:#fffef5;"><td style="border:1px solid #ddd; padding:5px;">Weak lensing (Case A)</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">⚪</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">LEN (phenomenological)</td></tr>
     <tr><td style="border:1px solid #ddd; padding:5px;">Weak lensing (Case B)</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">⚪</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">GRW + LEN</td></tr>
     <tr><td style="border:1px solid #ddd; padding:5px;">E<sub>G</sub> statistic (lensing×RSD)</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">⚪</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">BG + LEN</td></tr>
-    <tr style="background-color:#e6ffe6;"><td style="border:1px solid #ddd; padding:5px;">ISW cross-correlation</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">BG</td></tr>
+    <tr style="background-color:#e6ffe6;"><td style="border:1px solid #ddd; padding:5px;">ISW cross-correlation</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">BG → GRW (growth response only; no direct potential coupling)</td></tr>
     <tr><td style="border:1px solid #ddd; padding:5px;">Lyα high-z null test</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">⚪</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">⚪</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">BG (suppressed)</td></tr>
     <tr style="background-color:#e6ffe6;"><td style="border:1px solid #ddd; padding:5px;">Galaxy rotation curves (SPARC)</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">⚪</td><td style="border:1px solid #ddd; padding:5px;">GRW + SCR</td></tr>
     <tr><td style="border:1px solid #ddd; padding:5px;">Cluster lensing geometry</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">✅</td><td style="border:1px solid #ddd; padding:5px; text-align:center;">—</td><td style="border:1px solid #ddd; padding:5px;">LEN + SCR</td></tr>
@@ -572,7 +572,7 @@ with defined methodologies to ensure transparency and falsifiability.
       </td>
     </tr>
 
-    <!-- ISW cross-correlation - UPDATED v1.6 -->
+    <!-- ISW cross-correlation - UPDATED v2.1 (ISW Consistency Audit v1.1) -->
     <tr style="background-color:#e6ffe6;">
       <td style="border:1px solid #ddd; padding:8px;"><strong>ISW cross-correlation</strong></td>
       <td style="border:1px solid #ddd; padding:8px;">Planck × DESI DR1 tracers</td>
@@ -581,11 +581,11 @@ with defined methodologies to ensure transparency and falsifiability.
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">⚪</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">✅</td>
       <td style="border:1px solid #ddd; padding:8px;">
-        L1 linear perturbations: EFC predicts tracer-dependent ISW amplitude suppression via K<sub>μ</sub>/K<sub>μ′</sub> cancellation. Cancellation index 𝒞 increases monotonically from 0.59 (LRGz0, z<sub>eff</sub>=0.51) to 0.96 (ELG, z<sub>eff</sub>=1.32). Bias-calibrated A<sub>ISW</sub> values (0.29–0.56) consistent with all published measurements within 1.6σ (Hang et al. 2021; Ansarinejad et al. 2020). <strong>Definitive discriminator:</strong> DESI tomographic bins overlapping z<sub>t</sub>, where EFC predicts 𝒞 > 0.7 and A<sub>ISW</sub> < 0.5, while ΛCDM has 𝒞 = 0 and A<sub>ISW</sub> = 1.
+        L1 linear perturbations: Under fully self-consistent growth-channel implementation (ODE-based D(a), no potential μ′ term), EFC predicts a uniform late-time ISW amplitude suppression A<sub>ISW</sub> ≈ 0.89 ± 0.03 across tracer bins. No strong tomographic gradient survives internal consistency audit. <strong>Definitive discriminator:</strong> Measured A<sub>ISW</sub> must deviate from unity by ≈10% in a tracer-independent manner. A statistically significant detection of A<sub>ISW</sub> ≈ 1.0 ± 0.02 would disfavor the background-driven EFC channel.
       </td>
-      <td style="border:1px solid #ddd; padding:8px;"><strong>Completed (no observational conflict; falsifiable prediction locked)</strong></td>
+      <td style="border:1px solid #ddd; padding:8px;"><strong>Completed (Self-consistent recomputation; quantitative revision)</strong></td>
       <td style="border:1px solid #ddd; padding:8px;">
-        <a href="https://doi.org/10.6084/m9.figshare.31301953">31301953</a>
+        <a href="https://doi.org/10.6084/m9.figshare.31301953">31301953</a> + ISW Consistency Audit v1.1
       </td>
     </tr>
 
@@ -859,15 +859,15 @@ They constrain EFC phenomenology without providing canonical theoretical validat
       <td style="border:1px solid #ddd; padding:8px;">Sign flip (ρ<sub>sim</sub> &lt; 0, ρ<sub>obs</sub> &gt; 0)</td>
       <td style="border:1px solid #ddd; padding:8px;">Sim–obs mismatch in ICM thermodynamic regulation; motivates entropy-flow physics</td>
     </tr>
-    <!-- ISW cancellation prediction (v1.6) -->
-    <tr style="background-color:#e6ffe6;">
-      <td style="border:1px solid #ddd; padding:8px;"><strong>ISW cancellation prediction (𝒞 metric)</strong></td>
+    <!-- ISW cancellation prediction (v1.6 → DEPRECATED v2.1) -->
+    <tr style="background-color:#fffef5;">
+      <td style="border:1px solid #ddd; padding:8px;"><strong>ISW cancellation metric 𝒞 (DEPRECATED)</strong></td>
       <td style="border:1px solid #ddd; padding:8px;">Planck × DESI DR1 tracer windows (LRGz0, LRGz1, LRG+ELG, ELG)</td>
       <td style="border:1px solid #ddd; padding:8px;">
-        𝒞 = 0.59–0.96 (monotonic); A<sub>ISW</sub> = 0.29–0.56; all published data within 1.6σ
+        Previously: 𝒞 = 0.59–0.96 (monotonic); A<sub>ISW</sub> = 0.29–0.56
       </td>
       <td style="border:1px solid #ddd; padding:8px;">
-        K<sub>μ</sub> and K<sub>μ′</sub> have opposite signs near z<sub>t</sub>; total ISW signal is suppressed residual after cancellation. Shape ratio S<sub>EFC</sub>/S<sub>ΛCDM</sub> ≈ 1 confirms amplitude-only signature. H(a) sensitivity test passed (Δχ² < 1 for δw ≤ 0.05).
+        The previously defined cancellation metric 𝒞 relied on mixed-channel implementation and is no longer considered a canonical observable under growth-driven EFC. Superseded by uniform A<sub>ISW</sub> ≈ 0.89 ± 0.03 under self-consistent ODE-based growth-channel (ISW Consistency Audit v1.1).
       </td>
     </tr>
   </tbody>
@@ -1133,9 +1133,9 @@ does not require new physics but remains a target for Stage-IV precision tests.
   <li><strong>Cluster core entropy–structure coupling – Pre-registered diagnostic test:</strong>
     <a href="https://doi.org/10.6084/m9.figshare.31286368">31286368</a></li>
 
-  <!-- ISW cross-correlation (v1.6) -->
-  <li><strong>ISW cross-correlation predictions and cancellation metrics (DESI DR1 tracers):</strong>
-    <a href="https://doi.org/10.6084/m9.figshare.31301953">31301953</a></li>
+  <!-- ISW cross-correlation (v1.6 → revised v2.1) -->
+  <li><strong>ISW cross-correlation predictions (DESI DR1 tracers; revised under ISW Consistency Audit v1.1):</strong>
+    <a href="https://doi.org/10.6084/m9.figshare.31301953">31301953</a> + ISW Consistency Audit v1.1</li>
 
   <!-- v1.7 additions -->
   <li><strong>Four-channel background coupling architecture test (β·T(a)):</strong>
@@ -1192,8 +1192,8 @@ does not require new physics but remains a target for Stage-IV precision tests.
   <li><strong>DES Y3 cross-validation</strong> – replicate KiDS-1000 Case A test on independent dataset (v1.4)</li>
   <li><strong>Case B implementation</strong> – consistent MG with μ in perturbation growth equations (v1.4)</li>
   <li><strong>Cluster shock-front lensing asymmetry</strong> – execute pre-registered A<sub>sig</sub> directional residual test on JWST κ maps (v1.5)</li>
-  <!-- ISW tomographic validation (v1.6) -->
-  <li><strong>ISW tomographic validation</strong> – execute 𝒞-metric test on DESI DR1 × Planck measured C<sub>ℓ</sub><sup>Tg</sup> when published (v1.6)</li>
+  <!-- ISW amplitude validation (v1.6 → revised v2.1) -->
+  <li><strong>ISW amplitude validation</strong> – measure tracer-independent A<sub>ISW</sub> on DESI DR1 × Planck C<sub>ℓ</sub><sup>Tg</sup> when published; EFC predicts uniform A<sub>ISW</sub> ≈ 0.89 ± 0.03 (𝒞-metric tomographic test deprecated under ISW Consistency Audit v1.1) (v2.1)</li>
   <!-- v1.7 additions -->
   <li><strong>β-split test (distance vs growth)</strong> – constrain propagation-limit coupling ε using DESI DR3 + Euclid; evidence basis: <a href="https://doi.org/10.6084/m9.figshare.31305421">31305421</a> (v1.7)</li>
   <li><strong>Standard sirens (GW vs EM distances)</strong> – sector-dependent propagation test (Einstein Telescope era) (v1.7)</li>
@@ -1204,6 +1204,9 @@ does not require new physics but remains a target for Stage-IV precision tests.
 <h2>6. Update Log</h2>
 
 <ul>
+  <!-- v2.1 entry -->
+  <li><strong>2026-02-12 (v2.1)</strong> – ISW Consistency Audit v1.1 applied. Removed tomographic cancellation metric 𝒞 from canonical prediction set. Recomputed A<sub>ISW</sub> under fully self-consistent growth-channel implementation (ODE-based D(a), no potential μ′ term). Revised prediction: uniform suppression A<sub>ISW</sub> ≈ 0.89 ± 0.03 across tracers. Updated ISW row status from "Completed (no observational conflict; falsifiable prediction locked)" to "Completed (Self-consistent recomputation; quantitative revision)". Deprecated 𝒞-metric in Section 1.1 Phenomenological Constraints. Updated ISW sector in Regime × Observable Matrix to "BG → GRW (growth response only; no direct potential coupling)". Updated ISW planned pipeline entry from 𝒞-metric tomographic test to uniform A<sub>ISW</sub> amplitude validation.</li>
+
   <!-- v2.0.1 entry -->
   <li><strong>2026-02-11 (v2.0.1)</strong> – KB synchronization update: Added Section 2.3 S₈ Stage-III Convergence table with DEPRECATED/CURRENT framing (KiDS Legacy 0.815, HSC Y3 0.805, Combined 0.813). Standardized three "Completed" rows to follow the 9-level status system: Galaxy rotation curves → Data Likelihood Test; Δ<sub>F</sub> regime transition → Consistency Check; H₀ tension → Consistency Check.</li>
 
@@ -1274,7 +1277,7 @@ does not require new physics but remains a target for Stage-IV precision tests.
 </ul>
 
 <p style="font-size:13px; color:#666;">
-© 2026 Energy-Flow Cosmology Initiative · Canonical Validation Ledger (v2.0.1)
+© 2026 Energy-Flow Cosmology Initiative · Canonical Validation Ledger (v2.1)
 </p>
 
 </body>


### PR DESCRIPTION
Apply ISW revision under self-consistent growth-channel recomputation:
- Replace tomographic cancellation metric C with uniform A_ISW ≈ 0.89 ± 0.03
- Update ISW row status, falsification criterion, and regime interpretation
- Deprecate C-metric in Section 1.1 Phenomenological Constraints
- Update ISW sector in Regime × Observable Matrix to BG → GRW
- Revise planned pipeline from C-metric test to A_ISW amplitude validation
- Add v2.1 entry to Update Log

https://claude.ai/code/session_01Tzsw4JRrQr1zHf16mGrrF5