### PR TITLE
Add MVP-G1 Growth fσ8 LOO robustness test to validation ledger

### DIFF
--- a/docs/validation-ledger/data/changelog.json
+++ b/docs/validation-ledger/data/changelog.json
@@ -5,6 +5,18 @@
   "period_days": 7,
   "changes": [
     {
+      "name": "MVP-G1 Growth fσ8 LOO Robustness (N2a)",
+      "status": "COMPLETE",
+      "result": "α = −1.00 ± 0.46 (2.20σ); 7/7 LOO pass; robust hint for α<0 in EFC growth channel",
+      "last_updated": "2026-02-13T00:00:00Z",
+      "source": null,
+      "all_labels": [
+        "EFCValidation",
+        "PhenomenologicalTest",
+        "GrowthSector"
+      ]
+    },
+    {
       "name": "Strong Lens Time Delay Conflict",
       "status": "unresolved",
       "result": null,

--- a/docs/validation-ledger/data/ledger.json
+++ b/docs/validation-ledger/data/ledger.json
@@ -6,10 +6,10 @@
   "stats": {
     "physics_test": 2,
     "consistency_check": 9,
-    "phenomenological": 6,
+    "phenomenological": 7,
     "framework_constraint": 5,
     "planned_pipeline": 12,
-    "total_public": 34,
+    "total_public": 35,
     "inference_count": 6,
     "chi2_summary": "N/A, N/A, 0.00, N/A, N/A, 10.39",
     "hypothesis_count": 15,
@@ -277,6 +277,21 @@
         "quantitative_result": "",
         "last_synced": "2026-02-11T18:40:54.859771Z",
         "status_detail": "partial"
+      },
+      {
+        "test_id": "ledger_mvpg1_growth_fs8_loo_robustness_n2a",
+        "name": "MVP-G1 Growth: fσ8 Leave-One-Out robustness (N2a)",
+        "description": "fσ8_extended (7 pts, z=0.02–0.85) + BAO(14); N2a-mode: rd=147.09, σ8~N(0.81,0.02)",
+        "result": "Completed (robust hint) — α = −1.00 ± 0.46 (2.20σ); 7/7 LOO pass |α|/σ ≥ 1.7 AND ΔAIC ≤ 0; LOO range [−1.11, −0.88]",
+        "status": "success",
+        "vl_category": "phenomenological",
+        "also_phenomenological": true,
+        "data_source": "fσ8_extended (7 pts, z=0.02–0.85) + BAO(14)",
+        "prediction": "Late-time growth suppression consistent with α<0 in Hubble friction channel (background→growth response)",
+        "notes": "MVP-G1 Growth: fσ8 Leave-One-Out robustness (N2a) | ✅ | ⚪ | ✅ | T7 Leave-One-Out robustness (fσ8, N2a-mode): 7/7 LOO runs pass (|α|/σ ≥ 1.7 AND ΔAIC ≤ 0). α-estimate extremely stable: α = −1.00 ± 0.46 (2.20σ), LOO-range [−1.11, −0.88], spread only 0.23. No single fσ8 measurement drives the hint; lowest significance at z=0.02 drop (1.84σ, ΔAIC=−1.59), highest at z=0.15 drop (2.42σ, ΔAIC=−3.97). Correlations stable across LOO: corr(α,Ωm) ≈ +0.59, corr(α,σ8) ≈ −0.26. Full MVP-G1 control suite passed: N1 rd-independence, N2 σ8-prior strengthening (2.20σ under tight prior), T7 LOO robustness (7/7). Conclusion: Robust, distributed ~2σ preference for α<0 in EFC growth channel under rd-fixing and tight σ8-prior; signal is structural, not artefactual.",
+        "quantitative_result": "α = −1.00 ± 0.46 (2.20σ); ΔAIC = −2.91; LOO 7/7 pass; |α|/σ range [1.84, 2.42]; ΔAIC range [−3.97, −1.59]; corr(α,Ωm)≈+0.59; corr(α,σ8)≈−0.26",
+        "last_synced": "2026-02-13T00:00:00Z",
+        "status_detail": "completed_robust_hint"
       }
     ],
     "framework_constraint": [
@@ -1715,6 +1730,18 @@
     }
   ],
   "changelog": [
+    {
+      "name": "MVP-G1 Growth fσ8 LOO Robustness (N2a)",
+      "status": "COMPLETE",
+      "result": "α = −1.00 ± 0.46 (2.20σ); 7/7 LOO pass; robust hint for α<0 in EFC growth channel",
+      "last_updated": "2026-02-13T00:00:00Z",
+      "source": null,
+      "all_labels": [
+        "EFCValidation",
+        "PhenomenologicalTest",
+        "GrowthSector"
+      ]
+    },
     {
       "name": "Strong Lens Time Delay Conflict",
       "status": "unresolved",

--- a/docs/validation-ledger/data/stats.json
+++ b/docs/validation-ledger/data/stats.json
@@ -5,10 +5,10 @@
   "stats": {
     "physics_test": 2,
     "consistency_check": 9,
-    "phenomenological": 6,
+    "phenomenological": 7,
     "framework_constraint": 5,
     "planned_pipeline": 12,
-    "total_public": 34,
+    "total_public": 35,
     "inference_count": 6,
     "chi2_summary": "N/A, N/A, 0.00, N/A, N/A, 10.39",
     "hypothesis_count": 15,

--- a/docs/validation-ledger/data/tests.json
+++ b/docs/validation-ledger/data/tests.json
@@ -262,6 +262,21 @@
         "quantitative_result": "",
         "last_synced": "2026-02-11T18:40:54.859771Z",
         "status_detail": "partial"
+      },
+      {
+        "test_id": "ledger_mvpg1_growth_fs8_loo_robustness_n2a",
+        "name": "MVP-G1 Growth: fσ8 Leave-One-Out robustness (N2a)",
+        "description": "fσ8_extended (7 pts, z=0.02–0.85) + BAO(14); N2a-mode: rd=147.09, σ8~N(0.81,0.02)",
+        "result": "Completed (robust hint) — α = −1.00 ± 0.46 (2.20σ); 7/7 LOO pass |α|/σ ≥ 1.7 AND ΔAIC ≤ 0; LOO range [−1.11, −0.88]",
+        "status": "success",
+        "vl_category": "phenomenological",
+        "also_phenomenological": true,
+        "data_source": "fσ8_extended (7 pts, z=0.02–0.85) + BAO(14)",
+        "prediction": "Late-time growth suppression consistent with α<0 in Hubble friction channel (background→growth response)",
+        "notes": "MVP-G1 Growth: fσ8 Leave-One-Out robustness (N2a) | ✅ | ⚪ | ✅ | T7 Leave-One-Out robustness (fσ8, N2a-mode): 7/7 LOO runs pass (|α|/σ ≥ 1.7 AND ΔAIC ≤ 0). α-estimate extremely stable: α = −1.00 ± 0.46 (2.20σ), LOO-range [−1.11, −0.88], spread only 0.23. No single fσ8 measurement drives the hint; lowest significance at z=0.02 drop (1.84σ, ΔAIC=−1.59), highest at z=0.15 drop (2.42σ, ΔAIC=−3.97). Correlations stable across LOO: corr(α,Ωm) ≈ +0.59, corr(α,σ8) ≈ −0.26. Full MVP-G1 control suite passed: N1 rd-independence, N2 σ8-prior strengthening (2.20σ under tight prior), T7 LOO robustness (7/7). Conclusion: Robust, distributed ~2σ preference for α<0 in EFC growth channel under rd-fixing and tight σ8-prior; signal is structural, not artefactual.",
+        "quantitative_result": "α = −1.00 ± 0.46 (2.20σ); ΔAIC = −2.91; LOO 7/7 pass; |α|/σ range [1.84, 2.42]; ΔAIC range [−3.97, −1.59]; corr(α,Ωm)≈+0.59; corr(α,σ8)≈−0.26",
+        "last_synced": "2026-02-13T00:00:00Z",
+        "status_detail": "completed_robust_hint"
       }
     ],
     "framework_constraint": [
@@ -524,5 +539,5 @@
       }
     ]
   },
