### PR TITLE
Refine v3.3 ledger per review: dataset, regime, scale, and F7 fixes

### DIFF
--- a/docs/public/EFC_Validation_Ledger.html
+++ b/docs/public/EFC_Validation_Ledger.html
@@ -875,7 +875,7 @@ with defined methodologies to ensure transparency and falsifiability.
     <tr style="background-color:#e6ffe6;">
       <td style="border:1px solid #ddd; padding:8px;"><strong>CMB systematic localization</strong></td>
       <td style="border:1px solid #ddd; padding:8px;">Planck 2018 TT/TE/EE + BAO (BOSS/eBOSS)</td>
-      <td style="border:1px solid #ddd; padding:8px; text-align:center;">⚪</td>
+      <td style="border:1px solid #ddd; padding:8px; text-align:center;">✅</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">✅</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">⚪</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">✅</td>
@@ -942,13 +942,13 @@ with defined methodologies to ensure transparency and falsifiability.
     <!-- B0 fσ₈ bridge test (v3.3) -->
     <tr style="background-color:#e6ffe6;">
       <td style="border:1px solid #ddd; padding:8px;"><strong>B0 f&sigma;<sub>8</sub> bridge test &mdash; sign constraint &mu; &lt; 1</strong></td>
-      <td style="border:1px solid #ddd; padding:8px;">BOSS DR12 RSD f&sigma;<sub>8</sub> (3 pts)</td>
+      <td style="border:1px solid #ddd; padding:8px;">f&sigma;<sub>8</sub> compilation (7 pts, z = 0.38&ndash;0.85)</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">✅</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">⚪</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">⚪</td>
       <td style="border:1px solid #ddd; padding:8px; text-align:center;">⚪</td>
       <td style="border:1px solid #ddd; padding:8px;">
-        f&sigma;<sub>8</sub> independently confirms &mu; &lt; 1 sign: &Delta;&chi;&sup2; = &minus;5.22 (&gt; 2&sigma;) improvement. &mu; &gt; 1 ruled out with &Delta;&chi;&sup2; &gt; +400. This is a CMB-independent sign constraint that breaks the A<sub>L</sub> degeneracy: &mu; &lt; 1 is required by growth data regardless of lensing interpretation.
+        f&sigma;<sub>8</sub> independently confirms &mu; &lt; 1 sign: &Delta;&chi;&sup2; = &minus;5.22 (&gt; 2&sigma;) improvement via F3 tanh filter at k &asymp; 0.05&ndash;0.1 h/Mpc. &mu; &gt; 1 ruled out with &Delta;&chi;&sup2; &gt; +400. Original GRAV-sector screening scale (k<sub>&Lambda;</sub> = 0.0014 h/Mpc) gives &Delta;&chi;&sup2; = &minus;0.01 (no effect), confirming the modification must operate at much larger k than the discrete gravity sector provides. This is a CMB-independent sign constraint that breaks the A<sub>L</sub> degeneracy: &mu; &lt; 1 is required by growth data regardless of lensing interpretation.
       </td>
       <td style="border:1px solid #ddd; padding:8px;"><span style="background:#e6ffe6; padding:1px 6px; border-radius:3px; font-size:11px; font-weight:600;">T2</span> <strong>Completed (sign constraint)</strong></td>
       <td style="border:1px solid #ddd; padding:8px;">
@@ -1621,7 +1621,7 @@ does not require new physics but remains a target for Stage-IV precision tests.
       <td style="border:1px solid #ddd; padding:8px;">&Lambda; as bulk capacity hypothesis fails; screening mechanism requires replacement</td>
     </tr>
     <tr>
-      <td style="border:1px solid #ddd; padding:8px;"><strong>F7</strong></td>
+      <td style="border:1px solid #ddd; padding:8px;"><strong>F7 (theoretical)</strong></td>
       <td style="border:1px solid #ddd; padding:8px;">Relativistic EFC perturbation theory produces &eta; = 1 (no gravitational slip) in the cosmological regime, failing to generate the required &mu;&ndash;&Sigma; split with &mu; &lt; 1 and &Sigma; &gt; 1</td>
       <td style="border:1px solid #ddd; padding:8px;">GRW + LEN (L1)</td>
       <td style="border:1px solid #ddd; padding:8px;">GRAV regime must produce &eta; &ne; 1 at cosmological scales; if relativistic derivation yields &eta; = 1, the perturbation sector cannot match the (&mu;,&Sigma;) survival valley and must be structurally revised</td>


### PR DESCRIPTION
1. B0 bridge dataset: "BOSS DR12 RSD fσ₈ (3 pts)" → "fσ₈ compilation (7 pts, z=0.38–0.85)" to match full paper compilation
2. CMB localization EFC-S: ⚪→✅ (Planck TT+TE+EE+lensing is primary and actively constraining)
3. F7: add "(theoretical)" label to distinguish from observational F1–F6
4. B0 regime: add scale info — F3 tanh at k≈0.05–0.1 h/Mpc vs kΛ=0.0014 h/Mpc (Δχ²=−0.01)

https://claude.ai/code/session_01QCbcF9ck3a33AC6PjXABFY