### PR TITLE
Add AI-friendly package for GRC Double-Slit paper

### DIFF
--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/EFC-GRC-DoubleSlit.jsonld
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/EFC-GRC-DoubleSlit.jsonld
@@ -1,0 +1,24 @@
+{
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  "name": "Double-Slit as Grid-Resolution Phenomenon in Grid-Rendering Cosmology",
+  "alternativeHeadline": "Ontological Extension, UV-Cutoff Analysis, and Open Gaps toward Quantum Testability",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-03-08",
+  "version": "v0.2",
+  "description": "GRC treats quantum uncertainty as grid-resolution: Delta x >= l_g. UV-cutoff derivation shows exponential suppression of geometric deviations from QM. Primary testable distinction relocated to entropy-sensitive decoherence (P3) and higher-order statistics (P4).",
+  "keywords": [
+    "Grid-Rendering Cosmology", "GRC", "double-slit experiment", "UV cutoff",
+    "grid resolution", "quantum uncertainty", "entropy decoherence",
+    "discrete geometry", "Energy-Flow Cosmology"
+  ],
+  "isPartOf": {
+    "@type": "CreativeWork",
+    "name": "Energy-Flow Cosmology Initiative",
+    "url": "https://energyflow-cosmology.com"
+  }
+}

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/README.md
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/README.md
@@ -1,0 +1,117 @@
+# Double-Slit as Grid-Resolution Phenomenon in Grid-Rendering Cosmology
+
+**Ontological Extension, UV-Cutoff Analysis, and Open Gaps toward Quantum Testability**
+
+| Field | Value |
+|-------|-------|
+| Author | Morten Magnusson |
+| ORCID | 0009-0002-4860-5095 |
+| Version | Working Note v0.2 (Revised) |
+| Date | March 8, 2026 |
+| Status | Preprint. Not peer-reviewed. |
+| Scope | Ontological and minimal-model extension of GRC to sub-L0 quantum regime |
+
+## Quick Start
+
+```python
+from src.grc_double_slit import (
+    GRCAxioms, UVCutoffModel, EntropyClarity, PredictionStatus, OpenGaps,
+)
+
+# UV cutoff deviation
+uv = UVCutoffModel(l_g=1e-35, sigma=1e-6)
+print(f"Deviation: |delta A| ~ {uv.deviation_bound():.2e}")  # ~0 for sub-Planck l_g
+
+# Entropy-clarity function
+C = EntropyClarity(S_max=1.0)
+print(f"C(S=0.1) = {C(0.1):.4f}")  # High clarity
+print(f"C(S=0.9) = {C(0.9):.4f}")  # Low clarity
+```
+
+## Summary
+
+GRC treats quantum uncertainty as a grid-resolution phenomenon: Delta x >= l_g, where l_g is the fundamental node scale of a discrete geometric substrate. This note derives consequences for the double-slit experiment within the GRC triad:
+
+```
+Psi_manifest = G(x) ⊗ E(x,t) · C(S(x,t))
+```
+
+### Six Axioms
+| ID | Axiom | Content |
+|----|-------|---------|
+| A1 | Grid (G) | Discrete geometric substrate with node scale l_g |
+| A2 | Energy Flow (E) | Energy as distributed flow through G |
+| A3 | Clarity Function C(S) | C(S) = exp(-S/S_max); low S = high clarity |
+| A4 | Manifest Structure | Psi_manifest = G(x) ⊗ E(x,t) · C(S(x,t)) |
+| A5 | Grid-Resolution Limit | Position limited by l_g |
+| A6 | Registration as Local Selection | Measurement = local stabilization of Psi_manifest |
+
+### Key Result: UV-Cutoff Derivation (Section 7)
+
+The exact GRC amplitude with UV cutoff:
+```
+A_GRC(x) = integral[-kmax,kmax] a-tilde(k) e^{ikx} dk,  kmax = pi/l_g
+```
+
+Deviation from standard QM:
+```
+Delta A(x) = integral[|k|>pi/l_g] a-tilde(k) e^{ikx} dk
+```
+
+For Gaussian slit profiles (width sigma):
+```
+|Delta A| ~ (l_g / pi*sigma^2) * exp(-pi^2 sigma^2 / 2*l_g^2)
+```
+
+**Conclusion**: Deviation is exponentially suppressed for sigma >> l_g. The polynomial ansatz O((l_g/d)^2) from v0.1 is withdrawn.
+
+### Five Predictions
+| ID | Prediction | Status |
+|----|-----------|--------|
+| P1 | Backward compatibility (recover QM as C->1, l_g/d->0) | Required (analytic) |
+| P2 | Geometric cutoff deviation | Downgraded: principled but inaccessible |
+| P3 | S-sensitive decoherence (primary candidate) | Open — blocked by G2 |
+| P4 | Gradual which-path suppression (higher-order stats) | Open — secondary candidate |
+| P5 | No new prediction for d >> l_g | Explicit no-claim |
+
+### Six Falsification Points
+| ID | Falsification condition |
+|----|----------------------|
+| F1 | Backward compatibility fails |
+| F2 | No scale-deviation where GRC predicts one (principled, not operative) |
+| F3 | Decoherence fully reduced to T + environment (no S-component) |
+| F4 | Higher-order statistics identical to QM under partial measurement |
+| F5 | Delta P(x) doesn't decrease with d/l_g |
+| F6 | Standard QM results at d >> l_g do NOT falsify GRC |
+
+### Open Gaps (Table 1)
+| Priority | Gap | Description | Blocks |
+|----------|-----|-------------|--------|
+| 1 | G2 | Operational definition of local S | P3 testability |
+| 2 | P3 | Formal decoherence model via C(S) | Main test candidate |
+| 3 | P4 | Concrete higher-order observable | Secondary test |
+| 4 | G3 | Explicit P(x) for concrete geometry | Numerical check |
+| 5 | G5 | Closure Condition 3 vs mode basis | Internal consistency |
+
+### G2 Candidates for Operational S
+- **A**: von Neumann entropy (weakest; likely reduces to standard QM)
+- **B**: Entanglement entropy against environment
+- **C**: Free-energy or structural complexity proxy (most EFC-native; hardest)
+
+## Caveats
+- Working note, not completed derivation
+- Geometric cutoff test (P2) is practically inaccessible for sub-Planckian l_g
+- Theory's quantum distinction lies in measurement as entropy process (P3/P4), not interference geometry
+- G2 (operational S) is the critical blocking gap
+
+## File Manifest
+| File | Description |
+|------|-------------|
+| `index.json` | Machine-readable metadata, axioms, equations, predictions |
+| `schema.json` | JSON Schema for validation |
+| `metadata.json` | Package metadata |
+| `EFC-GRC-DoubleSlit.jsonld` | Schema.org linked data |
+| `citations.bib` | BibTeX references (13 entries) |
+| `src/grc_double_slit.py` | Reference implementation |
+| `data/model_parameters.json` | All parameters and status tables |
+| `examples/double_slit_demo.py` | Runnable demo |

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/citations.bib
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/citations.bib
@@ -1,0 +1,109 @@
+@book{Feynman1965,
+  author    = {Feynman, Richard P. and Leighton, Robert B. and Sands, Matthew},
+  title     = {The {Feynman} Lectures on Physics, Vol. {III}},
+  publisher = {Addison-Wesley},
+  year      = {1965},
+  note      = {Chapter 1: Quantum Behavior}
+}
+
+@article{Zurek2003,
+  author  = {Zurek, Wojciech H.},
+  title   = {Decoherence, einselection, and the quantum origins of the classical},
+  journal = {Reviews of Modern Physics},
+  volume  = {75},
+  pages   = {715--775},
+  year    = {2003},
+  doi     = {10.1103/RevModPhys.75.715}
+}
+
+@book{Joos2003,
+  author    = {Joos, E. and Zeh, H. D. and Kiefer, C. and Giulini, D. and Kupsch, J. and Stamatescu, I.-O.},
+  title     = {Decoherence and the Appearance of a Classical World in Quantum Theory},
+  edition   = {2nd},
+  publisher = {Springer},
+  year      = {2003},
+  doi       = {10.1007/978-3-662-05328-7}
+}
+
+@article{Scully1991,
+  author  = {Scully, Marlan O. and Englert, Berthold-Georg and Walther, Herbert},
+  title   = {Quantum optical tests of complementarity},
+  journal = {Nature},
+  volume  = {351},
+  pages   = {111--116},
+  year    = {1991},
+  doi     = {10.1038/351111a0}
+}
+
+@article{Brune1996,
+  author  = {Brune, M. and Hagley, E. and Dreyer, J. and Ma\^{i}tre, X. and Maali, A. and Wunderlich, C. and Raimond, J. M. and Haroche, S.},
+  title   = {Observing the progressive decoherence of the ``meter'' in a quantum measurement},
+  journal = {Physical Review Letters},
+  volume  = {77},
+  pages   = {4887--4890},
+  year    = {1996},
+  doi     = {10.1103/PhysRevLett.77.4887}
+}
+
+@article{Arndt1999,
+  author  = {Arndt, Markus and Nairz, Olaf and Vos-Andreae, Julian and Keller, Claudia and van der Zouw, Gerbrand and Zeilinger, Anton},
+  title   = {Wave-particle duality of {C60} molecules},
+  journal = {Nature},
+  volume  = {401},
+  pages   = {680--682},
+  year    = {1999},
+  doi     = {10.1038/44348}
+}
+
+@book{Rovelli2004,
+  author    = {Rovelli, Carlo},
+  title     = {Quantum Gravity},
+  publisher = {Cambridge University Press},
+  year      = {2004},
+  note      = {Ch. 10: Discreteness of space}
+}
+
+@article{Lindblad1976,
+  author  = {Lindblad, G\"{o}ran},
+  title   = {On the generators of quantum dynamical semigroups},
+  journal = {Communications in Mathematical Physics},
+  volume  = {48},
+  pages   = {119--130},
+  year    = {1976},
+  doi     = {10.1007/BF01608499}
+}
+
+@misc{Magnusson2026GRC,
+  author = {Magnusson, Morten},
+  title  = {Grid-Rendering Cosmology: A Three-Field Synthesis of Geometry, Energy and Entropy},
+  year   = {2026},
+  note   = {Preprint}
+}
+
+@misc{Magnusson2026Ontological,
+  author = {Magnusson, Morten},
+  title  = {{EFC} Ontological Foundations v1.0.2},
+  year   = {2026},
+  doi    = {10.6084/m9.figshare.31223668}
+}
+
+@misc{Magnusson2026Closure,
+  author = {Magnusson, Morten},
+  title  = {{EFC} Closure Conjectures},
+  year   = {2026},
+  doi    = {10.6084/m9.figshare.31224466}
+}
+
+@misc{Magnusson2026SPARC,
+  author = {Magnusson, Morten},
+  title  = {{EFC} Phase 3 {SPARC} Validation},
+  year   = {2026},
+  doi    = {10.6084/m9.figshare.31224538}
+}
+
+@misc{Magnusson2026DESI,
+  author = {Magnusson, Morten},
+  title  = {Energy-Flow Cosmology: Regime-Transition Fit to {DESI DR2 BAO}},
+  year   = {2026},
+  doi    = {10.6084/m9.figshare.31230703}
+}

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/data/model_parameters.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/data/model_parameters.json
@@ -1,0 +1,50 @@
+{
+  "paper_id": "EFC-GRC-DoubleSlit-v02",
+  "manifest_triad": {
+    "equation": "Psi_manifest = G(x) tensor E(x,t) . C(S(x,t))",
+    "components": ["G: discrete geometric grid", "E: energy flow", "C(S): entropy-clarity"]
+  },
+  "clarity_function": {
+    "equation": "C(S) = exp(-S/S_max)",
+    "S_max": "maximum entropy scale",
+    "limits": {"S_to_0": "C -> 1 (high clarity)", "S_to_Smax": "C -> 1/e (low clarity)"}
+  },
+  "uv_cutoff": {
+    "k_max": "pi / l_g",
+    "gaussian_slit_fourier": "a-tilde(k) = exp(-sigma^2 k^2 / 2) cos(kD/2)",
+    "deviation_bound": "|Delta A| <= (l_g / pi sigma^2) exp(-pi^2 sigma^2 / 2 l_g^2)",
+    "suppression_type": "exponential in (sigma/l_g)^2",
+    "withdrawn": "Polynomial ansatz O((l_g/d)^2) from v0.1"
+  },
+  "predictions": [
+    {"id": "P1", "name": "Backward compatibility", "status": "Required", "type": "analytic"},
+    {"id": "P2", "name": "Geometric cutoff", "status": "Downgraded", "type": "principled but inaccessible"},
+    {"id": "P3", "name": "S-sensitive decoherence", "status": "Open", "type": "primary candidate", "blocked_by": "G2"},
+    {"id": "P4", "name": "Which-path suppression", "status": "Open", "type": "secondary candidate"},
+    {"id": "P5", "name": "No prediction d >> l_g", "status": "No-claim", "type": "scope limit"}
+  ],
+  "falsification_points": [
+    {"id": "F1", "condition": "Backward compatibility fails"},
+    {"id": "F2", "condition": "No scale-deviation predicted"},
+    {"id": "F3", "condition": "Decoherence fully standard (no S-component)"},
+    {"id": "F4", "condition": "Higher-order stats identical to QM"},
+    {"id": "F5", "condition": "Delta P doesn't decrease with d/l_g"},
+    {"id": "F6", "condition": "QM at d >> l_g does NOT falsify (scope)"}
+  ],
+  "open_gaps": [
+    {"id": "G2", "priority": 1, "description": "Operational definition of local S", "blocks": "P3",
+     "candidates": ["A: von Neumann entropy", "B: Entanglement entropy", "C: Free-energy proxy"]},
+    {"id": "P3_gap", "priority": 2, "description": "Formal decoherence model via C(S)"},
+    {"id": "P4_gap", "priority": 3, "description": "Concrete higher-order observable"},
+    {"id": "G3", "priority": 4, "description": "Explicit P(x) for concrete geometry"},
+    {"id": "G5", "priority": 5, "description": "Closure Condition 3 vs mode basis"}
+  ],
+  "component_status": [
+    {"component": "Sections 1-6", "status": "Stable"},
+    {"component": "M5 geometric deviation", "status": "Revised (exponential not polynomial)"},
+    {"component": "P2 geometric test", "status": "Downgraded (principled not accessible)"},
+    {"component": "P3 S-sensitive decoherence", "status": "Open (primary candidate)"},
+    {"component": "P4 fluctuation statistics", "status": "Open (secondary candidate)"},
+    {"component": "G2 operational S", "status": "Open (highest priority)"}
+  ]
+}

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/examples/double_slit_demo.py
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/examples/double_slit_demo.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Demo: GRC Double-Slit as Grid-Resolution Phenomenon
+Working Note v0.2, March 8, 2026
+
+Usage: python double_slit_demo.py
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+from src.grc_double_slit import (
+    GRCAxioms, EntropyClarity, UVCutoffModel,
+    PredictionStatus, OpenGaps, FALSIFICATION_POINTS,
+)
+
+def main():
+    print("GRC Double-Slit — Demo")
+    print("Working Note v0.2, March 8, 2026\n")
+
+    # Axioms
+    axioms = GRCAxioms()
+    print(axioms.summary())
+    print()
+
+    # Entropy-clarity function
+    C = EntropyClarity(S_max=1.0)
+    print("Clarity Function C(S) = exp(-S/S_max)")
+    print("=" * 40)
+    for S in [0.0, 0.1, 0.3, 0.5, 0.7, 1.0]:
+        print(f"  S = {S:.1f}  ->  C(S) = {C(S):.4f}")
+    print()
+
+    # UV cutoff — sub-Planck scale
+    print("UV-Cutoff: Sub-Planckian l_g")
+    print("=" * 50)
+    uv_planck = UVCutoffModel(l_g=1.6e-35, sigma=1e-6)
+    print(uv_planck.summary())
+    print()
+
+    # UV cutoff — hypothetical accessible scale
+    print("UV-Cutoff: Hypothetical l_g = 1e-9 m (nanoscale)")
+    print("=" * 50)
+    uv_nano = UVCutoffModel(l_g=1e-9, sigma=1e-6)
+    print(uv_nano.summary())
+    print()
+
+    # Scaling demonstration
+    print("Deviation scaling with l_g (sigma = 1e-6 m)")
+    print("=" * 50)
+    print(f"{'l_g (m)':<14} {'sigma/l_g':<14} {'|Delta A|':<16} {'Accessible?'}")
+    print("-" * 56)
+    for lg_exp in [-35, -20, -15, -10, -9, -8, -7, -6]:
+        lg = 10.0**lg_exp
+        uv = UVCutoffModel(l_g=lg, sigma=1e-6)
+        dev = uv.deviation_bound()
+        print(f"{lg:<14.0e} {1e-6/lg:<14.0e} {dev:<16.2e} {uv.is_accessible()}")
+    print()
+
+    # Predictions
+    ps = PredictionStatus()
+    print(ps.summary())
+    print()
+
+    # Falsification points
+    print("Falsification Points (Section 6)")
+    print("=" * 60)
+    for fid, condition, ftype in FALSIFICATION_POINTS:
+        print(f"  {fid}: {condition}")
+        print(f"      Type: {ftype}")
+    print()
+
+    # Open gaps
+    gaps = OpenGaps()
+    print(gaps.summary())
+    print()
+
+    # One-line status
+    print("One-line status:")
+    print("Geometric cutoff (P2) inaccessible for sub-Planckian l_g.")
+    print("Quantum distinction, if any, lies in measurement as entropy")
+    print("process (P3/P4), not interference geometry.")
+
+if __name__ == "__main__":
+    main()

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/index.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/index.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "./schema.json",
+  "paper_id": "EFC-GRC-DoubleSlit-v02",
+  "title": "Double-Slit as Grid-Resolution Phenomenon in Grid-Rendering Cosmology",
+  "subtitle": "Ontological Extension, UV-Cutoff Analysis, and Open Gaps toward Quantum Testability",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "version": "v0.2 (Revised)",
+  "date": "2026-03-08",
+  "status": "Working note. Not peer-reviewed.",
+  "scope": "Ontological and minimal-model extension of GRC to sub-L0 quantum regime. Not an empirical closure paper.",
+
+  "abstract": "GRC treats quantum uncertainty as grid-resolution: Delta x >= l_g. UV-cutoff derivation shows geometric deviation from QM is exponentially suppressed: |Delta A| ~ exp(-pi^2 sigma^2 / 2 l_g^2). Primary testable distinction relocated to entropy-sensitive decoherence (P3) and higher-order measurement statistics (P4). Polynomial ansatz O((l_g/d)^2) withdrawn.",
+
+  "manifest_triad": {
+    "equation": "Psi_manifest(x,t) = G(x) ⊗ E(x,t) · C(S(x,t))",
+    "G": "Discrete geometric substrate with node scale l_g",
+    "E": "Energy flow through G (dynamic mode)",
+    "C_S": "Clarity function: C(S) = exp(-S/S_max)"
+  },
+
+  "axioms": [
+    {"id": "A1", "name": "Grid (G)", "content": "Discrete geometric substrate with fundamental node scale l_g"},
+    {"id": "A2", "name": "Energy Flow (E)", "content": "Energy manifests as distributed flow through G; localized = particle-like, distributed = field-like"},
+    {"id": "A3", "name": "Clarity Function C(S)", "content": "C(S) = exp(-S/S_max); low S = high clarity, high S = low clarity"},
+    {"id": "A4", "name": "Manifest Structure", "content": "Psi_manifest = G(x) ⊗ E(x,t) · C(S(x,t)); no registration without triad"},
+    {"id": "A5", "name": "Grid-Resolution Limit", "content": "Spatial registration limited by l_g; position cannot be realized below l_g"},
+    {"id": "A6", "name": "Registration as Local Selection", "content": "Measurement = physical process that locally selects and stabilizes Psi_manifest"}
+  ],
+
+  "definitions": [
+    {"id": "D1", "name": "Geometry as boundary condition", "content": "Double-slit = boundary condition selecting subset of allowed grid modes"},
+    {"id": "D2", "name": "Interference as distributed grid-coupling", "content": "High C(S) maintains distributed coupling; P(x) = weighted distribution over allowed positions"},
+    {"id": "D3", "name": "Registration as local selection", "content": "Distributed manifest structure selected and stabilized as local event"},
+    {"id": "D4", "name": "Measurement as entropic localization", "content": "Which-path measurement increases S locally, lowers C(S), reduces distributed coupling"},
+    {"id": "D5", "name": "Scale limit", "content": "At d ~ l_g, continuous approximation breaks; possible QM distinction"}
+  ],
+
+  "minimal_model": {
+    "M1": "Grid-mode basis {phi_n(x)} with resolution l_g; recovers QM as l_g -> 0",
+    "M2": "Amplitude: A(x) = sum_n a_n phi_n(x) C(S_n)",
+    "M3": "Registration: P(x) = |A(x)|^2; recovers QM in double limit C->1, l_g/d->0",
+    "M4": "Decoherence: local S-increase suppresses cross-terms in |A(x)|^2",
+    "M5_revised": "UV cutoff: Delta A = integral[|k|>pi/l_g] a-tilde(k) e^{ikx} dk"
+  },
+
+  "uv_cutoff": {
+    "grc_amplitude": "A_GRC(x) = integral[-kmax,kmax] a-tilde(k) e^{ikx} dk, kmax = pi/l_g",
+    "qm_amplitude": "A_QM(x) = integral[-inf,inf] a-tilde(k) e^{ikx} dk",
+    "exact_deviation": "Delta A(x) = integral[|k|>pi/l_g] a-tilde(k) e^{ikx} dk",
+    "gaussian_profile": "a-tilde(k) = exp(-sigma^2 k^2 / 2) cos(kD/2)",
+    "gaussian_bound": "|Delta A| <= (l_g / pi sigma^2) exp(-pi^2 sigma^2 / 2 l_g^2)",
+    "conclusion": "Exponentially suppressed for sigma >> l_g; polynomial ansatz O((l_g/d)^2) withdrawn",
+    "practical_implication": "For sub-Planckian l_g, deviation is numerically indistinguishable from zero"
+  },
+
+  "predictions": [
+    {"id": "P1", "name": "Backward compatibility", "status": "Required (analytic)", "content": "Must recover standard QM as C->1 and l_g/d->0", "type": "consistency"},
+    {"id": "P2", "name": "Geometric cutoff deviation", "status": "Downgraded", "content": "UV-cutoff deviation is exponentially suppressed; principled but inaccessible for sub-Planckian l_g", "type": "principled"},
+    {"id": "P3", "name": "S-sensitive decoherence", "status": "Open (primary candidate)", "content": "Decoherence modulated by local S via tau_d proportional to C(S); distinct from standard Lindblad if S definable independently of T", "blocked_by": "G2", "type": "empirical"},
+    {"id": "P4", "name": "Gradual which-path suppression", "status": "Open (secondary candidate)", "content": "Partial S-increase produces gradual interference suppression; distinguishable via higher-order statistics", "type": "empirical"},
+    {"id": "P5", "name": "No prediction for d >> l_g", "status": "Explicit no-claim", "content": "GRC makes no deviation prediction when d >> l_g and S is low", "type": "scope_limit"}
+  ],
+
+  "falsification_points": [
+    {"id": "F1", "condition": "Backward compatibility fails", "type": "analytic"},
+    {"id": "F2", "condition": "No scale-deviation where GRC predicts one", "note": "Principled, not operative for sub-Planckian l_g"},
+    {"id": "F3", "condition": "Decoherence fully reduced to T + environment with no S-component", "type": "nearest-term empirical"},
+    {"id": "F4", "condition": "Higher-order statistics identical to QM under partial measurement", "type": "empirical"},
+    {"id": "F5", "condition": "Delta P(x) doesn't decrease with d/l_g in UV-cutoff model", "type": "analytic"},
+    {"id": "F6", "condition": "Standard QM results at d >> l_g do NOT falsify GRC", "type": "scope_boundary"}
+  ],
+
+  "open_gaps": [
+    {"id": "G2", "priority": 1, "description": "Operational definition of local S", "blocks": "P3 testability", "status": "critical",
+     "candidates": [
+       {"id": "A", "name": "von Neumann entropy of subsystem", "assessment": "Weakest; likely reduces to standard QM"},
+       {"id": "B", "name": "Entanglement entropy against environment", "assessment": "Requires showing C(S_B) predicts different rate than Lindblad"},
+       {"id": "C", "name": "Free-energy or structural complexity proxy", "assessment": "Most EFC-native; hardest to operationalize; highest priority"}
+     ],
+     "success_criterion": "Produces (1) distinct proxy not reducible to T, (2) different functional form, (3) different dependence, or (4) different statistical signature"
+    },
+    {"id": "P3", "priority": 2, "description": "Formal decoherence model via C(S)", "blocks": "Main test candidate"},
+    {"id": "P4", "priority": 3, "description": "Concrete higher-order observable", "blocks": "Secondary test"},
+    {"id": "G3", "priority": 4, "description": "Explicit P(x) for concrete geometry", "blocks": "Numerical check"},
+    {"id": "G5", "priority": 5, "description": "Closure Condition 3 vs mode basis", "blocks": "Internal consistency"}
+  ],
+
+  "component_status": [
+    {"component": "Sections 1-6 (axioms through falsification)", "status": "Stable", "note": "Canonical"},
+    {"component": "M5 (geometric deviation)", "status": "Revised", "note": "Exponential, not polynomial"},
+    {"component": "P2 (geometric test)", "status": "Downgraded", "note": "Principled, not accessible"},
+    {"component": "P3 (S-sensitive decoherence)", "status": "Open", "note": "Primary test candidate"},
+    {"component": "P4 (fluctuation statistics)", "status": "Open", "note": "Secondary test candidate"},
+    {"component": "G2 (operational S)", "status": "Open", "note": "Highest priority gap"}
+  ],
+
+  "one_line_status": "Geometric cutoff test (P2) inaccessible for sub-Planckian l_g. Quantum distinction, if any, lies in measurement as entropy process (P3/P4), not interference geometry.",
+
+  "references": [
+    {"key": "[1]", "citation": "Feynman et al. 1965, Feynman Lectures Vol III"},
+    {"key": "[2]", "doi": "10.1103/RevModPhys.75.715", "citation": "Zurek 2003"},
+    {"key": "[3]", "doi": "10.1007/978-3-662-05328-7", "citation": "Joos et al. 2003"},
+    {"key": "[4]", "doi": "10.1038/351111a0", "citation": "Scully et al. 1991"},
+    {"key": "[5]", "doi": "10.1103/PhysRevLett.77.4887", "citation": "Brune et al. 1996"},
+    {"key": "[6]", "doi": "10.1038/44348", "citation": "Arndt et al. 1999"},
+    {"key": "[7]", "citation": "Rovelli 2004, Quantum Gravity"},
+    {"key": "[8]", "doi": "10.1007/BF01608499", "citation": "Lindblad 1976"},
+    {"key": "[9]", "citation": "Magnusson 2026, GRC Three-Field Synthesis"},
+    {"key": "[10]", "doi": "10.6084/m9.figshare.31223668", "citation": "EFC Ontological Foundations"},
+    {"key": "[11]", "doi": "10.6084/m9.figshare.31224466", "citation": "EFC Closure Conjectures"},
+    {"key": "[12]", "doi": "10.6084/m9.figshare.31224538", "citation": "EFC Phase 3 SPARC"},
+    {"key": "[13]", "doi": "10.6084/m9.figshare.31230703", "citation": "EFC DESI DR2 BAO"}
+  ]
+}

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/metadata.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/metadata.json
@@ -1,0 +1,32 @@
+{
+  "package_format": "efc-ai-friendly-v1",
+  "paper_id": "EFC-GRC-DoubleSlit-v02",
+  "title": "Double-Slit as Grid-Resolution Phenomenon in Grid-Rendering Cosmology",
+  "subtitle": "Ontological Extension, UV-Cutoff Analysis, and Open Gaps toward Quantum Testability",
+  "author": {"name": "Morten Magnusson", "orcid": "0009-0002-4860-5095"},
+  "version": "v0.2",
+  "date": "2026-03-08",
+  "status": "working_note",
+  "license": "CC-BY-4.0",
+  "topics": ["grid-rendering cosmology", "double-slit", "UV cutoff", "quantum uncertainty", "discrete geometry", "entropy decoherence"],
+  "ai_metadata": {
+    "ai_parseable": true,
+    "structured_data": ["index.json", "data/model_parameters.json"],
+    "executable_code": ["src/grc_double_slit.py", "examples/double_slit_demo.py"],
+    "linked_data": ["EFC-GRC-DoubleSlit.jsonld"],
+    "validation": ["schema.json"]
+  },
+  "files": [
+    {"path": "README.md", "type": "documentation", "format": "markdown"},
+    {"path": "index.json", "type": "structured_data", "format": "json"},
+    {"path": "schema.json", "type": "validation", "format": "json-schema"},
+    {"path": "metadata.json", "type": "metadata", "format": "json"},
+    {"path": "EFC-GRC-DoubleSlit.jsonld", "type": "linked_data", "format": "json-ld"},
+    {"path": "citations.bib", "type": "references", "format": "bibtex"},
+    {"path": "src/__init__.py", "type": "source", "format": "python"},
+    {"path": "src/grc_double_slit.py", "type": "source", "format": "python"},
+    {"path": "data/model_parameters.json", "type": "data", "format": "json"},
+    {"path": "examples/double_slit_demo.py", "type": "example", "format": "python"}
+  ],
+  "dependencies": {"python": ">=3.8", "numpy": ">=1.20"}
+}

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/schema.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GRC Double-Slit index.json schema",
+  "type": "object",
+  "required": ["paper_id", "title", "author", "axioms", "predictions", "falsification_points"],
+  "properties": {
+    "paper_id": {"type": "string"},
+    "title": {"type": "string"},
+    "author": {"type": "string"},
+    "axioms": {"type": "array", "items": {"type": "object", "required": ["id", "name", "content"]}},
+    "manifest_triad": {"type": "object"},
+    "uv_cutoff": {"type": "object"},
+    "predictions": {"type": "array", "items": {"type": "object", "required": ["id", "name", "status"]}},
+    "falsification_points": {"type": "array", "items": {"type": "object", "required": ["id", "condition"]}},
+    "open_gaps": {"type": "array"}
+  }
+}

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/src/__init__.py
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/src/__init__.py
@@ -1,0 +1,15 @@
+"""
+GRC Double-Slit — Reference Implementation
+Working Note v0.2, March 8, 2026
+"""
+from .grc_double_slit import (
+    GRCAxioms, EntropyClarity, UVCutoffModel,
+    PredictionStatus, OpenGaps,
+    PREDICTIONS, FALSIFICATION_POINTS, OPEN_GAPS, G2_CANDIDATES,
+)
+
+__all__ = [
+    "GRCAxioms", "EntropyClarity", "UVCutoffModel",
+    "PredictionStatus", "OpenGaps",
+    "PREDICTIONS", "FALSIFICATION_POINTS", "OPEN_GAPS", "G2_CANDIDATES",
+]

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/src/grc_double_slit.py
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/src/grc_double_slit.py
@@ -1,0 +1,255 @@
+"""
+GRC Double-Slit — Reference Implementation
+
+Grid-Rendering Cosmology: double-slit as grid-resolution phenomenon.
+UV-cutoff derivation, entropy-clarity function, predictions and gaps.
+
+Author: Morten Magnusson (ORCID: 0009-0002-4860-5095)
+Version: Working Note v0.2 (Revised), March 8, 2026
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional
+import numpy as np
+
+
+# =============================================================================
+# Axioms (Section 2)
+# =============================================================================
+
+GRC_AXIOMS = [
+    ("A1", "Grid (G)", "Discrete geometric substrate with fundamental node scale l_g"),
+    ("A2", "Energy Flow (E)", "Energy as distributed flow through G; localized=particle, distributed=field"),
+    ("A3", "Clarity Function C(S)", "C(S) = exp(-S/S_max); low S = high clarity"),
+    ("A4", "Manifest Structure", "Psi_manifest = G(x) tensor E(x,t) . C(S(x,t))"),
+    ("A5", "Grid-Resolution Limit", "Position limited by l_g"),
+    ("A6", "Registration", "Measurement = local selection and stabilization of Psi_manifest"),
+]
+
+
+class GRCAxioms:
+    """GRC axiom set (Section 2)."""
+    def __init__(self):
+        self.axioms = GRC_AXIOMS
+
+    def summary(self):
+        lines = ["GRC Axioms (Section 2)", "=" * 60]
+        for aid, name, content in self.axioms:
+            lines.append(f"  {aid}: {name}")
+            lines.append(f"      {content}")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Entropy-Clarity Function (Axiom A3)
+# =============================================================================
+
+class EntropyClarity:
+    """Clarity function C(S) = exp(-S/S_max) — Eq. (1).
+
+    Parameters
+    ----------
+    S_max : float
+        Maximum entropy scale (default 1.0).
+    """
+    def __init__(self, S_max: float = 1.0):
+        self.S_max = S_max
+
+    def __call__(self, S):
+        """Evaluate C(S) = exp(-S/S_max)."""
+        S = np.asarray(S, dtype=float)
+        return np.exp(-S / self.S_max)
+
+    def decoherence_time_factor(self, S):
+        """tau_d proportional to C(S) — Eq. (7)."""
+        return self.__call__(S)
+
+
+# =============================================================================
+# UV-Cutoff Model (Section 7)
+# =============================================================================
+
+class UVCutoffModel:
+    """UV-cutoff realization of GRC grid-resolution — Eqs. (8)-(14).
+
+    Parameters
+    ----------
+    l_g : float
+        Grid node scale (fundamental length).
+    sigma : float
+        Gaussian slit width.
+    D : float
+        Slit separation (default 1e-4 m).
+    """
+    def __init__(self, l_g: float = 1e-35, sigma: float = 1e-6, D: float = 1e-4):
+        self.l_g = l_g
+        self.sigma = sigma
+        self.D = D
+
+    @property
+    def k_max(self) -> float:
+        """UV cutoff: k_max = pi / l_g."""
+        return np.pi / self.l_g
+
+    def gaussian_fourier(self, k):
+        """Fourier amplitude for double-Gaussian slit — Eq. (11)."""
+        k = np.asarray(k, dtype=float)
+        return np.exp(-self.sigma**2 * k**2 / 2) * np.cos(k * self.D / 2)
+
+    def deviation_bound(self) -> float:
+        """Upper bound on |Delta A| for Gaussian slit — Eq. (14).
+
+        |Delta A| <= (l_g / pi sigma^2) exp(-pi^2 sigma^2 / 2 l_g^2)
+        """
+        ratio = self.sigma / self.l_g
+        exponent = -np.pi**2 * ratio**2 / 2
+        if exponent < -700:
+            return 0.0
+        prefactor = self.l_g / (np.pi * self.sigma**2)
+        return prefactor * np.exp(exponent)
+
+    def is_accessible(self, threshold: float = 1e-100) -> bool:
+        """True if deviation is above threshold (practically measurable)."""
+        return self.deviation_bound() > threshold
+
+    def grc_amplitude(self, x, n_points: int = 10000):
+        """Compute A_GRC(x) via numerical integration with UV cutoff — Eq. (8)."""
+        x = np.asarray(x, dtype=float)
+        k = np.linspace(-self.k_max, self.k_max, n_points)
+        dk = k[1] - k[0]
+        a_k = self.gaussian_fourier(k)
+        A = np.array([np.sum(a_k * np.exp(1j * k * xi)) * dk for xi in x])
+        return A
+
+    def qm_amplitude(self, x):
+        """Standard QM amplitude (analytic for Gaussian slits)."""
+        x = np.asarray(x, dtype=float)
+        env = np.exp(-x**2 / (2 * self.sigma**2))
+        return env * np.cos(np.pi * x * self.D / (2 * self.sigma**2))
+
+    def summary(self):
+        dev = self.deviation_bound()
+        lines = [
+            "UV-Cutoff Model (Section 7)",
+            "=" * 50,
+            f"l_g   = {self.l_g:.2e} m",
+            f"sigma = {self.sigma:.2e} m",
+            f"D     = {self.D:.2e} m",
+            f"k_max = pi/l_g = {self.k_max:.2e} m^-1",
+            f"sigma/l_g = {self.sigma/self.l_g:.2e}",
+            f"|Delta A| bound = {dev:.2e}",
+            f"Accessible: {self.is_accessible()}",
+        ]
+        if dev == 0.0:
+            lines.append("(Deviation underflows to zero — exponential suppression)")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Predictions (Section 5)
+# =============================================================================
+
+@dataclass
+class GRCPrediction:
+    """One prediction from Section 5."""
+    id: str
+    name: str
+    status: str
+    content: str
+    prediction_type: str
+    blocked_by: Optional[str] = None
+
+
+PREDICTIONS = [
+    GRCPrediction("P1", "Backward compatibility", "Required (analytic)",
+                  "Recover QM as C->1 and l_g/d->0", "consistency"),
+    GRCPrediction("P2", "Geometric cutoff deviation", "Downgraded",
+                  "Exponentially suppressed; principled but inaccessible", "principled"),
+    GRCPrediction("P3", "S-sensitive decoherence", "Open (primary)",
+                  "tau_d ~ C(S); distinct from Lindblad if S definable independently of T",
+                  "empirical", "G2"),
+    GRCPrediction("P4", "Gradual which-path suppression", "Open (secondary)",
+                  "Distinguishable via higher-order statistics under partial measurement",
+                  "empirical"),
+    GRCPrediction("P5", "No prediction for d >> l_g", "Explicit no-claim",
+                  "GRC makes no deviation prediction when d >> l_g and S is low",
+                  "scope_limit"),
+]
+
+
+class PredictionStatus:
+    """Prediction register for GRC double-slit (Section 5)."""
+    def __init__(self):
+        self.predictions = PREDICTIONS
+
+    def summary(self):
+        lines = ["Predictions (Section 5)", "=" * 60,
+                 f"{'ID':<5} {'Name':<30} {'Status':<25}",
+                 "-" * 60]
+        for p in self.predictions:
+            lines.append(f"{p.id:<5} {p.name:<30} {p.status:<25}")
+        return "\n".join(lines)
+
+
+# =============================================================================
+# Falsification Points (Section 6)
+# =============================================================================
+
+FALSIFICATION_POINTS = [
+    ("F1", "Backward compatibility fails", "analytic"),
+    ("F2", "No scale-deviation where GRC predicts one", "principled (not operative)"),
+    ("F3", "Decoherence fully reduced to T + environment; no S-component", "nearest-term empirical"),
+    ("F4", "Higher-order statistics identical to QM under partial measurement", "empirical"),
+    ("F5", "Delta P(x) doesn't decrease with d/l_g", "analytic"),
+    ("F6", "Standard QM results at d >> l_g do NOT falsify GRC", "scope boundary"),
+]
+
+
+# =============================================================================
+# Open Gaps (Section 8)
+# =============================================================================
+
+@dataclass
+class OpenGap:
+    """One open gap from Table 1."""
+    id: str
+    priority: int
+    description: str
+    blocks: str
+
+
+OPEN_GAPS = [
+    OpenGap("G2", 1, "Operational definition of local S", "P3 testability"),
+    OpenGap("P3", 2, "Formal decoherence model via C(S)", "Main test candidate"),
+    OpenGap("P4", 3, "Concrete higher-order observable", "Secondary test"),
+    OpenGap("G3", 4, "Explicit P(x) for concrete geometry", "Numerical check"),
+    OpenGap("G5", 5, "Closure Condition 3 vs mode basis", "Internal consistency"),
+]
+
+G2_CANDIDATES = [
+    ("A", "von Neumann entropy of subsystem", "Weakest; likely reduces to standard QM"),
+    ("B", "Entanglement entropy against environment", "Requires different rate than Lindblad"),
+    ("C", "Free-energy or structural complexity proxy", "Most EFC-native; hardest; highest priority"),
+]
+
+
+class OpenGaps:
+    """Open gaps and priorities (Section 8, Table 1)."""
+    def __init__(self):
+        self.gaps = OPEN_GAPS
+        self.g2_candidates = G2_CANDIDATES
+
+    def summary(self):
+        lines = [
+            "Open Gaps (Table 1)", "=" * 60,
+            f"{'Pri':<5} {'Gap':<5} {'Description':<35} {'Blocks':<20}",
+            "-" * 60,
+        ]
+        for g in self.gaps:
+            lines.append(f"{g.priority:<5} {g.id:<5} {g.description:<35} {g.blocks:<20}")
+        lines.append("")
+        lines.append("G2 Candidates for operational S:")
+        for cid, name, assess in self.g2_candidates:
+            lines.append(f"  {cid}: {name}")
+            lines.append(f"     {assess}")
+        return "\n".join(lines)


### PR DESCRIPTION
Complete AI-friendly package for "Double-Slit as Grid-Resolution Phenomenon in Grid-Rendering Cosmology" (Working Note v0.2).

Package includes:
- README.md: Six axioms, UV-cutoff derivation, 5 predictions, 6 falsification points, 5 open gaps with G2 candidates
- index.json: Full machine-readable metadata with equations, manifest triad, UV cutoff formulas
- schema.json, metadata.json, JSON-LD, citations.bib (13 refs)
- src/grc_double_slit.py: GRCAxioms, EntropyClarity, UVCutoffModel, PredictionStatus, OpenGaps classes
- data/model_parameters.json: All parameters and component status
- examples/double_slit_demo.py: Runnable demo with scaling analysis

https://claude.ai/code/session_012Tf9r7G7HE7YmiFRr6yK2e