-  "total_count": 34
+  "total_count": 35
 }

--- a/docs/validation-ledger/index.md
+++ b/docs/validation-ledger/index.md
@@ -6,7 +6,7 @@ _Version: v2.1 (auto-generated) — Regime-structured falsification methodology_
 
 ## Executive Summary
 
-The Energy-Flow Cosmology (EFC) validation ledger reports 2 physics tests, 9 consistency checks, and 6 phenomenological fits, with no confirmed falsifications to date. Theory coherence is maintained at compression=1.33 and mismatch=0.25. Recent updates include the resolution of the Monotonic Radial Boost Problem and completion of EFC-Y6 compressed likelihood analysis.
+The Energy-Flow Cosmology (EFC) validation ledger reports 2 physics tests, 9 consistency checks, and 7 phenomenological fits, with no confirmed falsifications to date. Theory coherence is maintained at compression=1.33 and mismatch=0.25. Recent updates include the resolution of the Monotonic Radial Boost Problem and completion of EFC-Y6 compressed likelihood analysis.
 
 ## Status Classification System
 
@@ -92,7 +92,7 @@ _Legend: ✓ = Primary sensitivity, (suppressed) = Secondary/consistency, — = 
 
 ## Empirical Validation Status
 
-_34 tests tracked: 2 physics, 9 consistency, 6 phenomenological, 5 structural, 12 planned — **0 confirmed falsifications**_
+_35 tests tracked: 2 physics, 9 consistency, 7 phenomenological, 5 structural, 12 planned — **0 confirmed falsifications**_
 
 
 ### 🔬 Physics Tests — Data Likelihood Comparisons (2)
