### PR TITLE
Add AI-friendly package for EFC EFT Ansatz paper

### DIFF
--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/EFC-EFT-Ansatz.jsonld
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/EFC-EFT-Ansatz.jsonld
@@ -1,0 +1,37 @@
+{
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  "name": "Minimal EFC Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-03-06",
+  "version": "v6",
+  "description": "Two complementary EFT ansatze for Energy-Flow Cosmology: scalar-tensor (Horndeski) and vector-tensor formulations. Both use a sigmoid entropy field S(a) to govern the GR-to-modified-gravity transition, targeting mu < 1, eta > 1, Sigma > 1.",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "EFC",
+    "effective field theory",
+    "scalar-tensor",
+    "vector-tensor",
+    "Horndeski",
+    "gravitational slip",
+    "entropy gradients",
+    "modified gravity",
+    "Bellini-Sawicki alpha basis"
+  ],
+  "isPartOf": {
+    "@type": "CreativeWork",
+    "name": "Energy-Flow Cosmology Initiative",
+    "url": "https://energyflow-cosmology.com"
+  },
+  "citation": [
+    {"@type": "ScholarlyArticle", "name": "Bellini & Sawicki 2014", "identifier": "arXiv:1404.3713"},
+    {"@type": "ScholarlyArticle", "name": "Horndeski 1974", "identifier": "doi:10.1007/BF01807638"},
+    {"@type": "ScholarlyArticle", "name": "Zumalacárregui et al. 2017", "identifier": "arXiv:1605.06102"},
+    {"@type": "ScholarlyArticle", "name": "Heisenberg 2019", "identifier": "arXiv:1807.01725"},
+    {"@type": "ScholarlyArticle", "name": "GW170817", "identifier": "arXiv:1710.05834"}
+  ]
+}

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/README.md
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/README.md
@@ -1,0 +1,114 @@
+# Minimal EFC Effective Field Theory Ansatz
+
+**Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients**
+
+| Field | Value |
+|-------|-------|
+| Author | Morten Magnusson |
+| ORCID | 0009-0002-4860-5095 |
+| Version | Research Note v6 — March 6, 2026 |
+| DOI | 10.6084/m9.figshare.31368433 |
+| Status | Proposed EFT completion (not canonical baseline EFC-D) |
+
+## Quick Start
+
+```python
+from src.efc_eft_ansatz import EntropyField, ScalarTensorEFT, VectorTensorEFT, TargetSignature
+
+# Entropy sigmoid
+S = EntropyField(a_t=0.30, Delta=0.3)
+print(f"S(a=0.5) = {S(0.5):.4f}")
+
+# Scalar-tensor alpha functions
+st = ScalarTensorEFT(B0=1.0, M0=1.0, a_t=0.30, Delta=0.3)
+print(f"alpha_B(0.5) = {st.alpha_B(0.5):.4f}")
+print(f"alpha_M(0.5) = {st.alpha_M(0.5):.4f}")
+
+# Target signature
+target = TargetSignature()
+print(f"Required slip: eta > {target.eta_required:.2f}")
+```
+
+## Summary
+
+This note constructs two minimal EFT ansatze for Energy-Flow Cosmology:
+
+### EFC Target Signature
+All three conditions must hold simultaneously in the transition regime (0.5 < z < 1.5):
+
+| Observable | GR value | EFC target | Mechanism |
+|------------|----------|------------|-----------|
+| mu(a) | 1 | ~0.925 | Weakened gravity (growth suppression) |
+| eta(a) = Phi/Psi | 1 | >1.2 | Gravitational slip from entropy gradients |
+| Sigma(a) | 1 | >1 | Enhanced lensing; Sigma = mu(1+eta)/2 |
+
+### Ansatz I: Scalar-Tensor (Horndeski)
+- Maps EFC to Bellini-Sawicki alpha-parameter basis
+- alpha_T = 0 (GW170817 constraint)
+- alpha_B(a) proportional to dS/d(ln a) (braiding from entropy gradient)
+- alpha_M(a) proportional to S(a) (running Planck mass)
+- Free parameters: {B0, M0, a_t, Delta}
+- Immediately testable via hi_class
+
+### Ansatz II: Vector-Tensor (Energy Flow)
+- Dynamical 4-vector J^mu represents physical energy flow
+- Anisotropic stress: pi ~ beta^2 (nabla S)^2 generates Phi != Psi
+- Slip estimate: eta - 1 ~ C_eta beta^2 (nabla S_bar)^2 / (k^2 rho_eff)
+- Free parameters: {beta, m^2, a_t, Delta}
+- Ontologically natural EFC completion
+
+### EFC Entropy Field
+Sigmoid in log scale-factor:
+
+```
+S(a) = [1 + exp(-(ln a - ln a_t) / Delta)]^{-1}
+```
+
+- a_t ≈ 0.30 (z_t ≈ 2.3)
+- Delta ≈ 0.3
+- S → 0 at high z (GR recovery)
+- S → 1 today (maximum modification)
+
+### Key Equations
+
+| Eq | Expression | Description |
+|----|-----------|-------------|
+| (5) | eta = Phi/Psi | Gravitational slip (GR: eta=1) |
+| (7) | Sigma = mu(1+eta)/2 | Lensing function |
+| (8) | eta > 2*Sigma/mu - 1 | Constraint for Sigma > 1 with mu < 1 |
+| (13) | mu(a) = 1 + delta_mu * S(a) | Growth-function ansatz (delta_mu ~ -0.075) |
+| (14) | L_EFC^(S) = M_Pl^2/2 R + K(S,X) + G3(S,X) box S | Scalar-tensor action |
+| (18) | L_EFC^(J) = M_Pl^2/2 R - F^2/4 - m^2 J^2/2 + beta J.nabla S | Vector-tensor action |
+| (21) | eta-1 ~ C_eta beta^2 (nabla S_bar)^2 / (k^2 rho_eff) | Slip from entropy gradient |
+| (24) | eta > 2*Sigma/mu - 1 ~ 1.24 | Required slip for mu=0.925, Sigma=1.05 |
+
+### Stability Conditions
+- Scalar-tensor: Q_S = alpha_K + 3/2 alpha_B^2 > 0 (no ghost), c_S^2 > 0 (no gradient instability)
+- Vector-tensor: m^2 > 0 (no tachyon), beta^2 < beta_max^2 (no ghost)
+
+### Falsification Criterion
+If no parameter region {B0, M0, a_t, Delta} exists with mu < 1, eta > 1, Sigma > 1 simultaneously under stability + CMB + LSS constraints in hi_class, the scalar-tensor ansatz is falsified.
+
+### Open Numerical Questions
+1. Does {B0, M0} region exist with mu < 1, eta > 1, Sigma > 1 simultaneously?
+2. Are stability conditions satisfied across the sigmoid transition?
+3. What is the precise coefficient C_eta in the vector-tensor slip?
+4. Does J^mu action reduce to scalar EFT in isotropic quasi-static limit?
+
+## Caveats
+- This is a *proposed* EFT completion, not canonical baseline EFC-D
+- mu(k,z) and Sigma(k,z) remain outside canonical baseline pending derivation
+- Numerical verification via hi_class/Boltzmann code is required
+- Vector-tensor requires new Boltzmann code implementation
+
+## File Manifest
+| File | Description |
+|------|-------------|
+| `index.json` | Machine-readable metadata and equations |
+| `schema.json` | JSON Schema for validation |
+| `metadata.json` | Package metadata |
+| `EFC-EFT-Ansatz.jsonld` | Schema.org linked data |
+| `citations.bib` | BibTeX references |
+| `src/efc_eft_ansatz.py` | Reference implementation |
+| `data/eft_parameters.json` | Parameter tables and comparison |
+| `examples/eft_demo.py` | Runnable demo |

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/citations.bib
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/citations.bib
@@ -1,0 +1,70 @@
+@article{Bellini2014,
+  author  = {Bellini, Emilio and Sawicki, Ignacy},
+  title   = {Maximal freedom at minimum cost: linear large-scale structure in general modifications of gravity},
+  journal = {JCAP},
+  volume  = {07},
+  pages   = {050},
+  year    = {2014},
+  eprint  = {1404.3713},
+  doi     = {10.1088/1475-7516/2014/07/050}
+}
+
+@article{Horndeski1974,
+  author  = {Horndeski, Gregory W.},
+  title   = {Second-order scalar-tensor field equations in a four-dimensional space},
+  journal = {Int. J. Theor. Phys.},
+  volume  = {10},
+  pages   = {363--384},
+  year    = {1974},
+  doi     = {10.1007/BF01807638}
+}
+
+@article{Zumalacarregui2017,
+  author  = {Zumalac\'{a}rregui, Miguel and Bellini, Emilio and Sawicki, Ignacy and Lesgourgues, Julien and Ferreira, Pedro G.},
+  title   = {hi\_class: Horndeski in the Cosmic Linear Anisotropy Solving System},
+  journal = {JCAP},
+  volume  = {08},
+  pages   = {019},
+  year    = {2017},
+  eprint  = {1605.06102},
+  doi     = {10.1088/1475-7516/2017/08/019}
+}
+
+@article{Heisenberg2019,
+  author  = {Heisenberg, Lavinia},
+  title   = {A systematic approach to generalisations of General Relativity and their cosmological implications},
+  journal = {Phys. Rept.},
+  volume  = {796},
+  pages   = {1--113},
+  year    = {2019},
+  eprint  = {1807.01725},
+  doi     = {10.1016/j.physrep.2018.11.006}
+}
+
+@article{GW170817,
+  author  = {Abbott, B. P. and others},
+  collaboration = {LIGO/Virgo, Fermi/INTEGRAL},
+  title   = {Gravitational Waves and Gamma-Rays from a Binary Neutron Star Merger: GW170817 and GRB 170817A},
+  journal = {ApJL},
+  volume  = {848},
+  pages   = {L13},
+  year    = {2017},
+  eprint  = {1710.05834},
+  doi     = {10.3847/2041-8213/aa920c}
+}
+
+@misc{Magnusson2026EFC,
+  author = {Magnusson, Morten},
+  title  = {Energy-Flow Cosmology --- research notes and validation pipeline},
+  year   = {2025--2026},
+  url    = {https://energyflow-cosmology.com},
+  publisher = {Figshare}
+}
+
+@misc{Magnusson2026EFT,
+  author = {Magnusson, Morten},
+  title  = {Minimal {EFC} Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients},
+  year   = {2026},
+  note   = {Research Note v6},
+  doi    = {10.6084/m9.figshare.31368433}
+}

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/data/eft_parameters.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/data/eft_parameters.json
@@ -1,0 +1,62 @@
+{
+  "paper_doi": "10.6084/m9.figshare.31368433",
+  "conventions": {
+    "metric": "ds^2 = -(1+2Psi)dt^2 + a^2(1-2Phi)dx^2",
+    "slip_definition": "eta = Phi/Psi",
+    "mu_definition": "mu = G_eff/G",
+    "sigma_definition": "Sigma = G_lens/G = mu(1+eta)/2",
+    "GR_values": {"mu": 1, "eta": 1, "sigma": 1}
+  },
+  "target_signature": {
+    "mu": {"value": 0.925, "condition": "< 1"},
+    "eta": {"value": 1.27, "condition": "> 1", "note": "For mu=0.925, Sigma=1.05"},
+    "sigma": {"value": 1.05, "condition": "> 1"},
+    "delta_mu": -0.075,
+    "transition_regime": {"z_min": 0.5, "z_max": 1.5}
+  },
+  "entropy_field": {
+    "a_t": 0.30,
+    "z_t": 2.3,
+    "Delta": 0.3,
+    "S_today": 0.969,
+    "dS_dlna_peak": 0.833
+  },
+  "scalar_tensor_ansatz": {
+    "alpha_T": 0,
+    "alpha_B_form": "B0 * dS/d(ln a)",
+    "alpha_M_form": "M0 * S(a)",
+    "free_parameters": {
+      "B0": {"description": "Braiding amplitude", "range": "to be constrained"},
+      "M0": {"description": "Planck-mass running", "range": "to be constrained"},
+      "a_t": {"value": 0.30, "description": "Transition scale factor"},
+      "Delta": {"value": 0.3, "description": "Transition sharpness"}
+    },
+    "stability": {
+      "no_ghost": "Q_S = alpha_K + 3/2 alpha_B^2 > 0",
+      "no_gradient": "c_S^2 > 0"
+    },
+    "implementation": "hi_class + EFTCosmoMC"
+  },
+  "vector_tensor_ansatz": {
+    "coupling": "beta",
+    "mass": "m^2",
+    "slip_estimate": "eta - 1 ~ C_eta * beta^2 * (nabla S)^2 / (k^2 * rho_eff)",
+    "C_eta": "positive, to be determined",
+    "free_parameters": {
+      "beta": {"description": "Entropy-flow coupling", "range": "to be constrained"},
+      "m2": {"description": "Vector field mass squared", "constraint": "> 0"},
+      "a_t": {"value": 0.30},
+      "Delta": {"value": 0.3}
+    },
+    "stability": {
+      "no_tachyon": "m^2 > 0",
+      "no_ghost": "beta^2 < beta_max^2"
+    },
+    "implementation": "Requires new Boltzmann code"
+  },
+  "cmb_compatibility": {
+    "high_z_recovery": "mu -> 1, eta -> 1 at z > 10 via S -> 0",
+    "required_slip_for_target": 1.24,
+    "note": "eta > 2*Sigma/mu - 1 for mu=0.925, Sigma=1.05"
+  }
+}

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/examples/eft_demo.py
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/examples/eft_demo.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Demo: EFC EFT Ansatz — Scalar-Tensor and Vector-Tensor Formulations
+DOI: 10.6084/m9.figshare.31368433
+
+Usage: python eft_demo.py
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+from src.efc_eft_ansatz import (
+    EntropyField, TargetSignature, ScalarTensorEFT,
+    VectorTensorEFT, print_comparison,
+)
+
+def main():
+    print("EFC EFT Ansatz — Demo")
+    print("DOI: 10.6084/m9.figshare.31368433\n")
+
+    # Target signature
+    target = TargetSignature()
+    print(target.summary())
+    print()
+
+    # Entropy field
+    S = EntropyField(a_t=0.30, Delta=0.3)
+    a_vals = np.array([0.1, 0.2, 0.3, 0.5, 0.7, 1.0])
+    print("Entropy Field S(a):")
+    print(f"{'a':>6} {'z':>6} {'S(a)':>8} {'dS/dlna':>10} {'mu_growth':>10}")
+    for a in a_vals:
+        z = 1.0 / a - 1.0
+        print(f"{a:>6.2f} {z:>6.1f} {S(a):>8.4f} {S.dS_dlna(a):>10.4f} {S.mu_growth(a):>10.4f}")
+    print()
+
+    # Scalar-tensor EFT
+    st = ScalarTensorEFT(B0=1.0, M0=1.0, a_t=0.30, Delta=0.3)
+    print(st.summary())
+    print()
+
+    print("Alpha functions across transition:")
+    print(f"{'a':>6} {'alpha_B':>10} {'alpha_M':>10} {'Q_S':>10}")
+    for a in a_vals:
+        print(f"{a:>6.2f} {st.alpha_B(a):>10.4f} {st.alpha_M(a):>10.4f} {st.no_ghost_QS(a):>10.4f}")
+    print()
+
+    # Vector-tensor EFT
+    vt = VectorTensorEFT(beta=1.0, m2=1.0, a_t=0.30, Delta=0.3)
+    print(vt.summary())
+    print()
+
+    print("Slip estimate (schematic) across transition:")
+    print(f"{'a':>6} {'eta-1 estimate':>16}")
+    for a in a_vals:
+        print(f"{a:>6.2f} {vt.slip_estimate(a):>16.6f}")
+    print()
+
+    # Comparison
+    print(print_comparison())
+
+if __name__ == "__main__":
+    main()

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/index.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/index.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "./schema.json",
+  "paper_id": "EFC-EFT-Ansatz-v6",
+  "title": "Minimal EFC Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "version": "v6",
+  "date": "2026-03-06",
+  "doi": "10.6084/m9.figshare.31368433",
+  "status": "Proposed EFT completion — not canonical baseline EFC-D",
+  "abstract": "Two complementary EFT ansatze for EFC: scalar-tensor (Horndeski/EFT-DE) and vector-tensor (dynamical 4-vector J^mu). Both use sigmoid entropy field S(a) to govern GR-to-modified-gravity transition. Target: mu < 1, eta > 1, Sigma > 1.",
+
+  "conventions": {
+    "metric": "ds^2 = -(1+2Psi)dt^2 + a^2(1-2Phi)dx^2",
+    "gauge": "Conformal Newtonian (longitudinal)",
+    "slip": "eta = Phi/Psi (GR: eta = 1)",
+    "mu": "mu = G_eff / G (GR: mu = 1)",
+    "sigma": "Sigma = G_lens / G = mu(1+eta)/2 (GR: Sigma = 1)",
+    "sign_convention": "eta > 1 means |Phi| > |Psi|: lensing potential enhanced"
+  },
+
+  "target_signature": {
+    "mu": {"value": 0.925, "condition": "< 1", "mechanism": "Weakened gravity in growth ODE"},
+    "eta": {"value": 1.27, "condition": "> 1", "mechanism": "Gravitational slip from entropy gradients"},
+    "sigma": {"value": 1.05, "condition": "> 1", "mechanism": "Enhanced lensing: Sigma = mu(1+eta)/2"},
+    "regime": "0.5 < z < 1.5 (transition)",
+    "constraint_eq8": "eta > 2*Sigma/mu - 1"
+  },
+
+  "entropy_field": {
+    "equation": "S(a) = [1 + exp(-(ln a - ln a_t) / Delta)]^{-1}",
+    "parameters": {
+      "a_t": {"value": 0.30, "description": "Transition scale factor", "z_t": 2.3},
+      "Delta": {"value": 0.3, "description": "Transition sharpness"}
+    },
+    "boundary_conditions": {
+      "early_universe": "S -> 0 (GR recovery)",
+      "today": "S -> 1 (max modification)",
+      "peak": "dS/d(ln a) peaks at a = a_t"
+    },
+    "growth_ansatz": {
+      "equation": "mu(a) = 1 + delta_mu * S(a)",
+      "delta_mu": -0.075
+    }
+  },
+
+  "ansatz_I_scalar_tensor": {
+    "name": "Scalar-Tensor EFT (Horndeski)",
+    "action": "L = M_Pl^2/2 R + K(S,X) + G3(S,X) box S",
+    "X_definition": "X = -1/2 (nabla S)^2",
+    "alpha_parameters": {
+      "alpha_T": {"value": 0, "reason": "GW170817 constraint"},
+      "alpha_B": {"form": "proportional to dS/d(ln a)", "coefficient": "B0 (free)"},
+      "alpha_M": {"form": "proportional to S(a)", "coefficient": "M0 (free)"}
+    },
+    "free_parameters": ["B0", "M0", "a_t", "Delta"],
+    "observables": "mu, eta, Sigma determined by {alpha_K, alpha_B, alpha_M, alpha_T} via quasi-static limit",
+    "expected_behaviour": [
+      "mu < 1 at mid-z (alpha_B, alpha_M -> 0 at high z)",
+      "eta > 1 from alpha_B != 0 (sign for B0 > 0, to be confirmed numerically)",
+      "Sigma > 1 region may exist in {B0, M0} space"
+    ],
+    "stability_conditions": {
+      "no_ghost": "Q_S = alpha_K + 3/2 alpha_B^2 > 0",
+      "no_gradient": "c_S^2 > 0"
+    },
+    "implementation": "hi_class + EFTCosmoMC",
+    "testability": "High"
+  },
+
+  "ansatz_II_vector_tensor": {
+    "name": "Vector-Tensor EFT (Energy Flow)",
+    "action": "L = M_Pl^2/2 R - 1/4 F_{mu nu} F^{mu nu} - m^2/2 J_mu J^mu + beta J^mu nabla_mu S",
+    "F_definition": "F_{mu nu} = nabla_mu J_nu - nabla_nu J_mu",
+    "coupling": "beta (entropy-flow coupling constant)",
+    "anisotropic_stress": {
+      "energy_momentum": "T_{mu nu}^(nabla S) = beta^2 [nabla_mu S nabla_nu S - 1/4 g_{mu nu} (nabla S)^2]",
+      "shear": "pi ~ beta^2 nabla S_bar . nabla delta_S",
+      "slip_estimate": "eta - 1 ~ C_eta beta^2 (nabla S_bar)^2 / (k^2 rho_eff)",
+      "C_eta": "positive, to be determined by full perturbation analysis"
+    },
+    "free_parameters": ["beta", "m^2", "a_t", "Delta"],
+    "stability_conditions": {
+      "no_tachyon": "m^2 > 0",
+      "no_ghost": "beta^2 < beta_max^2"
+    },
+    "scalar_connection": "S ~ nabla_mu J^mu or S ~ |J|^2",
+    "implementation": "Requires new Boltzmann code",
+    "testability": "Low"
+  },
+
+  "comparison_table": [
+    {"property": "EFC ontology", "scalar_tensor": "Indirect (S as effective scalar)", "vector_tensor": "Direct (J^mu as flow)"},
+    {"property": "Free parameters", "scalar_tensor": "{B0, M0, a_t, Delta}", "vector_tensor": "{beta, m^2, a_t, Delta}"},
+    {"property": "mu < 1 mechanism", "scalar_tensor": "Via alpha_B, alpha_M", "vector_tensor": "Via J^mu mass term"},
+    {"property": "eta > 1 mechanism", "scalar_tensor": "Via braiding alpha_B != 0", "vector_tensor": "Via pi ~ (nabla S)^2"},
+    {"property": "Sigma > 1", "scalar_tensor": "Numerical check required", "vector_tensor": "Numerical check required"},
+    {"property": "GR at high z", "scalar_tensor": "Automatic (alpha -> 0)", "vector_tensor": "Automatic (nabla S -> 0)"},
+    {"property": "GW170817", "scalar_tensor": "alpha_T = 0 imposed", "vector_tensor": "Naturally small c_T correction"},
+    {"property": "Numerical tools", "scalar_tensor": "hi_class, EFTCosmoMC", "vector_tensor": "New Boltzmann code needed"},
+    {"property": "Testability", "scalar_tensor": "High", "vector_tensor": "Low"}
+  ],
+
+  "cmb_compatibility": {
+    "requirement": "mu -> 1, eta -> 1 at z > 10",
+    "mechanism": "Sigmoid S -> 0 at high z",
+    "alens_motivation": "Sigma > 1 at z ~ 0.5-1",
+    "required_slip": "eta > 2*Sigma/mu - 1 ~ 1.24 for mu=0.925, Sigma=1.05"
+  },
+
+  "falsification_criterion": "No parameter region {B0, M0, a_t, Delta} with mu < 1, eta > 1, Sigma > 1 simultaneously under stability + CMB + LSS constraints in hi_class scan",
+
+  "open_questions": [
+    "Does {B0, M0} region exist with mu < 1, eta > 1, Sigma > 1 simultaneously?",
+    "Are stability conditions Q_S > 0, c_S^2 > 0 satisfied across sigmoid transition?",
+    "What is the precise coefficient C_eta in the vector-tensor slip (Eq 21)?",
+    "Does J^mu action reduce to scalar EFT in isotropic quasi-static limit?"
+  ],
+
+  "priority_steps": [
+    "Implement alpha_B(a), alpha_M(a) with EFC sigmoid in hi_class",
+    "Run joint Planck 2018 + DESI Y1 + BOSS likelihood for {B0, M0, a_t, Delta}",
+    "Verify stability conditions numerically",
+    "Derive linearised perturbation equations for J^mu sector, compute eta(a,k)"
+  ],
+
+  "references": [
+    {"key": "Bellini2014", "arxiv": "1404.3713", "title": "Maximal freedom at minimum cost"},
+    {"key": "Horndeski1974", "doi": "10.1007/BF01807638", "title": "Second-order scalar-tensor field equations"},
+    {"key": "Zumalacarregui2017", "arxiv": "1605.06102", "title": "hi_class"},
+    {"key": "Heisenberg2019", "arxiv": "1807.01725", "title": "Systematic approach to GR generalisations"},
+    {"key": "GW170817", "arxiv": "1710.05834", "title": "GW and gamma-rays from BNS merger"},
+    {"key": "Magnusson2026", "url": "https://energyflow-cosmology.com", "title": "EFC research notes"}
+  ]
+}

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/metadata.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/metadata.json
@@ -1,0 +1,58 @@
+{
+  "package_format": "efc-ai-friendly-v1",
+  "paper_id": "EFC-EFT-Ansatz-v6",
+  "title": "Minimal EFC Effective Field Theory Ansatz",
+  "subtitle": "Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Energy-Flow Cosmology Initiative"
+  },
+  "version": "v6",
+  "date": "2026-03-06",
+  "doi": "10.6084/m9.figshare.31368433",
+  "license": "CC-BY-4.0",
+  "status": "research_note",
+  "canonical_status": "proposed (not canonical baseline EFC-D)",
+  "topics": [
+    "effective field theory",
+    "modified gravity",
+    "scalar-tensor gravity",
+    "vector-tensor gravity",
+    "Horndeski theory",
+    "gravitational slip",
+    "entropy gradients",
+    "CMB lensing",
+    "energy-flow cosmology"
+  ],
+  "ai_metadata": {
+    "ai_parseable": true,
+    "structured_data": ["index.json", "data/eft_parameters.json"],
+    "executable_code": ["src/efc_eft_ansatz.py", "examples/eft_demo.py"],
+    "linked_data": ["EFC-EFT-Ansatz.jsonld"],
+    "validation": ["schema.json"]
+  },
+  "files": [
+    {"path": "README.md", "type": "documentation", "format": "markdown"},
+    {"path": "index.json", "type": "structured_data", "format": "json"},
+    {"path": "schema.json", "type": "validation", "format": "json-schema"},
+    {"path": "metadata.json", "type": "metadata", "format": "json"},
+    {"path": "EFC-EFT-Ansatz.jsonld", "type": "linked_data", "format": "json-ld"},
+    {"path": "citations.bib", "type": "references", "format": "bibtex"},
+    {"path": "src/__init__.py", "type": "source", "format": "python"},
+    {"path": "src/efc_eft_ansatz.py", "type": "source", "format": "python"},
+    {"path": "data/eft_parameters.json", "type": "data", "format": "json"},
+    {"path": "examples/eft_demo.py", "type": "example", "format": "python"}
+  ],
+  "dependencies": {
+    "python": ">=3.8",
+    "numpy": ">=1.20"
+  },
+  "related_papers": [
+    {
+      "id": "EFC-CMB-Localization",
+      "title": "Systematic Localization of Late-Time Cosmological Signals in Modified Gravity",
+      "relation": "Provides the mu-Sigma survival valley that motivates this EFT ansatz"
+    }
+  ]
+}

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/schema.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EFC-EFT-Ansatz index.json schema",
+  "type": "object",
+  "required": ["paper_id", "title", "author", "conventions", "target_signature", "entropy_field", "ansatz_I_scalar_tensor", "ansatz_II_vector_tensor"],
+  "properties": {
+    "paper_id": {"type": "string"},
+    "title": {"type": "string"},
+    "author": {"type": "string"},
+    "orcid": {"type": "string", "pattern": "^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"},
+    "version": {"type": "string"},
+    "date": {"type": "string", "format": "date"},
+    "doi": {"type": "string"},
+    "status": {"type": "string"},
+    "abstract": {"type": "string"},
+    "conventions": {
+      "type": "object",
+      "required": ["metric", "gauge", "slip", "mu", "sigma"],
+      "properties": {
+        "metric": {"type": "string"},
+        "gauge": {"type": "string"},
+        "slip": {"type": "string"},
+        "mu": {"type": "string"},
+        "sigma": {"type": "string"}
+      }
+    },
+    "target_signature": {
+      "type": "object",
+      "required": ["mu", "eta", "sigma"],
+      "properties": {
+        "mu": {"type": "object", "properties": {"value": {"type": "number"}, "condition": {"type": "string"}}},
+        "eta": {"type": "object", "properties": {"value": {"type": "number"}, "condition": {"type": "string"}}},
+        "sigma": {"type": "object", "properties": {"value": {"type": "number"}, "condition": {"type": "string"}}}
+      }
+    },
+    "entropy_field": {
+      "type": "object",
+      "required": ["equation", "parameters"],
+      "properties": {
+        "equation": {"type": "string"},
+        "parameters": {"type": "object"},
+        "boundary_conditions": {"type": "object"},
+        "growth_ansatz": {"type": "object"}
+      }
+    },
+    "ansatz_I_scalar_tensor": {
+      "type": "object",
+      "required": ["name", "action", "alpha_parameters", "free_parameters"],
+      "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "alpha_parameters": {"type": "object"},
+        "free_parameters": {"type": "array", "items": {"type": "string"}},
+        "stability_conditions": {"type": "object"}
+      }
+    },
+    "ansatz_II_vector_tensor": {
+      "type": "object",
+      "required": ["name", "action", "coupling", "free_parameters"],
+      "properties": {
+        "name": {"type": "string"},
+        "action": {"type": "string"},
+        "coupling": {"type": "string"},
+        "anisotropic_stress": {"type": "object"},
+        "free_parameters": {"type": "array", "items": {"type": "string"}},
+        "stability_conditions": {"type": "object"}
+      }
+    },
+    "comparison_table": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["property", "scalar_tensor", "vector_tensor"],
+        "properties": {
+          "property": {"type": "string"},
+          "scalar_tensor": {"type": "string"},
+          "vector_tensor": {"type": "string"}
+        }
+      }
+    },
+    "falsification_criterion": {"type": "string"},
+    "open_questions": {"type": "array", "items": {"type": "string"}},
+    "references": {"type": "array"}
+  }
+}

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/src/__init__.py
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/src/__init__.py
@@ -1,0 +1,19 @@
+"""
+EFC EFT Ansatz — Reference Implementation
+DOI: 10.6084/m9.figshare.31368433
+"""
+from .efc_eft_ansatz import (
+    EntropyField,
+    TargetSignature,
+    ScalarTensorEFT,
+    VectorTensorEFT,
+    print_comparison,
+)
+
+__all__ = [
+    "EntropyField",
+    "TargetSignature",
+    "ScalarTensorEFT",
+    "VectorTensorEFT",
+    "print_comparison",
+]

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/src/efc_eft_ansatz.py
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/src/efc_eft_ansatz.py
@@ -1,0 +1,259 @@
+"""
+EFC Effective Field Theory Ansatz — Reference Implementation
+
+Two EFT formulations for Energy-Flow Cosmology:
+  Ansatz I:  Scalar-tensor (Horndeski/EFT-DE)
+  Ansatz II: Vector-tensor (dynamical energy flow)
+
+Reference: DOI 10.6084/m9.figshare.31368433
+Author: Morten Magnusson (ORCID: 0009-0002-4860-5095)
+Version: Research Note v6
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+import numpy as np
+
+
+# =============================================================================
+# EFC Entropy Field (Section 3)
+# =============================================================================
+
+class EntropyField:
+    """EFC sigmoid entropy field S(a) — Eq. (9).
+
+    S(a) = [1 + exp(-(ln a - ln a_t) / Delta)]^{-1}
+
+    Parameters
+    ----------
+    a_t : float
+        Transition scale factor (default 0.30, z_t ~ 2.3).
+    Delta : float
+        Transition sharpness (default 0.3).
+    """
+    def __init__(self, a_t: float = 0.30, Delta: float = 0.3):
+        self.a_t = a_t
+        self.Delta = Delta
+
+    def __call__(self, a):
+        """Evaluate S(a)."""
+        a = np.asarray(a, dtype=float)
+        return 1.0 / (1.0 + np.exp(-(np.log(a) - np.log(self.a_t)) / self.Delta))
+
+    def dS_dlna(self, a):
+        """Derivative dS/d(ln a) — peaks at a = a_t."""
+        S = self(a)
+        return S * (1 - S) / self.Delta
+
+    def mu_growth(self, a, delta_mu: float = -0.075):
+        """Phenomenological mu(a) = 1 + delta_mu * S(a) — Eq. (13)."""
+        return 1.0 + delta_mu * self(a)
+
+
+# =============================================================================
+# Target Signature (Section 2)
+# =============================================================================
+
+@dataclass
+class TargetSignature:
+    """EFC target observable signature — Eqs. (1)-(3), (8), (24).
+
+    All three conditions must hold simultaneously in 0.5 < z < 1.5.
+    """
+    mu: float = 0.925
+    sigma: float = 1.05
+    delta_mu: float = -0.075
+
+    @property
+    def eta_required(self) -> float:
+        """Required slip: eta > 2*Sigma/mu - 1 — Eq. (8)."""
+        return 2.0 * self.sigma / self.mu - 1.0
+
+    def sigma_from_mu_eta(self, mu: float, eta: float) -> float:
+        """Sigma = mu * (1 + eta) / 2 — Eq. (7)."""
+        return mu * (1.0 + eta) / 2.0
+
+    def eta_from_mu_sigma(self, mu: float, sigma: float) -> float:
+        """Invert Eq. (7): eta = 2*Sigma/mu - 1."""
+        return 2.0 * sigma / mu - 1.0
+
+    def summary(self):
+        lines = [
+            "EFC Target Signature",
+            "=" * 50,
+            f"mu    = {self.mu}  (< 1, weakened gravity)",
+            f"Sigma = {self.sigma}  (> 1, enhanced lensing)",
+            f"eta   = {self.eta_required:.3f}  (> 1, gravitational slip)",
+            f"delta_mu = {self.delta_mu}",
+            f"Regime: 0.5 < z < 1.5",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Ansatz I: Scalar-Tensor EFT (Section 4)
+# =============================================================================
+
+class ScalarTensorEFT:
+    """Scalar-tensor EFT in Bellini-Sawicki alpha basis — Eqs. (14)-(17).
+
+    Action: L = M_Pl^2/2 R + K(S,X) + G3(S,X) box S
+
+    Alpha parameters:
+        alpha_T = 0          (GW170817)
+        alpha_B ~ B0 * dS/d(ln a)  (braiding from entropy gradient)
+        alpha_M ~ M0 * S(a)        (running Planck mass)
+
+    Parameters
+    ----------
+    B0 : float
+        Braiding amplitude (free parameter).
+    M0 : float
+        Planck-mass running amplitude (free parameter).
+    a_t : float
+        Transition scale factor.
+    Delta : float
+        Transition sharpness.
+    """
+    def __init__(self, B0: float = 1.0, M0: float = 1.0,
+                 a_t: float = 0.30, Delta: float = 0.3):
+        self.B0 = B0
+        self.M0 = M0
+        self.entropy = EntropyField(a_t, Delta)
+
+    def alpha_T(self, a) -> float:
+        """Tensor speed excess: alpha_T = 0 (GW170817)."""
+        return 0.0
+
+    def alpha_B(self, a):
+        """Braiding: alpha_B = B0 * dS/d(ln a) — Eq. (16)."""
+        return self.B0 * self.entropy.dS_dlna(a)
+
+    def alpha_M(self, a):
+        """Planck-mass running: alpha_M = M0 * S(a) — Eq. (17)."""
+        return self.M0 * self.entropy(a)
+
+    def no_ghost_QS(self, a, alpha_K: float = 1.0):
+        """No-ghost condition: Q_S = alpha_K + 3/2 alpha_B^2 > 0 — Eq. (22)."""
+        aB = self.alpha_B(a)
+        return alpha_K + 1.5 * aB**2
+
+    @property
+    def free_parameters(self) -> list:
+        return ["B0", "M0", "a_t", "Delta"]
+
+    def summary(self):
+        lines = [
+            "Ansatz I: Scalar-Tensor EFT (Horndeski)",
+            "=" * 50,
+            f"B0 = {self.B0}  (braiding amplitude)",
+            f"M0 = {self.M0}  (Planck-mass running)",
+            f"a_t = {self.entropy.a_t}  (z_t = {1/self.entropy.a_t - 1:.1f})",
+            f"Delta = {self.entropy.Delta}",
+            f"alpha_T = 0  (GW170817)",
+            f"alpha_B(a_t) = {self.alpha_B(self.entropy.a_t):.4f}",
+            f"alpha_M(a_t) = {self.alpha_M(self.entropy.a_t):.4f}",
+            "Implementation: hi_class + EFTCosmoMC",
+            "Testability: High",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Ansatz II: Vector-Tensor EFT (Section 5)
+# =============================================================================
+
+class VectorTensorEFT:
+    """Vector-tensor EFT with dynamical energy flow J^mu — Eq. (18).
+
+    Action: L = M_Pl^2/2 R - 1/4 F_{mn} F^{mn} - m^2/2 J_m J^m + beta J^m nabla_m S
+
+    Anisotropic stress from entropy gradient:
+        pi ~ beta^2 nabla S_bar . nabla delta_S
+        eta - 1 ~ C_eta beta^2 (nabla S_bar)^2 / (k^2 rho_eff)
+
+    Parameters
+    ----------
+    beta : float
+        Entropy-flow coupling constant.
+    m2 : float
+        Vector field mass squared (m^2 > 0 required).
+    a_t : float
+        Transition scale factor.
+    Delta : float
+        Transition sharpness.
+    """
+    def __init__(self, beta: float = 1.0, m2: float = 1.0,
+                 a_t: float = 0.30, Delta: float = 0.3):
+        self.beta = beta
+        self.m2 = m2
+        self.entropy = EntropyField(a_t, Delta)
+
+    def slip_estimate(self, a, k: float = 0.05, rho_eff: float = 1.0,
+                      C_eta: float = 1.0):
+        """Schematic slip estimate: eta - 1 ~ C_eta beta^2 (dS/dlna)^2 / (k^2 rho_eff) — Eq. (21).
+
+        Note: C_eta > 0 is to be determined by full perturbation analysis.
+        """
+        dSdlna = self.entropy.dS_dlna(a)
+        return C_eta * self.beta**2 * dSdlna**2 / (k**2 * rho_eff)
+
+    def is_tachyon_free(self) -> bool:
+        """Stability: m^2 > 0 — no tachyonic instability."""
+        return self.m2 > 0
+
+    @property
+    def free_parameters(self) -> list:
+        return ["beta", "m^2", "a_t", "Delta"]
+
+    def summary(self):
+        lines = [
+            "Ansatz II: Vector-Tensor EFT (Energy Flow)",
+            "=" * 50,
+            f"beta = {self.beta}  (entropy-flow coupling)",
+            f"m^2 = {self.m2}  (vector mass squared)",
+            f"a_t = {self.entropy.a_t}  (z_t = {1/self.entropy.a_t - 1:.1f})",
+            f"Delta = {self.entropy.Delta}",
+            f"Tachyon-free: {self.is_tachyon_free()}",
+            f"Slip at a_t (schematic): eta-1 ~ {self.slip_estimate(self.entropy.a_t):.4f}",
+            "Implementation: Requires new Boltzmann code",
+            "Testability: Low",
+        ]
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Comparison table
+# =============================================================================
+
+@dataclass
+class ComparisonRow:
+    """One row of Table 2."""
+    property: str
+    scalar_tensor: str
+    vector_tensor: str
+
+COMPARISON_TABLE = [
+    ComparisonRow("EFC ontology", "Indirect (S as effective scalar)", "Direct (J^mu as flow)"),
+    ComparisonRow("Free parameters", "{B0, M0, a_t, Delta}", "{beta, m^2, a_t, Delta}"),
+    ComparisonRow("mu < 1 mechanism", "Via alpha_B, alpha_M", "Via J^mu mass term"),
+    ComparisonRow("eta > 1 mechanism", "Via braiding alpha_B != 0", "Via pi ~ (nabla S)^2"),
+    ComparisonRow("Sigma > 1", "Numerical check required", "Numerical check required"),
+    ComparisonRow("GR at high z", "Automatic (alpha -> 0)", "Automatic (nabla S -> 0)"),
+    ComparisonRow("GW170817", "alpha_T = 0 imposed", "Naturally small c_T correction"),
+    ComparisonRow("Numerical tools", "hi_class, EFTCosmoMC", "New Boltzmann code needed"),
+    ComparisonRow("Testability", "High", "Low"),
+]
+
+
+def print_comparison():
+    """Print Table 2 comparison."""
+    lines = [
+        "Comparison: Scalar-Tensor vs Vector-Tensor",
+        "=" * 70,
+        f"{'Property':<22} {'Scalar-Tensor':<26} {'Vector-Tensor':<22}",
+        "-" * 70,
+    ]
+    for row in COMPARISON_TABLE:
+        lines.append(f"{row.property:<22} {row.scalar_tensor:<26} {row.vector_tensor:<22}")
+    return "\n".join(lines)


### PR DESCRIPTION
Complete AI-friendly package for "Minimal EFC Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients" (Research Note v6).

Package includes:
- README.md: Summary with target signature, both ansatze, key equations
- index.json: Full machine-readable metadata including conventions, entropy field, alpha parameters, comparison table
- schema.json: JSON Schema validation
- metadata.json: Package metadata with AI flags
- EFC-EFT-Ansatz.jsonld: Schema.org linked data
- citations.bib: 7 BibTeX references
- src/efc_eft_ansatz.py: 4 classes (EntropyField, TargetSignature, ScalarTensorEFT, VectorTensorEFT) + comparison table
- data/eft_parameters.json: All parameter values and constraints
- examples/eft_demo.py: Runnable demo

https://claude.ai/code/session_012Tf9r7G7HE7YmiFRr6yK2e