@@ -122,7 +122,7 @@ _EFC predicts minimal deviation; observations show no contradiction._
 | 9 | Solar System / PPN / EP | Cassini / LLR / perihelion | ⚪ | Quantitative compatibility supported (screened regime) |
 
 
-### 🟡 Phenomenological Fits — Not Field-Derived (6)
+### 🟡 Phenomenological Fits — Not Field-Derived (7)
 
 _Temporary parameterizations tested empirically but not derived from EFC field theory._
 
@@ -134,6 +134,7 @@ _Temporary parameterizations tested empirically but not derived from EFC field t
 | 4 | Galaxy bias evolution consistency | BOSS, DESI clustering + lensing cross-correlation | ⚪ | Planned – bias-growth joint modeling |
 | 5 | Weak-lensing phenomenological closure (Postulate A) | — | Demonstrates absence of a derived lensing coupling; introduces temporary phenomenological closure pending action-level derivation. Density Saturation (v1.3) provides path to replace this closure with  | — |
 | 6 | Weak-lensing shear (Case A) | KiDS-1000 Flinc ξ± | KiDS-1000 Flinc ξ± | αL2= 0.10 ± 0.01; Δ(−2 ln L) = −50.9S₈ = 0.685 (EFC) vs 0.739 (ΛCDM) |
+| 7 | MVP-G1 Growth: fσ8 Leave-One-Out robustness (N2a) | fσ8_extended (7 pts, z=0.02–0.85) + BAO(14) | Late-time growth suppression consistent with α<0 in Hubble friction channel | Completed (robust hint) — α = −1.00 ± 0.46 (2.20σ); 7/7 LOO pass; LOO range [−1.11, −0.88]; ΔAIC range [−3.97, −1.59] |
 
 
 ### 🔧 Framework Constraints — Model-Space Structure (5)
@@ -347,6 +348,7 @@ _Requires next-generation surveys or novel methodology._
 
 ## Recent Changes (last 7 days)
 
+- **2026-02-13** — MVP-G1 Growth fσ8 LOO Robustness (N2a): status=_COMPLETE_ — α = −1.00 ± 0.46 (2.20σ); 7/7 LOO pass; robust hint for α<0 in EFC growth channel
 - **2026-02-08** — Strong Lens Time Delay Conflict: status=_unresolved_
 - **2026-02-08** — Monotonic Radial Boost Problem: status=_resolved_
 - **2026-02-08** — EFC-Y6 Compressed Likelihood: status=_COMPLETE_


### PR DESCRIPTION
New phenomenological test entry: MVP-G1 Growth fσ8 Leave-One-Out robustness (N2a mode). Results: α = −1.00 ± 0.46 (2.20σ) with 7/7 LOO runs passing |α|/σ ≥ 1.7 AND ΔAIC ≤ 0. Signal is robust and distributed across all growth data points — not a single-point artefact. Full MVP-G1 control suite passed (N1 rd-independence, N2 σ8-prior strengthening, T7 LOO robustness).

Updated: tests.json, ledger.json, stats.json, changelog.json, index.md
Test count: 34 → 35 (phenomenological: 6 → 7)

https://claude.ai/code/session_011Z7NtFAdQrYq8Qksj3KjUf