### PR TITLE
Map 124 ORCID DOIs to paper directories in doi-map.json

### DIFF
--- a/docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology/index.json
+++ b/docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology/index.json
@@ -13,5 +13,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30656828"
 }

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/index.json
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/index.json
@@ -43,13 +43,20 @@
       "redshift": 0,
       "resolution": "TNG300-1",
       "gas_mass_resolution": {
-        "value": 1.2e7,
+        "value": 12000000.0,
         "unit": "M_sun"
       }
     },
     "lehle_catalogue": {
       "reference": "Lehle et al. 2024",
-      "variables": ["K0", "ne_slope", "tcool", "ne", "Cphys", "Cscaled"],
+      "variables": [
+        "K0",
+        "ne_slope",
+        "tcool",
+        "ne",
+        "Cphys",
+        "Cscaled"
+      ],
       "gas_selection": "non-star-forming, T > 1e6 K, mass-weighted"
     },
     "accept": {
@@ -84,7 +91,7 @@
       "interpretation": "Lower bound on alpha under physical temperature gradient assumption",
       "tng_distribution": {
         "min": -0.23,
-        "max": 1.60,
+        "max": 1.6,
         "median": 0.31
       }
     },
@@ -110,9 +117,18 @@
       }
     },
     "tng_population": {
-      "SCC": {"count": 28, "fraction": 0.08},
-      "WCC": {"count": 206, "fraction": 0.59},
-      "NCC": {"count": 118, "fraction": 0.34}
+      "SCC": {
+        "count": 28,
+        "fraction": 0.08
+      },
+      "WCC": {
+        "count": 206,
+        "fraction": 0.59
+      },
+      "NCC": {
+        "count": 118,
+        "fraction": 0.34
+      }
     }
   },
   "results": {
@@ -138,26 +154,58 @@
     },
     "mass_controlled": {
       "partial_ne_slope_K0_given_M": {
-        "rho": -0.880,
+        "rho": -0.88,
         "p_value": "2e-115",
         "mass_contribution": "0%"
       },
       "interpretation": "Sign flip is NOT driven by mass confounding"
     },
     "mass_binned": [
-      {"bin": "[14.0, 14.3)", "N": 41, "rho": -0.790, "p_value": "9e-10"},
-      {"bin": "[14.3, 14.6)", "N": 118, "rho": -0.860, "p_value": "1e-35"},
-      {"bin": "[14.6, 14.9)", "N": 121, "rho": -0.901, "p_value": "5e-45"},
-      {"bin": "[14.9, 15.5)", "N": 71, "rho": -0.897, "p_value": "4e-26"}
+      {
+        "bin": "[14.0, 14.3)",
+        "N": 41,
+        "rho": -0.79,
+        "p_value": "9e-10"
+      },
+      {
+        "bin": "[14.3, 14.6)",
+        "N": 118,
+        "rho": -0.86,
+        "p_value": "1e-35"
+      },
+      {
+        "bin": "[14.6, 14.9)",
+        "N": 121,
+        "rho": -0.901,
+        "p_value": "5e-45"
+      },
+      {
+        "bin": "[14.9, 15.5)",
+        "N": 71,
+        "rho": -0.897,
+        "p_value": "4e-26"
+      }
     ],
     "proxy_definition_matching": {
-      "alpha_proxy_vs_K0_raw": {"rho": -0.872, "p_value": "8e-111"},
-      "alpha_proxy_vs_K0_partial_M": {"rho": -0.880, "p_value": "2e-115"},
-      "alpha_proxy_vs_tcool_raw": {"rho": -0.878, "p_value": "7e-114"},
-      "alpha_proxy_vs_tcool_partial_M": {"rho": -0.876, "p_value": "1e-112"}
+      "alpha_proxy_vs_K0_raw": {
+        "rho": -0.872,
+        "p_value": "8e-111"
+      },
+      "alpha_proxy_vs_K0_partial_M": {
+        "rho": -0.88,
+        "p_value": "2e-115"
+      },
+      "alpha_proxy_vs_tcool_raw": {
+        "rho": -0.878,
+        "p_value": "7e-114"
+      },
+      "alpha_proxy_vs_tcool_partial_M": {
+        "rho": -0.876,
+        "p_value": "1e-112"
+      }
     },
     "ks_test_scc_vs_ncc": {
-      "D_statistic": 1.000,
+      "D_statistic": 1.0,
       "p_value": "2.4e-30",
       "interpretation": "Complete separation between SCC and NCC density slopes"
     }
@@ -175,7 +223,10 @@
       "description": "Full Cavagnolo-model K(r) fit over [20, 400] kpc",
       "parameters_locked": {
         "centre": "SUBFIND-determined",
-        "fit_range_kpc": [20, 400],
+        "fit_range_kpc": [
+          20,
+          400
+        ],
         "initial_alpha_guess": 1.1,
         "binning": "mass-weighted",
         "n_radial_bins": 30,
@@ -218,13 +269,38 @@
     "documentation": "README.md"
   },
   "references": [
-    {"key": "Cavagnolo2009", "citation": "Cavagnolo, K. W., et al. 2009, ApJS, 182, 12"},
-    {"key": "Fabian1994", "citation": "Fabian, A. C. 1994, ARA&A, 32, 277"},
-    {"key": "Hudson2010", "citation": "Hudson, D. S., et al. 2010, A&A, 513, A37"},
-    {"key": "Lehle2024", "citation": "Lehle, K., et al. 2024, A&A, 687, A30"},
-    {"key": "Nelson2024", "citation": "Nelson, D., et al. 2024, A&A, 686, A157"},
-    {"key": "Peterson2006", "citation": "Peterson, J. R. & Fabian, A. C. 2006, Phys. Rep., 427, 1"},
-    {"key": "Pillepich2018", "citation": "Pillepich, A., et al. 2018, MNRAS, 473, 4077"},
-    {"key": "Weinberger2017", "citation": "Weinberger, R., et al. 2017, MNRAS, 465, 3291"}
-  ]
+    {
+      "key": "Cavagnolo2009",
+      "citation": "Cavagnolo, K. W., et al. 2009, ApJS, 182, 12"
+    },
+    {
+      "key": "Fabian1994",
+      "citation": "Fabian, A. C. 1994, ARA&A, 32, 277"
+    },
+    {
+      "key": "Hudson2010",
+      "citation": "Hudson, D. S., et al. 2010, A&A, 513, A37"
+    },
+    {
+      "key": "Lehle2024",
+      "citation": "Lehle, K., et al. 2024, A&A, 687, A30"
+    },
+    {
+      "key": "Nelson2024",
+      "citation": "Nelson, D., et al. 2024, A&A, 686, A157"
+    },
+    {
+      "key": "Peterson2006",
+      "citation": "Peterson, J. R. & Fabian, A. C. 2006, Phys. Rep., 427, 1"
+    },
+    {
+      "key": "Pillepich2018",
+      "citation": "Pillepich, A., et al. 2018, MNRAS, 473, 4077"
+    },
+    {
+      "key": "Weinberger2017",
+      "citation": "Weinberger, R., et al. 2017, MNRAS, 465, 3291"
+    }
+  ],
+  "doi": "10.6084/m9.figshare.31286368"
 }

--- a/docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes/index.json
+++ b/docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes/index.json
@@ -41,7 +41,7 @@
       "alpha": {
         "symbol": "α",
         "description": "Lensing response amplitude",
-        "best_fit": 0.10,
+        "best_fit": 0.1,
         "unit": "dimensionless"
       },
       "k_trans": {
@@ -118,7 +118,10 @@
     },
     "comparison": {
       "cmb": "Planck 2018",
-      "other_wl": ["DES-Y3", "HSC-Y1"]
+      "other_wl": [
+        "DES-Y3",
+        "HSC-Y1"
+      ]
     }
   },
   "comparison_with_lcdm": {
@@ -158,5 +161,6 @@
       "doi": "10.6084/m9.figshare.31243828",
       "relation": "Growth constraints"
     }
-  ]
+  ],
+  "doi": "10.6084/m9.figshare.31271917"
 }

--- a/docs/papers/efc/CEM-Consciousness-Ego-Mirror/index.json
+++ b/docs/papers/efc/CEM-Consciousness-Ego-Mirror/index.json
@@ -13,5 +13,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30275947"
 }

--- a/docs/papers/efc/CMB-Thermodynamic-Interpretation/index.json
+++ b/docs/papers/efc/CMB-Thermodynamic-Interpretation/index.json
@@ -13,45 +13,107 @@
   "license": "CC-BY-4.0",
   "type": "null_test_framework",
   "status": "published",
-
   "abstract": "CMB compatibility framework for EFC with null tests: theta_s within 0.5%, damping scale within 5%, A_L in 0.9-0.95 range. Predictions for ISW phase shift and lensing evolution. JWST observations constrain S(z) which is tested against CMB constraints without parameter fitting.",
-
   "keywords": [
-    "CMB", "thermodynamic interpretation", "null tests", "EFC",
-    "Planck", "lensing", "ISW", "entropy profile", "JWST"
+    "CMB",
+    "thermodynamic interpretation",
+    "null tests",
+    "EFC",
+    "Planck",
+    "lensing",
+    "ISW",
+    "entropy profile",
+    "JWST"
   ],
-
   "core_principle": {
-    "causal_chain": ["JWST", "S(z)", "CMB"],
-    "constraints": ["No parameter fitting", "No circular inference", "Causal ordering enforced"]
+    "causal_chain": [
+      "JWST",
+      "S(z)",
+      "CMB"
+    ],
+    "constraints": [
+      "No parameter fitting",
+      "No circular inference",
+      "Causal ordering enforced"
+    ]
   },
-
   "compatibility_constraints": [
-    {"observable": "theta_s", "value": "100.09 +/- 0.30 arcmin", "requirement": "within_uncertainty"},
-    {"observable": "peak_ratio_R", "value": "~0.42", "requirement": "within_2sigma"},
-    {"observable": "damping_scale_lD", "requirement": "standard_functional_form"},
-    {"observable": "TE_EE_correlation", "value": "positive", "requirement": "sign_preserved"}
+    {
+      "observable": "theta_s",
+      "value": "100.09 +/- 0.30 arcmin",
+      "requirement": "within_uncertainty"
+    },
+    {
+      "observable": "peak_ratio_R",
+      "value": "~0.42",
+      "requirement": "within_2sigma"
+    },
+    {
+      "observable": "damping_scale_lD",
+      "requirement": "standard_functional_form"
+    },
+    {
+      "observable": "TE_EE_correlation",
+      "value": "positive",
+      "requirement": "sign_preserved"
+    }
   ],
-
   "prediction_zones": [
-    {"observable": "A_L", "prediction": "< 1.0", "mechanism": "smoother_halos"},
-    {"observable": "ISW_phase", "prediction": "0.01-0.1 rad at l > 1000", "mechanism": "energy_flow_coupling"},
-    {"observable": "C_l_phiphi", "prediction": "z-dependent at high l", "mechanism": "entropy_gradient_evolution"}
+    {
+      "observable": "A_L",
+      "prediction": "< 1.0",
+      "mechanism": "smoother_halos"
+    },
+    {
+      "observable": "ISW_phase",
+      "prediction": "0.01-0.1 rad at l > 1000",
+      "mechanism": "energy_flow_coupling"
+    },
+    {
+      "observable": "C_l_phiphi",
+      "prediction": "z-dependent at high l",
+      "mechanism": "entropy_gradient_evolution"
+    }
   ],
-
   "null_tests": [
-    {"name": "peak_position_invariance", "criterion": "theta_s within 0.5%", "falsification": "deviation > 0.5%"},
-    {"name": "damping_consistency", "criterion": "l_D within 5%", "falsification": "systematic deviation"},
-    {"name": "lensing_growth_consistency", "criterion": "A_L in range 0.9-0.95", "falsification": "A_L >= 1.0 at high significance"}
+    {
+      "name": "peak_position_invariance",
+      "criterion": "theta_s within 0.5%",
+      "falsification": "deviation > 0.5%"
+    },
+    {
+      "name": "damping_consistency",
+      "criterion": "l_D within 5%",
+      "falsification": "systematic deviation"
+    },
+    {
+      "name": "lensing_growth_consistency",
+      "criterion": "A_L in range 0.9-0.95",
+      "falsification": "A_L >= 1.0 at high significance"
+    }
   ],
-
   "efc_parameters": [
-    {"symbol": "S_0", "name": "Entropy at z=0", "constraint_source": "SPARC rotation curves"},
-    {"symbol": "S_eq", "name": "Entropy at matter-radiation equality", "constraint_source": "CMB peak structure"},
-    {"symbol": "alpha_S", "name": "Entropy coupling strength", "constraint_source": "JWST sSFR correlation"},
-    {"symbol": "n_S", "name": "Entropy profile exponent", "constraint_source": "Cross-scale consistency"}
+    {
+      "symbol": "S_0",
+      "name": "Entropy at z=0",
+      "constraint_source": "SPARC rotation curves"
+    },
+    {
+      "symbol": "S_eq",
+      "name": "Entropy at matter-radiation equality",
+      "constraint_source": "CMB peak structure"
+    },
+    {
+      "symbol": "alpha_S",
+      "name": "Entropy coupling strength",
+      "constraint_source": "JWST sSFR correlation"
+    },
+    {
+      "symbol": "n_S",
+      "name": "Entropy profile exponent",
+      "constraint_source": "Cross-scale consistency"
+    }
   ],
-
   "empirical_basis": {
     "source": "JWST/COSMOS-Web",
     "sample_size": 26288,
@@ -60,7 +122,6 @@
     "df": 4,
     "p_value": "<10^-9"
   },
-
   "files": {
     "readme": "README.md",
     "schema": "schema.json",
@@ -70,5 +131,6 @@
     "source": "src/cmb_thermodynamic.py",
     "data": "data/cmb_thermodynamic_data.json",
     "demo": "examples/demo_cmb_thermodynamic.py"
-  }
+  },
+  "doi": "10.6084/m9.figshare.31064929"
 }

--- a/docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling/index.json
+++ b/docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling/index.json
@@ -20,7 +20,10 @@
     "n_datapoints": 3391,
     "mean_points_per_galaxy": 19.4,
     "std_points_per_galaxy": 16.0,
-    "range": [4, 115]
+    "range": [
+      4,
+      115
+    ]
   },
   "results": {
     "regimes": {
@@ -28,7 +31,7 @@
         "n": 62,
         "percentage": 35.4,
         "efc_success_rate": 100.0,
-        "mean_L": 0.290,
+        "mean_L": 0.29,
         "std_L": 0.143,
         "mean_chi2_red": 2.05,
         "std_chi2_red": 2.82
@@ -46,16 +49,16 @@
         "n": 27,
         "percentage": 15.4,
         "efc_success_rate": 3.7,
-        "mean_L": 0.500,
+        "mean_L": 0.5,
         "std_L": 0.111,
         "mean_chi2_red": 297.83,
-        "std_chi2_red": 553.50
+        "std_chi2_red": 553.5
       }
     },
     "statistics": {
       "mann_whitney": {
         "test": "FLOW vs LATENT separation",
-        "p_value": 0.0000,
+        "p_value": 0.0,
         "conclusion": "Highly significant (p < 0.0001)"
       },
       "spearman": {
@@ -98,9 +101,18 @@
       "formula": "v(r) = v_flat × sqrt(1 - exp(-(r/r_turnon)^sharpness))",
       "parameters": 3,
       "bounds": {
-        "v_flat": [50, 200],
-        "r_turnon": [0.1, 30],
-        "sharpness": [0.5, 5.0]
+        "v_flat": [
+          50,
+          200
+        ],
+        "r_turnon": [
+          0.1,
+          30
+        ],
+        "sharpness": [
+          0.5,
+          5.0
+        ]
       }
     },
     "comparison": {
@@ -112,8 +124,8 @@
       "method": "differential_evolution",
       "maxiter": 300,
       "seed": 42,
-      "atol": 1e-6,
-      "tol": 1e-4
+      "atol": 1e-06,
+      "tol": 0.0001
     },
     "classification": {
       "FLOW": "ΔAIC ≤ -10 AND χ²_red < 20",
@@ -159,5 +171,6 @@
     "last_updated": "2026-01-11",
     "format_version": "1.0",
     "schema": "schema.json"
-  }
+  },
+  "doi": "10.6084/m9.figshare.31045126"
 }

--- a/docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity/index.json
+++ b/docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity/index.json
@@ -108,8 +108,17 @@
   ],
   "files": {
     "paper": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity.pdf",
-    "documentation": ["README.md", "QUICKSTART.md", "MANIFEST.md"],
-    "metadata": ["CITATION.cff", "index.json", "CosmologicalGrowthConstraints.jsonld", "schema.json"],
+    "documentation": [
+      "README.md",
+      "QUICKSTART.md",
+      "MANIFEST.md"
+    ],
+    "metadata": [
+      "CITATION.cff",
+      "index.json",
+      "CosmologicalGrowthConstraints.jsonld",
+      "schema.json"
+    ],
     "source_code": [
       "src/__init__.py",
       "src/geff_coupling.py",
@@ -125,5 +134,6 @@
       "examples/run_scenarios.py",
       "examples/geff_profile.py"
     ]
-  }
+  },
+  "doi": "10.6084/m9.figshare.31348414"
 }

--- a/docs/papers/efc/Directional_Lensing_Residuals/index.json
+++ b/docs/papers/efc/Directional_Lensing_Residuals/index.json
@@ -35,7 +35,31 @@
         "description": "Rotation null distribution",
         "n_angles": 23,
         "step_degrees": 15,
-        "angles": [15, 30, 45, 60, 75, 90, 105, 120, 135, 150, 165, 180, 195, 210, 225, 240, 255, 270, 285, 300, 315, 330, 345]
+        "angles": [
+          15,
+          30,
+          45,
+          60,
+          75,
+          90,
+          105,
+          120,
+          135,
+          150,
+          165,
+          180,
+          195,
+          210,
+          225,
+          240,
+          255,
+          270,
+          285,
+          300,
+          315,
+          330,
+          345
+        ]
       },
       "sigma_MAD": {
         "formula": "1.4826 * MAD[A_rot]",
@@ -188,7 +212,11 @@
       {
         "name": "Abell 2146",
         "feature": "Double-shock system",
-        "references": ["Russell et al. 2010", "Russell et al. 2012", "Russell et al. 2022"]
+        "references": [
+          "Russell et al. 2010",
+          "Russell et al. 2012",
+          "Russell et al. 2022"
+        ]
       }
     ]
   },
@@ -216,5 +244,6 @@
     "examples": "examples/directional_lensing_demo.py",
     "citation": "CITATION.cff",
     "license": "LICENSE"
-  }
+  },
+  "doi": "10.6084/m9.figshare.31288063"
 }

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/index.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/index.json
@@ -9,33 +9,72 @@
   "date": "2026-03-08",
   "status": "Working note. Not peer-reviewed.",
   "scope": "Ontological and minimal-model extension of GRC to sub-L0 quantum regime. Not an empirical closure paper.",
-
   "abstract": "GRC treats quantum uncertainty as grid-resolution: Delta x >= l_g. UV-cutoff derivation shows geometric deviation from QM is exponentially suppressed: |Delta A| ~ exp(-pi^2 sigma^2 / 2 l_g^2). Primary testable distinction relocated to entropy-sensitive decoherence (P3) and higher-order measurement statistics (P4). Polynomial ansatz O((l_g/d)^2) withdrawn.",
-
   "manifest_triad": {
     "equation": "Psi_manifest(x,t) = G(x) ⊗ E(x,t) · C(S(x,t))",
     "G": "Discrete geometric substrate with node scale l_g",
     "E": "Energy flow through G (dynamic mode)",
     "C_S": "Clarity function: C(S) = exp(-S/S_max)"
   },
-
   "axioms": [
-    {"id": "A1", "name": "Grid (G)", "content": "Discrete geometric substrate with fundamental node scale l_g"},
-    {"id": "A2", "name": "Energy Flow (E)", "content": "Energy manifests as distributed flow through G; localized = particle-like, distributed = field-like"},
-    {"id": "A3", "name": "Clarity Function C(S)", "content": "C(S) = exp(-S/S_max); low S = high clarity, high S = low clarity"},
-    {"id": "A4", "name": "Manifest Structure", "content": "Psi_manifest = G(x) ⊗ E(x,t) · C(S(x,t)); no registration without triad"},
-    {"id": "A5", "name": "Grid-Resolution Limit", "content": "Spatial registration limited by l_g; position cannot be realized below l_g"},
-    {"id": "A6", "name": "Registration as Local Selection", "content": "Measurement = physical process that locally selects and stabilizes Psi_manifest"}
+    {
+      "id": "A1",
+      "name": "Grid (G)",
+      "content": "Discrete geometric substrate with fundamental node scale l_g"
+    },
+    {
+      "id": "A2",
+      "name": "Energy Flow (E)",
+      "content": "Energy manifests as distributed flow through G; localized = particle-like, distributed = field-like"
+    },
+    {
+      "id": "A3",
+      "name": "Clarity Function C(S)",
+      "content": "C(S) = exp(-S/S_max); low S = high clarity, high S = low clarity"
+    },
+    {
+      "id": "A4",
+      "name": "Manifest Structure",
+      "content": "Psi_manifest = G(x) ⊗ E(x,t) · C(S(x,t)); no registration without triad"
+    },
+    {
+      "id": "A5",
+      "name": "Grid-Resolution Limit",
+      "content": "Spatial registration limited by l_g; position cannot be realized below l_g"
+    },
+    {
+      "id": "A6",
+      "name": "Registration as Local Selection",
+      "content": "Measurement = physical process that locally selects and stabilizes Psi_manifest"
+    }
   ],
-
   "definitions": [
-    {"id": "D1", "name": "Geometry as boundary condition", "content": "Double-slit = boundary condition selecting subset of allowed grid modes"},
-    {"id": "D2", "name": "Interference as distributed grid-coupling", "content": "High C(S) maintains distributed coupling; P(x) = weighted distribution over allowed positions"},
-    {"id": "D3", "name": "Registration as local selection", "content": "Distributed manifest structure selected and stabilized as local event"},
-    {"id": "D4", "name": "Measurement as entropic localization", "content": "Which-path measurement increases S locally, lowers C(S), reduces distributed coupling"},
-    {"id": "D5", "name": "Scale limit", "content": "At d ~ l_g, continuous approximation breaks; possible QM distinction"}
+    {
+      "id": "D1",
+      "name": "Geometry as boundary condition",
+      "content": "Double-slit = boundary condition selecting subset of allowed grid modes"
+    },
+    {
+      "id": "D2",
+      "name": "Interference as distributed grid-coupling",
+      "content": "High C(S) maintains distributed coupling; P(x) = weighted distribution over allowed positions"
+    },
+    {
+      "id": "D3",
+      "name": "Registration as local selection",
+      "content": "Distributed manifest structure selected and stabilized as local event"
+    },
+    {
+      "id": "D4",
+      "name": "Measurement as entropic localization",
+      "content": "Which-path measurement increases S locally, lowers C(S), reduces distributed coupling"
+    },
+    {
+      "id": "D5",
+      "name": "Scale limit",
+      "content": "At d ~ l_g, continuous approximation breaks; possible QM distinction"
+    }
   ],
-
   "minimal_model": {
     "M1": "Grid-mode basis {phi_n(x)} with resolution l_g; recovers QM as l_g -> 0",
     "M2": "Amplitude: A(x) = sum_n a_n phi_n(x) C(S_n)",
@@ -43,7 +82,6 @@
     "M4": "Decoherence: local S-increase suppresses cross-terms in |A(x)|^2",
     "M5_revised": "UV cutoff: Delta A = integral[|k|>pi/l_g] a-tilde(k) e^{ikx} dk"
   },
-
   "uv_cutoff": {
     "grc_amplitude": "A_GRC(x) = integral[-kmax,kmax] a-tilde(k) e^{ikx} dk, kmax = pi/l_g",
     "qm_amplitude": "A_QM(x) = integral[-inf,inf] a-tilde(k) e^{ikx} dk",
@@ -53,63 +91,223 @@
     "conclusion": "Exponentially suppressed for sigma >> l_g; polynomial ansatz O((l_g/d)^2) withdrawn",
     "practical_implication": "For sub-Planckian l_g, deviation is numerically indistinguishable from zero"
   },
-
   "predictions": [
-    {"id": "P1", "name": "Backward compatibility", "status": "Required (analytic)", "content": "Must recover standard QM as C->1 and l_g/d->0", "type": "consistency"},
-    {"id": "P2", "name": "Geometric cutoff deviation", "status": "Downgraded", "content": "UV-cutoff deviation is exponentially suppressed; principled but inaccessible for sub-Planckian l_g", "type": "principled"},
-    {"id": "P3", "name": "S-sensitive decoherence", "status": "Open (primary candidate)", "content": "Decoherence modulated by local S via tau_d proportional to C(S); distinct from standard Lindblad if S definable independently of T", "blocked_by": "G2", "type": "empirical"},
-    {"id": "P4", "name": "Gradual which-path suppression", "status": "Open (secondary candidate)", "content": "Partial S-increase produces gradual interference suppression; distinguishable via higher-order statistics", "type": "empirical"},
-    {"id": "P5", "name": "No prediction for d >> l_g", "status": "Explicit no-claim", "content": "GRC makes no deviation prediction when d >> l_g and S is low", "type": "scope_limit"}
-  ],
-
-  "falsification_points": [
-    {"id": "F1", "condition": "Backward compatibility fails", "type": "analytic"},
-    {"id": "F2", "condition": "No scale-deviation where GRC predicts one", "note": "Principled, not operative for sub-Planckian l_g"},
-    {"id": "F3", "condition": "Decoherence fully reduced to T + environment with no S-component", "type": "nearest-term empirical"},
-    {"id": "F4", "condition": "Higher-order statistics identical to QM under partial measurement", "type": "empirical"},
-    {"id": "F5", "condition": "Delta P(x) doesn't decrease with d/l_g in UV-cutoff model", "type": "analytic"},
-    {"id": "F6", "condition": "Standard QM results at d >> l_g do NOT falsify GRC", "type": "scope_boundary"}
-  ],
-
-  "open_gaps": [
-    {"id": "G2", "priority": 1, "description": "Operational definition of local S", "blocks": "P3 testability", "status": "critical",
-     "candidates": [
-       {"id": "A", "name": "von Neumann entropy of subsystem", "assessment": "Weakest; likely reduces to standard QM"},
-       {"id": "B", "name": "Entanglement entropy against environment", "assessment": "Requires showing C(S_B) predicts different rate than Lindblad"},
-       {"id": "C", "name": "Free-energy or structural complexity proxy", "assessment": "Most EFC-native; hardest to operationalize; highest priority"}
-     ],
-     "success_criterion": "Produces (1) distinct proxy not reducible to T, (2) different functional form, (3) different dependence, or (4) different statistical signature"
+    {
+      "id": "P1",
+      "name": "Backward compatibility",
+      "status": "Required (analytic)",
+      "content": "Must recover standard QM as C->1 and l_g/d->0",
+      "type": "consistency"
     },
-    {"id": "P3", "priority": 2, "description": "Formal decoherence model via C(S)", "blocks": "Main test candidate"},
-    {"id": "P4", "priority": 3, "description": "Concrete higher-order observable", "blocks": "Secondary test"},
-    {"id": "G3", "priority": 4, "description": "Explicit P(x) for concrete geometry", "blocks": "Numerical check"},
-    {"id": "G5", "priority": 5, "description": "Closure Condition 3 vs mode basis", "blocks": "Internal consistency"}
+    {
+      "id": "P2",
+      "name": "Geometric cutoff deviation",
+      "status": "Downgraded",
+      "content": "UV-cutoff deviation is exponentially suppressed; principled but inaccessible for sub-Planckian l_g",
+      "type": "principled"
+    },
+    {
+      "id": "P3",
+      "name": "S-sensitive decoherence",
+      "status": "Open (primary candidate)",
+      "content": "Decoherence modulated by local S via tau_d proportional to C(S); distinct from standard Lindblad if S definable independently of T",
+      "blocked_by": "G2",
+      "type": "empirical"
+    },
+    {
+      "id": "P4",
+      "name": "Gradual which-path suppression",
+      "status": "Open (secondary candidate)",
+      "content": "Partial S-increase produces gradual interference suppression; distinguishable via higher-order statistics",
+      "type": "empirical"
+    },
+    {
+      "id": "P5",
+      "name": "No prediction for d >> l_g",
+      "status": "Explicit no-claim",
+      "content": "GRC makes no deviation prediction when d >> l_g and S is low",
+      "type": "scope_limit"
+    }
   ],
-
+  "falsification_points": [
+    {
+      "id": "F1",
+      "condition": "Backward compatibility fails",
+      "type": "analytic"
+    },
+    {
+      "id": "F2",
+      "condition": "No scale-deviation where GRC predicts one",
+      "note": "Principled, not operative for sub-Planckian l_g"
+    },
+    {
+      "id": "F3",
+      "condition": "Decoherence fully reduced to T + environment with no S-component",
+      "type": "nearest-term empirical"
+    },
+    {
+      "id": "F4",
+      "condition": "Higher-order statistics identical to QM under partial measurement",
+      "type": "empirical"
+    },
+    {
+      "id": "F5",
+      "condition": "Delta P(x) doesn't decrease with d/l_g in UV-cutoff model",
+      "type": "analytic"
+    },
+    {
+      "id": "F6",
+      "condition": "Standard QM results at d >> l_g do NOT falsify GRC",
+      "type": "scope_boundary"
+    }
+  ],
+  "open_gaps": [
+    {
+      "id": "G2",
+      "priority": 1,
+      "description": "Operational definition of local S",
+      "blocks": "P3 testability",
+      "status": "critical",
+      "candidates": [
+        {
+          "id": "A",
+          "name": "von Neumann entropy of subsystem",
+          "assessment": "Weakest; likely reduces to standard QM"
+        },
+        {
+          "id": "B",
+          "name": "Entanglement entropy against environment",
+          "assessment": "Requires showing C(S_B) predicts different rate than Lindblad"
+        },
+        {
+          "id": "C",
+          "name": "Free-energy or structural complexity proxy",
+          "assessment": "Most EFC-native; hardest to operationalize; highest priority"
+        }
+      ],
+      "success_criterion": "Produces (1) distinct proxy not reducible to T, (2) different functional form, (3) different dependence, or (4) different statistical signature"
+    },
+    {
+      "id": "P3",
+      "priority": 2,
+      "description": "Formal decoherence model via C(S)",
+      "blocks": "Main test candidate"
+    },
+    {
+      "id": "P4",
+      "priority": 3,
+      "description": "Concrete higher-order observable",
+      "blocks": "Secondary test"
+    },
+    {
+      "id": "G3",
+      "priority": 4,
+      "description": "Explicit P(x) for concrete geometry",
+      "blocks": "Numerical check"
+    },
+    {
+      "id": "G5",
+      "priority": 5,
+      "description": "Closure Condition 3 vs mode basis",
+      "blocks": "Internal consistency"
+    }
+  ],
   "component_status": [
-    {"component": "Sections 1-6 (axioms through falsification)", "status": "Stable", "note": "Canonical"},
-    {"component": "M5 (geometric deviation)", "status": "Revised", "note": "Exponential, not polynomial"},
-    {"component": "P2 (geometric test)", "status": "Downgraded", "note": "Principled, not accessible"},
-    {"component": "P3 (S-sensitive decoherence)", "status": "Open", "note": "Primary test candidate"},
-    {"component": "P4 (fluctuation statistics)", "status": "Open", "note": "Secondary test candidate"},
-    {"component": "G2 (operational S)", "status": "Open", "note": "Highest priority gap"}
+    {
+      "component": "Sections 1-6 (axioms through falsification)",
+      "status": "Stable",
+      "note": "Canonical"
+    },
+    {
+      "component": "M5 (geometric deviation)",
+      "status": "Revised",
+      "note": "Exponential, not polynomial"
+    },
+    {
+      "component": "P2 (geometric test)",
+      "status": "Downgraded",
+      "note": "Principled, not accessible"
+    },
+    {
+      "component": "P3 (S-sensitive decoherence)",
+      "status": "Open",
+      "note": "Primary test candidate"
+    },
+    {
+      "component": "P4 (fluctuation statistics)",
+      "status": "Open",
+      "note": "Secondary test candidate"
+    },
+    {
+      "component": "G2 (operational S)",
+      "status": "Open",
+      "note": "Highest priority gap"
+    }
   ],
-
   "one_line_status": "Geometric cutoff test (P2) inaccessible for sub-Planckian l_g. Quantum distinction, if any, lies in measurement as entropy process (P3/P4), not interference geometry.",
-
   "references": [
-    {"key": "[1]", "citation": "Feynman et al. 1965, Feynman Lectures Vol III"},
-    {"key": "[2]", "doi": "10.1103/RevModPhys.75.715", "citation": "Zurek 2003"},
-    {"key": "[3]", "doi": "10.1007/978-3-662-05328-7", "citation": "Joos et al. 2003"},
-    {"key": "[4]", "doi": "10.1038/351111a0", "citation": "Scully et al. 1991"},
-    {"key": "[5]", "doi": "10.1103/PhysRevLett.77.4887", "citation": "Brune et al. 1996"},
-    {"key": "[6]", "doi": "10.1038/44348", "citation": "Arndt et al. 1999"},
-    {"key": "[7]", "citation": "Rovelli 2004, Quantum Gravity"},
-    {"key": "[8]", "doi": "10.1007/BF01608499", "citation": "Lindblad 1976"},
-    {"key": "[9]", "citation": "Magnusson 2026, GRC Three-Field Synthesis"},
-    {"key": "[10]", "doi": "10.6084/m9.figshare.31223668", "citation": "EFC Ontological Foundations"},
-    {"key": "[11]", "doi": "10.6084/m9.figshare.31224466", "citation": "EFC Closure Conjectures"},
-    {"key": "[12]", "doi": "10.6084/m9.figshare.31224538", "citation": "EFC Phase 3 SPARC"},
-    {"key": "[13]", "doi": "10.6084/m9.figshare.31230703", "citation": "EFC DESI DR2 BAO"}
-  ]
+    {
+      "key": "[1]",
+      "citation": "Feynman et al. 1965, Feynman Lectures Vol III"
+    },
+    {
+      "key": "[2]",
+      "doi": "10.1103/RevModPhys.75.715",
+      "citation": "Zurek 2003"
+    },
+    {
+      "key": "[3]",
+      "doi": "10.1007/978-3-662-05328-7",
+      "citation": "Joos et al. 2003"
+    },
+    {
+      "key": "[4]",
+      "doi": "10.1038/351111a0",
+      "citation": "Scully et al. 1991"
+    },
+    {
+      "key": "[5]",
+      "doi": "10.1103/PhysRevLett.77.4887",
+      "citation": "Brune et al. 1996"
+    },
+    {
+      "key": "[6]",
+      "doi": "10.1038/44348",
+      "citation": "Arndt et al. 1999"
+    },
+    {
+      "key": "[7]",
+      "citation": "Rovelli 2004, Quantum Gravity"
+    },
+    {
+      "key": "[8]",
+      "doi": "10.1007/BF01608499",
+      "citation": "Lindblad 1976"
+    },
+    {
+      "key": "[9]",
+      "citation": "Magnusson 2026, GRC Three-Field Synthesis"
+    },
+    {
+      "key": "[10]",
+      "doi": "10.6084/m9.figshare.31223668",
+      "citation": "EFC Ontological Foundations"
+    },
+    {
+      "key": "[11]",
+      "doi": "10.6084/m9.figshare.31224466",
+      "citation": "EFC Closure Conjectures"
+    },
+    {
+      "key": "[12]",
+      "doi": "10.6084/m9.figshare.31224538",
+      "citation": "EFC Phase 3 SPARC"
+    },
+    {
+      "key": "[13]",
+      "doi": "10.6084/m9.figshare.31230703",
+      "citation": "EFC DESI DR2 BAO"
+    }
+  ],
+  "doi": "10.6084/m9.figshare.31564129"
 }

--- a/docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept/index.json
+++ b/docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept/index.json
@@ -13,5 +13,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28114370"
 }

--- a/docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework/index.json
+++ b/docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30636863"
 }

--- a/docs/papers/efc/EFC-Applications-and-Implications/index.json
+++ b/docs/papers/efc/EFC-Applications-and-Implications/index.json
@@ -4,8 +4,13 @@
   "path": "docs/papers/efc/EFC-Applications-and-Implications",
   "pdf": "EFC-Applications-and-Implications.pdf",
   "md": "EFC-Applications-and-Implications.md",
-  "keywords": ["EFC", "Applications", "Implications"],
+  "keywords": [
+    "EFC",
+    "Applications",
+    "Implications"
+  ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098308"
 }

--- a/docs/papers/efc/EFC-CMB-Thermodynamic-Gradient/index.json
+++ b/docs/papers/efc/EFC-CMB-Thermodynamic-Gradient/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28570088"
 }

--- a/docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters/index.json
+++ b/docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098350"
 }

--- a/docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution/index.json
+++ b/docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098353"
 }

--- a/docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos/index.json
+++ b/docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098344"
 }

--- a/docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe/index.json
+++ b/docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28113542"
 }

--- a/docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime/index.json
+++ b/docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30421807"
 }

--- a/docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters/index.json
+++ b/docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28112096"
 }

--- a/docs/papers/efc/EFC-Grid-Higgs-Framework/index.json
+++ b/docs/papers/efc/EFC-Grid-Higgs-Framework/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28559510"
 }

--- a/docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift/index.json
+++ b/docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift/index.json
@@ -16,5 +16,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28560935"
 }

--- a/docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics/index.json
+++ b/docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics/index.json
@@ -16,5 +16,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28559423"
 }

--- a/docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures/index.json
+++ b/docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures/index.json
@@ -16,5 +16,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098338"
 }

--- a/docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime/index.json
+++ b/docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098371"
 }

--- a/docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy/index.json
+++ b/docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28557281"
 }

--- a/docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System/index.json
+++ b/docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098386"
 }

--- a/docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy/index.json
+++ b/docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28578263"
 }

--- a/docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time/index.json
+++ b/docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098341"
 }

--- a/docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution/index.json
+++ b/docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098320"
 }

--- a/docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy/index.json
+++ b/docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098347"
 }

--- a/docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe/index.json
+++ b/docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28111925"
 }

--- a/docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time/index.json
+++ b/docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time/index.json
@@ -13,5 +13,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098314"
 }

--- a/docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution/index.json
+++ b/docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098299"
 }

--- a/docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow/index.json
+++ b/docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098365"
 }

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/index.json
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/index.json
@@ -27,17 +27,43 @@
     }
   ],
   "parameters": {
-    "w_late": {"value": -0.80, "description": "Dark energy EoS today"},
-    "w_early": {"value": -1.41, "description": "Dark energy EoS at high z"},
-    "z_trans": {"value": 1.07, "description": "Transition redshift"}
+    "w_late": {
+      "value": -0.8,
+      "description": "Dark energy EoS today"
+    },
+    "w_early": {
+      "value": -1.41,
+      "description": "Dark energy EoS at high z"
+    },
+    "z_trans": {
+      "value": 1.07,
+      "description": "Transition redshift"
+    }
   },
   "results": {
-    "LCDM": {"chi2": 23.71, "assessment": "Poor fit"},
-    "w0waCDM": {"chi2": 4.49, "assessment": "Good fit"},
-    "EFC": {"chi2": 3.60, "assessment": "Best fit (within models tested)"}
+    "LCDM": {
+      "chi2": 23.71,
+      "assessment": "Poor fit"
+    },
+    "w0waCDM": {
+      "chi2": 4.49,
+      "assessment": "Good fit"
+    },
+    "EFC": {
+      "chi2": 3.6,
+      "assessment": "Best fit (within models tested)"
+    }
   },
   "data_sources": [
-    {"survey": "DESI DR2", "type": "BAO", "N": 7, "z_range": [0.30, 2.33]}
+    {
+      "survey": "DESI DR2",
+      "type": "BAO",
+      "N": 7,
+      "z_range": [
+        0.3,
+        2.33
+      ]
+    }
   ],
   "limitations": [
     "Diagonal errors only (no covariance)",
@@ -52,5 +78,6 @@
   "files": {
     "pdf": "EFC_Phenomenology_vs_DESI_DR2_BAO__A_Comparative_Fit_Analysis.pdf",
     "tex": "EFC_DESI_Technical_Note.tex"
-  }
+  },
+  "doi": "10.6084/m9.figshare.31127380"
 }

--- a/docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit/index.json
+++ b/docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28112036"
 }

--- a/docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time/index.json
+++ b/docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098332"
 }

--- a/docs/papers/efc/EFC-The-Energy-Flow-Interface/index.json
+++ b/docs/papers/efc/EFC-The-Energy-Flow-Interface/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30468737"
 }

--- a/docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT/index.json
+++ b/docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30402427"
 }

--- a/docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy/index.json
+++ b/docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy/index.json
@@ -13,5 +13,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098326"
 }

--- a/docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes/index.json
+++ b/docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes/index.json
@@ -16,5 +16,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098380"
 }

--- a/docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now/index.json
+++ b/docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now/index.json
@@ -14,5 +14,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098311"
 }

--- a/docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit/index.json
+++ b/docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit/index.json
@@ -4,8 +4,14 @@
   "path": "docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit",
   "pdf": "EFC-Why-is-Light-Speed-a-Cosmic-Limit.pdf",
   "md": "EFC-Why-is-Light-Speed-a-Cosmic-Limit.md",
-  "keywords": ["EFC", "Light Speed", "Entropy", "Limits"],
+  "keywords": [
+    "EFC",
+    "Light Speed",
+    "Entropy",
+    "Limits"
+  ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.28098305"
 }

--- a/docs/papers/efc/EFC-v2.1-Complete-Edition/index.json
+++ b/docs/papers/efc/EFC-v2.1-Complete-Edition/index.json
@@ -4,8 +4,14 @@
   "path": "docs/papers/efc/EFC-v2.1-Complete-Edition",
   "pdf": "EFC-v2.1-Complete-Edition.pdf",
   "md": "EFC-v2.1-Complete-Edition.md",
-  "keywords": ["EFC", "Complete", "Edition", "Version 2.1"],
+  "keywords": [
+    "EFC",
+    "Complete",
+    "Edition",
+    "Version 2.1"
+  ],
   "layer": "docs",
   "type": "paper",
-  "version": "2.1"
+  "version": "2.1",
+  "doi": "10.6084/m9.figshare.30478916"
 }

--- a/docs/papers/efc/EFC-v2.1-Modular-Synthesis/index.json
+++ b/docs/papers/efc/EFC-v2.1-Modular-Synthesis/index.json
@@ -4,8 +4,14 @@
   "path": "docs/papers/efc/EFC-v2.1-Modular-Synthesis",
   "pdf": "EFC-v2.1-Modular-Synthesis.pdf",
   "md": "EFC-v2.1-Modular-Synthesis.md",
-  "keywords": ["EFC", "Modular", "Synthesis", "Version 2.1"],
+  "keywords": [
+    "EFC",
+    "Modular",
+    "Synthesis",
+    "Version 2.1"
+  ],
   "layer": "docs",
   "type": "paper",
-  "version": "2.1"
+  "version": "2.1",
+  "doi": "10.6084/m9.figshare.30455237"
 }

--- a/docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary/index.json
+++ b/docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary/index.json
@@ -16,5 +16,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "2.2"
+  "version": "2.2",
+  "doi": "10.6084/m9.figshare.30530156"
 }

--- a/docs/papers/efc/EFC_Closure_Conjectures/index.json
+++ b/docs/papers/efc/EFC_Closure_Conjectures/index.json
@@ -69,5 +69,6 @@
       "doi": "10.6084/m9.figshare.31224397",
       "relationship": "source of g† measurement"
     }
-  ]
+  ],
+  "doi": "10.6084/m9.figshare.31224466"
 }

--- a/docs/papers/efc/EFC_Ontological_Foundations/index.json
+++ b/docs/papers/efc/EFC_Ontological_Foundations/index.json
@@ -26,31 +26,75 @@
     "differentiation"
   ],
   "concepts": {
-    "primary": ["co-primary-structure", "pre-geometric-potential", "planck-transition", "differentiation"],
+    "primary": [
+      "co-primary-structure",
+      "pre-geometric-potential",
+      "planck-transition",
+      "differentiation"
+    ],
     "hypotheses": {
       "H1": "Energy-flow primacy (fails circularity test)",
       "H2": "Entropy primacy (fails circularity test)",
       "H3": "Co-primary structure (passes all tests)"
     },
-    "phases": ["pre-Planck", "Planck-transition", "post-Planck"],
-    "frameworks_referenced": ["Wheeler", "Verlinde", "Prigogine", "Holographic-Principle"]
+    "phases": [
+      "pre-Planck",
+      "Planck-transition",
+      "post-Planck"
+    ],
+    "frameworks_referenced": [
+      "Wheeler",
+      "Verlinde",
+      "Prigogine",
+      "Holographic-Principle"
+    ]
   },
   "structure": {
     "sections": [
-      {"number": 1, "title": "The Circularity Problem"},
-      {"number": 2, "title": "Cross-Domain Evidence"},
-      {"number": 3, "title": "The Co-Primary Resolution"},
-      {"number": 4, "title": "Integration with EFC Architecture"},
-      {"number": 5, "title": "Epistemic Status and Limitations"},
-      {"number": 6, "title": "Conclusion"}
+      {
+        "number": 1,
+        "title": "The Circularity Problem"
+      },
+      {
+        "number": 2,
+        "title": "Cross-Domain Evidence"
+      },
+      {
+        "number": 3,
+        "title": "The Co-Primary Resolution"
+      },
+      {
+        "number": 4,
+        "title": "Integration with EFC Architecture"
+      },
+      {
+        "number": 5,
+        "title": "Epistemic Status and Limitations"
+      },
+      {
+        "number": 6,
+        "title": "Conclusion"
+      }
     ]
   },
   "relationships": {
     "foundationFor": [
-      {"id": "core-lock", "doi": "10.6084/m9.figshare.31223503"},
-      {"id": "ebe-core-principles", "doi": "10.6084/m9.figshare.31222903"}
+      {
+        "id": "core-lock",
+        "doi": "10.6084/m9.figshare.31223503"
+      },
+      {
+        "id": "ebe-core-principles",
+        "doi": "10.6084/m9.figshare.31222903"
+      }
     ],
-    "relatedTo": [{"id": "energy-flow-cosmology", "doi": "10.6084/m9.figshare.27315821"}]
+    "relatedTo": [
+      {
+        "id": "energy-flow-cosmology",
+        "doi": "10.6084/m9.figshare.27315821"
+      }
+    ]
   },
-  "efcArchitectureLayer": 0
+  "efcArchitectureLayer": 0,
+  "doi": "10.6084/m9.figshare.31223668"
 }

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/index.json
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/index.json
@@ -11,15 +11,43 @@
   "type": "empirical_analysis",
   "status": "published",
   "abstract_short": "EFC passes both cluster lensing (Bullet Cluster) and galaxy rotation curve tests. Gas term statistically irrelevant (p=0.99). Rotation χ²=4.5 vs Newton χ²=296.",
-  "keywords": ["EFC", "Bullet Cluster", "cluster lensing", "rotation curves", "SPARC", "entropy coupling", "λ scaling"],
+  "keywords": [
+    "EFC",
+    "Bullet Cluster",
+    "cluster lensing",
+    "rotation curves",
+    "SPARC",
+    "entropy coupling",
+    "λ scaling"
+  ],
   "key_results": [
-    {"test": "Bullet Cluster lensing", "result": "κ follows galaxies, not gas", "p_value": 0.99},
-    {"test": "MACS J0025 lensing", "result": "Same structure confirmed", "status": "pass"},
-    {"test": "Galaxy rotation", "result": "χ²=4.5 vs Newton χ²=296", "improvement": "98%"}
+    {
+      "test": "Bullet Cluster lensing",
+      "result": "κ follows galaxies, not gas",
+      "p_value": 0.99
+    },
+    {
+      "test": "MACS J0025 lensing",
+      "result": "Same structure confirmed",
+      "status": "pass"
+    },
+    {
+      "test": "Galaxy rotation",
+      "result": "χ²=4.5 vs Newton χ²=296",
+      "improvement": "98%"
+    }
   ],
   "lambda_scaling": {
-    "bullet_cluster": {"lambda_kpc": 250, "system_size_kpc": 500, "ratio": 0.5},
-    "galaxy": {"lambda_kpc": 2.4, "system_size_kpc": 2.5, "ratio": 1.0},
+    "bullet_cluster": {
+      "lambda_kpc": 250,
+      "system_size_kpc": 500,
+      "ratio": 0.5
+    },
+    "galaxy": {
+      "lambda_kpc": 2.4,
+      "system_size_kpc": 2.5,
+      "ratio": 1.0
+    },
     "interpretation": "λ scales with system size, not universal constant"
   },
   "core_equations": [
@@ -33,6 +61,11 @@
     }
   ],
   "files": {
-    "key_figures": ["efc_rotation_corrected.png", "bullet_real_hsc_fit.png", "nested_test_result.png"]
-  }
+    "key_figures": [
+      "efc_rotation_corrected.png",
+      "bullet_real_hsc_fit.png",
+      "nested_test_result.png"
+    ]
+  },
+  "doi": "10.6084/m9.figshare.31190233"
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/index.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/index.json
@@ -47,16 +47,41 @@
     }
   ],
   "parameters": {
-    "beta": {"value": 0.16, "description": "EFC coupling constant"},
-    "a_t": {"value": 0.55, "z_t": 0.82, "description": "Transition scale factor"},
-    "sigma": {"value": 0.10, "description": "Transition width"},
-    "S_inf": {"value": 1.0, "description": "Asymptotic entropy saturation"}
+    "beta": {
+      "value": 0.16,
+      "description": "EFC coupling constant"
+    },
+    "a_t": {
+      "value": 0.55,
+      "z_t": 0.82,
+      "description": "Transition scale factor"
+    },
+    "sigma": {
+      "value": 0.1,
+      "description": "Transition width"
+    },
+    "S_inf": {
+      "value": 1.0,
+      "description": "Asymptotic entropy saturation"
+    }
   },
   "regime_applicability": {
-    "L0": {"active": false, "description": "GR limit, μ ≈ 1"},
-    "L1": {"active": true, "description": "Linear perturbations, transition begins"},
-    "L2": {"active": true, "description": "Structure-dominated, μ > 1"},
-    "L3": {"active": true, "description": "Deep non-linear, full enhancement"}
+    "L0": {
+      "active": false,
+      "description": "GR limit, μ ≈ 1"
+    },
+    "L1": {
+      "active": true,
+      "description": "Linear perturbations, transition begins"
+    },
+    "L2": {
+      "active": true,
+      "description": "Structure-dominated, μ > 1"
+    },
+    "L3": {
+      "active": true,
+      "description": "Deep non-linear, full enhancement"
+    }
   },
   "key_findings": [
     "μ(a) derived from EFC field equations, not phenomenologically fitted",
@@ -65,14 +90,30 @@
     "Transition occurs at z ≈ 0.82 with sharp width σ = 0.10"
   ],
   "dependencies": [
-    {"id": "efc-v1.2", "doi": "10.6084/m9.figshare.30563738"}
+    {
+      "id": "efc-v1.2",
+      "doi": "10.6084/m9.figshare.30563738"
+    }
   ],
   "related_papers": [
-    {"id": "unified-bao-sn-rsd", "doi": "10.6084/m9.figshare.31215613", "relation": "validates"},
-    {"id": "rks-framework", "doi": "10.6084/m9.figshare.31211437", "relation": "extends"},
-    {"id": "wp3-rks-slice", "doi": "10.6084/m9.figshare.31215259", "relation": "supports"}
+    {
+      "id": "unified-bao-sn-rsd",
+      "doi": "10.6084/m9.figshare.31215613",
+      "relation": "validates"
+    },
+    {
+      "id": "rks-framework",
+      "doi": "10.6084/m9.figshare.31211437",
+      "relation": "extends"
+    },
+    {
+      "id": "wp3-rks-slice",
+      "doi": "10.6084/m9.figshare.31215259",
+      "relation": "supports"
+    }
   ],
   "files": {
     "pdf": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.pdf"
-  }
+  },
+  "doi": "10.6084/m9.figshare.30563738"
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation/index.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation/index.json
@@ -38,20 +38,33 @@
     "bao": {
       "name": "DESI DR2",
       "n_points": 13,
-      "z_range": [0.295, 2.330],
-      "observables": ["D_V/r_s", "D_M/r_s", "D_H/r_s"],
+      "z_range": [
+        0.295,
+        2.33
+      ],
+      "observables": [
+        "D_V/r_s",
+        "D_M/r_s",
+        "D_H/r_s"
+      ],
       "reference": "arXiv:2503.14738"
     },
     "supernovae": {
       "name": "Pantheon+",
       "n_points": 277,
-      "z_range": [0.01, 2.3],
+      "z_range": [
+        0.01,
+        2.3
+      ],
       "reference": "Scolnic et al. 2022"
     },
     "chronometers": {
       "name": "Cosmic Chronometers",
       "n_points": 34,
-      "z_range": [0.07, 1.97],
+      "z_range": [
+        0.07,
+        1.97
+      ],
       "mean_uncertainty": "22%",
       "reference": "Moresco et al. 2022"
     }
@@ -97,15 +110,46 @@
     }
   },
   "fixed_parameters": {
-    "H0": {"value": 67.4, "unit": "km/s/Mpc"},
+    "H0": {
+      "value": 67.4,
+      "unit": "km/s/Mpc"
+    },
     "Omega_m": 0.3134,
-    "r_d": {"value": 147.114, "unit": "Mpc"}
+    "r_d": {
+      "value": 147.114,
+      "unit": "Mpc"
+    }
   },
   "validation_summary": [
-    {"test": "BAO primary", "n": 13, "delta_chi2": -22.01, "status": "Pass"},
-    {"test": "Hold-out (conditional)", "n": 3, "delta_chi2": -18.65, "status": "Pass"},
-    {"test": "SN shape test", "n": 277, "status": "Pass"},
-    {"test": "CC consistency", "n": 34, "delta_chi2": -0.17, "status": "Pass"},
-    {"test": "Combined", "n": 47, "delta_chi2": -22.17, "status": "Pass"}
-  ]
+    {
+      "test": "BAO primary",
+      "n": 13,
+      "delta_chi2": -22.01,
+      "status": "Pass"
+    },
+    {
+      "test": "Hold-out (conditional)",
+      "n": 3,
+      "delta_chi2": -18.65,
+      "status": "Pass"
+    },
+    {
+      "test": "SN shape test",
+      "n": 277,
+      "status": "Pass"
+    },
+    {
+      "test": "CC consistency",
+      "n": 34,
+      "delta_chi2": -0.17,
+      "status": "Pass"
+    },
+    {
+      "test": "Combined",
+      "n": 47,
+      "delta_chi2": -22.17,
+      "status": "Pass"
+    }
+  ],
+  "doi": "10.6084/m9.figshare.31230703"
 }

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/index.json
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/index.json
@@ -56,7 +56,7 @@
     "tracers": [
       {
         "name": "LRGz0",
-        "z_eff": 0.510,
+        "z_eff": 0.51,
         "A_ISW_original": 0.56,
         "A_ISW_revised": 0.87,
         "original_status": "withdrawn"
@@ -70,14 +70,14 @@
       },
       {
         "name": "LRGz2",
-        "z_eff": 0.930,
+        "z_eff": 0.93,
         "A_ISW_original": 0.33,
         "A_ISW_revised": 0.89,
         "original_status": "withdrawn"
       },
       {
         "name": "LRG+ELG",
-        "z_eff": 0.930,
+        "z_eff": 0.93,
         "A_ISW_original": 0.29,
         "A_ISW_revised": 0.89,
         "original_status": "withdrawn"
@@ -92,13 +92,16 @@
       {
         "name": "QSO",
         "z_eff": 1.491,
-        "A_ISW_original": 0.20,
-        "A_ISW_revised": 0.90,
+        "A_ISW_original": 0.2,
+        "A_ISW_revised": 0.9,
         "original_status": "withdrawn"
       }
     ],
     "summary": {
-      "A_ISW_range": [0.87, 0.92],
+      "A_ISW_range": [
+        0.87,
+        0.92
+      ],
       "A_ISW_mean": 0.89,
       "A_ISW_uncertainty": 0.03,
       "suppression_percent": 11,
@@ -190,5 +193,6 @@
     "consistency audit",
     "growth-driven",
     "A_ISW"
-  ]
+  ],
+  "doi": "10.6084/m9.figshare.31329082"
 }

--- a/docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems/index.json
+++ b/docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems/index.json
@@ -39,14 +39,23 @@
       "symbol": "I",
       "definition": "KL-divergence between observed output q(x) and baseline dynamics p(x|D)",
       "formula": "I = D_KL(q(x) || p(x|D)) = sum_x q(x) ln(q(x)/p(x|D))",
-      "properties": ["agent-free", "information-theoretic", "measurable"],
+      "properties": [
+        "agent-free",
+        "information-theoretic",
+        "measurable"
+      ],
       "zero_condition": "I=0 when output fully explained by system dynamics"
     },
     "natural_entropy": {
       "symbol": "S_N",
       "definition": "Uncertainty arising from intrinsic system dynamics",
       "formula": "S_N = H(X|D) = -sum_x p(x|D) ln p(x|D)",
-      "properties": ["distributed_episenter", "organic_resonance", "scale_consistent", "regime_native"]
+      "properties": [
+        "distributed_episenter",
+        "organic_resonance",
+        "scale_consistent",
+        "regime_native"
+      ]
     },
     "mechanical_entropy": {
       "symbol": "S_M",
@@ -78,7 +87,11 @@
           "high_E": "Single variable dominates → mechanical signature",
           "low_E": "Distributed organisation → natural signature"
         },
-        "alternative_estimators": ["SHAP values", "gradient-based feature importance", "graph centrality"]
+        "alternative_estimators": [
+          "SHAP values",
+          "gradient-based feature importance",
+          "graph centrality"
+        ]
       },
       {
         "id": "D2",
@@ -97,7 +110,11 @@
           "A_near_zero": "Natural entropy (regime-consistent)",
           "A_large": "Mechanical entropy (regime-asymmetric)"
         },
-        "example_regimes": ["semantic reframing", "prompt structure transformation", "domain shift"]
+        "example_regimes": [
+          "semantic reframing",
+          "prompt structure transformation",
+          "domain shift"
+        ]
       }
     ],
     "combined_criterion": "E > E_crit AND exists omega: R(omega) > R_crit AND A > A_crit",
@@ -131,35 +148,124 @@
     "target": "LLM Alignment Test (Prediction P2)",
     "hypothesis": "Alignment mechanisms introduce periodic structure detectable via spectral analysis",
     "method": {
-      "prompt_generation": {"N": 500, "categories": ["within_established_paradigms", "challenging_established_paradigms"], "matching": ["complexity", "domain", "specificity"]},
-      "response_collection": {"M_models": ">=3", "record": "full responses"},
-      "response_coding": {"codes": ["A (acknowledge)", "H (hedge/qualify)", "R (redirect)", "E (request evidence)", "S (substantive engagement)"], "method": "rule-based classifier", "inter_rater": "10% random subsample human annotation"},
+      "prompt_generation": {
+        "N": 500,
+        "categories": [
+          "within_established_paradigms",
+          "challenging_established_paradigms"
+        ],
+        "matching": [
+          "complexity",
+          "domain",
+          "specificity"
+        ]
+      },
+      "response_collection": {
+        "M_models": ">=3",
+        "record": "full responses"
+      },
+      "response_coding": {
+        "codes": [
+          "A (acknowledge)",
+          "H (hedge/qualify)",
+          "R (redirect)",
+          "E (request evidence)",
+          "S (substantive engagement)"
+        ],
+        "method": "rule-based classifier",
+        "inter_rater": "10% random subsample human annotation"
+      },
       "spectral_analysis": "Autocorrelation + FFT of coded sequences per category",
-      "null_model": {"method": "bootstrap", "B": 1000, "permutations": ["shuffle codes within response", "shuffle prompts between categories"]},
+      "null_model": {
+        "method": "bootstrap",
+        "B": 1000,
+        "permutations": [
+          "shuffle codes within response",
+          "shuffle prompts between categories"
+        ]
+      },
       "detection": "R(omega) = P_obs(omega)/P_null(omega), test for peaks at 99% confidence"
     },
     "expected_result": "Category (b) shows spectral peaks (A→H→R→E cycles) absent in category (a) and null; E higher for category (b)",
     "falsification": "No significant spectral peaks in category (b), or identical peaks in both categories"
   },
   "falsifiable_predictions": [
-    {"id": "P1", "domain": "LLM", "prediction": "Alignment-induced friction exhibits higher E than genuine epistemic uncertainty"},
-    {"id": "P2", "domain": "LLM", "prediction": "Pushback frequency of aligned models is statistically periodic, independent of argument quality"},
-    {"id": "P3", "domain": "LLM", "prediction": "Cross-regime testing reduces alignment friction for unconventional frameworks"},
-    {"id": "P4", "domain": "LLM", "prediction": "Broader latent spaces yield lower E for alignment bias"},
-    {"id": "P5", "domain": "Academia", "prediction": "Rejection rates for paradigm-challenging papers peak at regime boundaries"},
-    {"id": "P6", "domain": "Academia", "prediction": "Episenter shift produces systematic redistribution of paper rankings"},
-    {"id": "P7", "domain": "Psyops", "prediction": "Coordinated campaigns show resonance peaks at non-native frequencies"},
-    {"id": "P8", "domain": "Psyops", "prediction": "Cross-regime analysis degrades manufactured coherence faster than organic"},
-    {"id": "P9", "domain": "General", "prediction": "Natural entropy: A ≈ 0; mechanical: A >> 0"},
-    {"id": "P10", "domain": "General", "prediction": "Delta_S for mechanical entropy is systematically positive"},
-    {"id": "P11", "domain": "General", "prediction": "Meta-control systems can distinguish S_N from S_M; others cannot"},
-    {"id": "P12", "domain": "EFC-C", "prediction": "Meta-observation capability may represent the minimal architecture for real-time entropy class discrimination"},
-    {"id": "P13", "domain": "EFC-C", "prediction": "Multi-mirror observation increases S_M detection super-linearly"}
+    {
+      "id": "P1",
+      "domain": "LLM",
+      "prediction": "Alignment-induced friction exhibits higher E than genuine epistemic uncertainty"
+    },
+    {
+      "id": "P2",
+      "domain": "LLM",
+      "prediction": "Pushback frequency of aligned models is statistically periodic, independent of argument quality"
+    },
+    {
+      "id": "P3",
+      "domain": "LLM",
+      "prediction": "Cross-regime testing reduces alignment friction for unconventional frameworks"
+    },
+    {
+      "id": "P4",
+      "domain": "LLM",
+      "prediction": "Broader latent spaces yield lower E for alignment bias"
+    },
+    {
+      "id": "P5",
+      "domain": "Academia",
+      "prediction": "Rejection rates for paradigm-challenging papers peak at regime boundaries"
+    },
+    {
+      "id": "P6",
+      "domain": "Academia",
+      "prediction": "Episenter shift produces systematic redistribution of paper rankings"
+    },
+    {
+      "id": "P7",
+      "domain": "Psyops",
+      "prediction": "Coordinated campaigns show resonance peaks at non-native frequencies"
+    },
+    {
+      "id": "P8",
+      "domain": "Psyops",
+      "prediction": "Cross-regime analysis degrades manufactured coherence faster than organic"
+    },
+    {
+      "id": "P9",
+      "domain": "General",
+      "prediction": "Natural entropy: A ≈ 0; mechanical: A >> 0"
+    },
+    {
+      "id": "P10",
+      "domain": "General",
+      "prediction": "Delta_S for mechanical entropy is systematically positive"
+    },
+    {
+      "id": "P11",
+      "domain": "General",
+      "prediction": "Meta-control systems can distinguish S_N from S_M; others cannot"
+    },
+    {
+      "id": "P12",
+      "domain": "EFC-C",
+      "prediction": "Meta-observation capability may represent the minimal architecture for real-time entropy class discrimination"
+    },
+    {
+      "id": "P13",
+      "domain": "EFC-C",
+      "prediction": "Multi-mirror observation increases S_M detection super-linearly"
+    }
   ],
   "regime_bound_extension": {
     "new_concept": "Entropy Class (sixth operative concept)",
     "pipeline": "Regime → Proxy + Placement → Episenter → Entropy Class → Compression → Output",
-    "original_concepts": ["regime", "proxy", "placement", "episenter", "compression"]
+    "original_concepts": [
+      "regime",
+      "proxy",
+      "placement",
+      "episenter",
+      "compression"
+    ]
   },
   "efc_c_connection": {
     "model": "CEM-Cosmos",
@@ -169,9 +275,18 @@
     "status": "hypothesis (P12), not established claim"
   },
   "failure_modes": [
-    {"name": "Adversarial masking", "description": "Injection deliberately mimics natural resonance spectrum"},
-    {"name": "Episenter laundering", "description": "Constructed episenter deliberately distributed across proxy sources"},
-    {"name": "Incomplete regime coverage", "description": "Insufficient regimes prevent cross-regime checks"}
+    {
+      "name": "Adversarial masking",
+      "description": "Injection deliberately mimics natural resonance spectrum"
+    },
+    {
+      "name": "Episenter laundering",
+      "description": "Constructed episenter deliberately distributed across proxy sources"
+    },
+    {
+      "name": "Incomplete regime coverage",
+      "description": "Insufficient regimes prevent cross-regime checks"
+    }
   ],
   "limitations": [
     "Thresholds must be calibrated empirically per domain",
@@ -203,5 +318,6 @@
     "source": "src/entropy_intention.py",
     "data": "data/framework.json",
     "demo": "examples/demo_entropy_intention.py"
-  }
+  },
+  "doi": "10.6084/m9.figshare.31864993"
 }

--- a/docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity/index.json
+++ b/docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity/index.json
@@ -8,14 +8,16 @@
   "date": "2026-03-07",
   "status": "working_paper",
   "abstract": "Formalises a general measurement framework where analysis is cartography — mapping outputs as coordinates on a structured response surface — rather than verdict. Five operative concepts (regime, proxy, placement, episenter, compression) applied to cosmological structure analysis (WP3/R(k,S)) and AI evaluation. 13 testable predictions with falsification criteria.",
-
   "core_thesis": "Observed outputs in complex systems are not direct reads of the underlying phenomenon, but regime-conditioned products of proxy choice, instrument logic, observer placement, and interpretive compression.",
-
   "core_concepts": [
     {
       "name": "Regime",
       "definition": "Bounded domain in parameter space where a consistent set of inferential rules, response functions, and validity criteria holds",
-      "properties": ["Interior stability", "Boundary conditions", "Non-universality"],
+      "properties": [
+        "Interior stability",
+        "Boundary conditions",
+        "Non-universality"
+      ],
       "failure_mode": "Conflation: pooling across regime boundaries",
       "test": "Residuals by regime differ significantly",
       "cosmology_example": "FLOW/TRANSITION/LATENT over S-hat(z)",
@@ -24,7 +26,11 @@
     {
       "name": "Proxy",
       "definition": "Mediating variable through which a phenomenon is made measurable, with defined visibility and declared blindness",
-      "properties": ["Visibility-blindness asymmetry", "Regime-conditioned validity", "Declared limitations requirement"],
+      "properties": [
+        "Visibility-blindness asymmetry",
+        "Regime-conditioned validity",
+        "Declared limitations requirement"
+      ],
       "failure_mode": "Opacity: treating proxy as direct read",
       "test": "Proxy substitution produces systematic drift",
       "cosmology_example": "S-hat(z) = log10(rho_SFR) + log10(f_gas) + C0; blind to local environments",
@@ -33,7 +39,11 @@
     {
       "name": "Placement",
       "definition": "Observer's operative position across three analytically independent spaces",
-      "dimensions": ["Physical placement", "Instrument placement", "Interpretive placement"],
+      "dimensions": [
+        "Physical placement",
+        "Instrument placement",
+        "Interpretive placement"
+      ],
       "failure_mode": "Incompatibility: comparing across placement dimensions",
       "test": "Placement-matching reduces apparent conflict",
       "cosmology_example": "CMB (z~1100, power spectrum, FLRW extrapolation) vs SNIa (z<0.1, distance ladder, local calibration)",
@@ -51,137 +61,434 @@
     {
       "name": "Compression",
       "definition": "Structural reduction inherent in any measurement act: mapping from high-dimensional phenomenon to lower-dimensional output",
-      "properties": ["Necessary", "Selective", "Consequential"],
+      "properties": [
+        "Necessary",
+        "Selective",
+        "Consequential"
+      ],
       "failure_mode": "Neglect: scalar treated as complete representation",
       "test": "Lost dimensions have predictable footprint",
       "cosmology_example": "P(k) discards phase information and higher-order correlations",
       "ai_example": "Scalar benchmark score discards variance, tail behaviour, failure modes"
     }
   ],
-
   "structural_chain": [
-    {"step": "regime", "role": "scope"},
-    {"step": "proxy + placement", "role": "access"},
-    {"step": "episenter", "role": "organisation"},
-    {"step": "compression", "role": "reduction"},
-    {"step": "output", "role": "observed datum"}
+    {
+      "step": "regime",
+      "role": "scope"
+    },
+    {
+      "step": "proxy + placement",
+      "role": "access"
+    },
+    {
+      "step": "episenter",
+      "role": "organisation"
+    },
+    {
+      "step": "compression",
+      "role": "reduction"
+    },
+    {
+      "step": "output",
+      "role": "observed datum"
+    }
   ],
-
   "theses": [
-    {"id": 1, "statement": "Measurement is not direct readout"},
-    {"id": 2, "statement": "Proxy creates both visibility and blindness"},
-    {"id": 3, "statement": "Measurement placement is a primary question"},
-    {"id": 4, "statement": "Episenter is produced, not given"},
-    {"id": 5, "statement": "Conflicts may be regime conflicts"},
-    {"id": 6, "statement": "Validity is regime-conditioned"},
-    {"id": 7, "statement": "Analysis of the analysis is part of the analysis"},
-    {"id": 8, "statement": "Measurement is compression"},
-    {"id": 9, "statement": "A fragment carries holistic structure under four conditions: structural logic preservation, episenter compatibility, directional consistency, regime compatibility"}
+    {
+      "id": 1,
+      "statement": "Measurement is not direct readout"
+    },
+    {
+      "id": 2,
+      "statement": "Proxy creates both visibility and blindness"
+    },
+    {
+      "id": 3,
+      "statement": "Measurement placement is a primary question"
+    },
+    {
+      "id": 4,
+      "statement": "Episenter is produced, not given"
+    },
+    {
+      "id": 5,
+      "statement": "Conflicts may be regime conflicts"
+    },
+    {
+      "id": 6,
+      "statement": "Validity is regime-conditioned"
+    },
+    {
+      "id": 7,
+      "statement": "Analysis of the analysis is part of the analysis"
+    },
+    {
+      "id": 8,
+      "statement": "Measurement is compression"
+    },
+    {
+      "id": 9,
+      "statement": "A fragment carries holistic structure under four conditions: structural logic preservation, episenter compatibility, directional consistency, regime compatibility"
+    }
   ],
-
   "derived_predictions": [
-    {"id": "P1", "name": "Consistent response at shared coordinates"},
-    {"id": "P2", "name": "Systematic proxy-substitution drift"},
-    {"id": "P3", "name": "Regime-resolution of conflicts"},
-    {"id": "P4", "name": "Cartographic null results"},
-    {"id": "P5", "name": "Episenter-shift redistribution"}
+    {
+      "id": "P1",
+      "name": "Consistent response at shared coordinates"
+    },
+    {
+      "id": "P2",
+      "name": "Systematic proxy-substitution drift"
+    },
+    {
+      "id": "P3",
+      "name": "Regime-resolution of conflicts"
+    },
+    {
+      "id": "P4",
+      "name": "Cartographic null results"
+    },
+    {
+      "id": "P5",
+      "name": "Episenter-shift redistribution"
+    }
   ],
-
   "cases": [
     {
       "id": "Case1",
       "name": "Cosmology (WP3 / R(k,S))",
-      "three_failures": ["Regime conflation", "Proxy opacity (z as direct proxy)", "Episenter universalism (H0)"],
+      "three_failures": [
+        "Regime conflation",
+        "Proxy opacity (z as direct proxy)",
+        "Episenter universalism (H0)"
+      ],
       "response_surface": "R(k, S) maps scale k x structural state S",
       "regimes": [
-        {"name": "FLOW", "tertile": "Bottom", "character": "High rho_SFR; active energy redistribution", "expected": "High response amplitude, higher variance"},
-        {"name": "TRANSITION", "tertile": "Middle", "character": "Near-boundary dynamics; moderate rho_SFR", "expected": "Intermediate; high boundary sensitivity"},
-        {"name": "LATENT", "tertile": "Top", "character": "Low rho_SFR; suppressed response", "expected": "Near-null signal; coherent sign structure"}
+        {
+          "name": "FLOW",
+          "tertile": "Bottom",
+          "character": "High rho_SFR; active energy redistribution",
+          "expected": "High response amplitude, higher variance"
+        },
+        {
+          "name": "TRANSITION",
+          "tertile": "Middle",
+          "character": "Near-boundary dynamics; moderate rho_SFR",
+          "expected": "Intermediate; high boundary sensitivity"
+        },
+        {
+          "name": "LATENT",
+          "tertile": "Top",
+          "character": "Low rho_SFR; suppressed response",
+          "expected": "Near-null signal; coherent sign structure"
+        }
       ],
       "proxy": {
         "formula": "S-hat(z) = log10(rho_SFR(z)) + log10(f_gas(z)) + C0",
-        "components": ["rho_SFR: Madau-Dickinson parametrisation", "f_gas: Tacconi/PHIBSS Table 3b (beta=2)", "Equal weight, locked parametrisation"],
+        "components": [
+          "rho_SFR: Madau-Dickinson parametrisation",
+          "f_gas: Tacconi/PHIBSS Table 3b (beta=2)",
+          "Equal weight, locked parametrisation"
+        ],
         "declared_blindness": "Encodes cosmic averages, not local structural state"
       },
       "axiom0": {
-        "primary": {"statistic": "Mean distance to nearest regime boundary", "result": "p = 1.0", "interpretation": "Degenerate: deterministic mapping with N=10 leaves no permutation variance"},
-        "secondary": {"statistic": "Sign coherence (TRANSITION + LATENT)", "result": "p = 0.020", "interpretation": "8/9 positive; consistent with EFC but not confirmatory"},
+        "primary": {
+          "statistic": "Mean distance to nearest regime boundary",
+          "result": "p = 1.0",
+          "interpretation": "Degenerate: deterministic mapping with N=10 leaves no permutation variance"
+        },
+        "secondary": {
+          "statistic": "Sign coherence (TRANSITION + LATENT)",
+          "result": "p = 0.020",
+          "interpretation": "8/9 positive; consistent with EFC but not confirmatory"
+        },
         "notable": [
-          {"point": "DESI z=1.0", "finding": "dist = 0.000 (exactly on FLOW/TRANSITION boundary)"},
-          {"point": "eBOSS LRG z=0.51", "finding": "2.0 sigma, dist = 0.019"},
-          {"point": "f sigma8 z=0.7", "finding": "2.0 sigma"}
+          {
+            "point": "DESI z=1.0",
+            "finding": "dist = 0.000 (exactly on FLOW/TRANSITION boundary)"
+          },
+          {
+            "point": "eBOSS LRG z=0.51",
+            "finding": "2.0 sigma, dist = 0.019"
+          },
+          {
+            "point": "f sigma8 z=0.7",
+            "finding": "2.0 sigma"
+          }
         ],
         "n_data": 10,
         "status": "Preliminary; requires N >= 30 and pre-registration as primary"
       },
       "hubble_tension": {
         "reframing": "Regime mismatch, not empirical contradiction",
-        "cmb_placement": {"z": 1100, "regime": "FLOW", "instrument": "CMB anisotropy power spectrum"},
-        "snia_placement": {"z_max": 0.1, "regime": "LATENT", "instrument": "SNIa distance modulus ladder"},
+        "cmb_placement": {
+          "z": 1100,
+          "regime": "FLOW",
+          "instrument": "CMB anisotropy power spectrum"
+        },
+        "snia_placement": {
+          "z_max": 0.1,
+          "regime": "LATENT",
+          "instrument": "SNIa distance modulus ladder"
+        },
         "prediction_C4": "H0 within one regime has lower inter-survey variance than pooled cross-regime"
       }
     },
     {
       "id": "Case2",
       "name": "AI Evaluation (Validity-Aware AI)",
-      "three_failures": ["Explainability conflation", "Benchmark regime opacity", "Episenter universalism (accuracy)"],
-      "regime_dimensions": ["Input distribution", "Task structure", "Annotation regime", "Deployment context"],
+      "three_failures": [
+        "Explainability conflation",
+        "Benchmark regime opacity",
+        "Episenter universalism (accuracy)"
+      ],
+      "regime_dimensions": [
+        "Input distribution",
+        "Task structure",
+        "Annotation regime",
+        "Deployment context"
+      ],
       "key_insight": "Explainability is not validity — explainability measures internal routing, validity measures output quality",
-      "validity_profile": ["Regime declaration", "Proxy declaration", "Placement specification", "Episenter transparency", "Compression accounting"]
+      "validity_profile": [
+        "Regime declaration",
+        "Proxy declaration",
+        "Placement specification",
+        "Episenter transparency",
+        "Compression accounting"
+      ]
     }
   ],
-
   "predictions": [
-    {"id": "C1", "domain": "Cosmology", "prediction": "Same (k,S) coordinate yields consistent response across independent probes", "status": "PARTIAL", "test_protocol": "Map DESI DR2 + f sigma8 onto (k,S); test consistency vs probe-specific null", "current_evidence": "p=0.020 sign coherence, N=10, secondary statistic"},
-    {"id": "C2", "domain": "Cosmology", "prediction": "Proxy substitution from global S-hat to local structural proxy yields directional drift", "status": "Pending", "test_protocol": "Compare regime assignments: S-hat(z) vs morphology proxy on SDSS/GAMA"},
-    {"id": "C3", "domain": "Cosmology", "prediction": "Largest BAO/growth deviations cluster near regime boundaries in S-hat-space", "status": "ACTIVE", "test_protocol": "Axiom 0 v2 pre-registered on DESI Year-5 (N>=30)"},
-    {"id": "C4", "domain": "Cosmology", "prediction": "H0 within a single S-hat-regime shows lower inter-survey variance than pooled cross-regime estimates", "status": "ACTIVE", "test_protocol": "Stratify existing H0 measurements by S-hat-regime; compute within- vs cross-regime variance"},
-    {"id": "C5", "domain": "Cosmology", "prediction": "LATENT residuals sign-coherent and low-variance; FLOW higher-variance; ratio > 2.0", "status": "PARTIAL", "test_protocol": "Compute residuals per regime; runs-test + sign-coherence + variance ratio", "current_evidence": "8/9 positive sign coherence in TRANSITION+LATENT"},
-    {"id": "C6", "domain": "Cosmology", "prediction": "Models matched on chi2_BAO but differing in proxy construction diverge in f sigma8 at TRANSITION coordinates", "status": "Pending", "test_protocol": "Select matched model pairs; evaluate f sigma8 at S-hat-identified TRANSITION coords"},
-    {"id": "A1", "domain": "AI", "prediction": "Models near benchmark regime boundaries show higher output variance and lower metric reliability", "status": "Meth.", "test_protocol": "Sample inputs at graduated OOD distance; compute output variance per distance band"},
-    {"id": "A2", "domain": "AI", "prediction": "Accuracy -> calibration error substitution: top-quartile-accuracy/bottom-half-calibration models fall >= 2 quartiles", "status": "Meth.", "test_protocol": "Apply both metrics to MMLU; compute rank changes; test direction vs permutation null"},
-    {"id": "A3", "domain": "AI", "prediction": "Spearman r < 0.5 between formal-academic and conversational/adversarial rankings; within-regime r > 0.75", "status": "ACTIVE", "test_protocol": "MMLU vs MT-Bench / adversarial NLI ranking correlation"},
-    {"id": "A4", "domain": "AI", "prediction": "SHAP coherence in training regime is uncorrelated with OOD performance", "status": "Meth.", "test_protocol": "Compute SHAP coherence on train-dist; evaluate same models OOD; test correlation"},
-    {"id": "A5", "domain": "AI", "prediction": "Validity profile reduces deployment failure prediction error by > 20% vs scalar score alone", "status": "Pending", "test_protocol": "Collect production incident data; compare prediction accuracy"},
-    {"id": "F1", "domain": "Both", "prediction": "Proxy substitution drift direction in both domains is predictable from declared structural blindness", "status": "ACTIVE", "test_protocol": "Proxy swap experiments in both domains; test direction vs permutation null"},
-    {"id": "F2", "domain": "Both", "prediction": "Conflicts resolved by regime identification but not by model substitution are more frequent than the reverse", "status": "Meth.", "test_protocol": "Systematic conflict taxonomy in both domains; resolution scoring"}
+    {
+      "id": "C1",
+      "domain": "Cosmology",
+      "prediction": "Same (k,S) coordinate yields consistent response across independent probes",
+      "status": "PARTIAL",
+      "test_protocol": "Map DESI DR2 + f sigma8 onto (k,S); test consistency vs probe-specific null",
+      "current_evidence": "p=0.020 sign coherence, N=10, secondary statistic"
+    },
+    {
+      "id": "C2",
+      "domain": "Cosmology",
+      "prediction": "Proxy substitution from global S-hat to local structural proxy yields directional drift",
+      "status": "Pending",
+      "test_protocol": "Compare regime assignments: S-hat(z) vs morphology proxy on SDSS/GAMA"
+    },
+    {
+      "id": "C3",
+      "domain": "Cosmology",
+      "prediction": "Largest BAO/growth deviations cluster near regime boundaries in S-hat-space",
+      "status": "ACTIVE",
+      "test_protocol": "Axiom 0 v2 pre-registered on DESI Year-5 (N>=30)"
+    },
+    {
+      "id": "C4",
+      "domain": "Cosmology",
+      "prediction": "H0 within a single S-hat-regime shows lower inter-survey variance than pooled cross-regime estimates",
+      "status": "ACTIVE",
+      "test_protocol": "Stratify existing H0 measurements by S-hat-regime; compute within- vs cross-regime variance"
+    },
+    {
+      "id": "C5",
+      "domain": "Cosmology",
+      "prediction": "LATENT residuals sign-coherent and low-variance; FLOW higher-variance; ratio > 2.0",
+      "status": "PARTIAL",
+      "test_protocol": "Compute residuals per regime; runs-test + sign-coherence + variance ratio",
+      "current_evidence": "8/9 positive sign coherence in TRANSITION+LATENT"
+    },
+    {
+      "id": "C6",
+      "domain": "Cosmology",
+      "prediction": "Models matched on chi2_BAO but differing in proxy construction diverge in f sigma8 at TRANSITION coordinates",
+      "status": "Pending",
+      "test_protocol": "Select matched model pairs; evaluate f sigma8 at S-hat-identified TRANSITION coords"
+    },
+    {
+      "id": "A1",
+      "domain": "AI",
+      "prediction": "Models near benchmark regime boundaries show higher output variance and lower metric reliability",
+      "status": "Meth.",
+      "test_protocol": "Sample inputs at graduated OOD distance; compute output variance per distance band"
+    },
+    {
+      "id": "A2",
+      "domain": "AI",
+      "prediction": "Accuracy -> calibration error substitution: top-quartile-accuracy/bottom-half-calibration models fall >= 2 quartiles",
+      "status": "Meth.",
+      "test_protocol": "Apply both metrics to MMLU; compute rank changes; test direction vs permutation null"
+    },
+    {
+      "id": "A3",
+      "domain": "AI",
+      "prediction": "Spearman r < 0.5 between formal-academic and conversational/adversarial rankings; within-regime r > 0.75",
+      "status": "ACTIVE",
+      "test_protocol": "MMLU vs MT-Bench / adversarial NLI ranking correlation"
+    },
+    {
+      "id": "A4",
+      "domain": "AI",
+      "prediction": "SHAP coherence in training regime is uncorrelated with OOD performance",
+      "status": "Meth.",
+      "test_protocol": "Compute SHAP coherence on train-dist; evaluate same models OOD; test correlation"
+    },
+    {
+      "id": "A5",
+      "domain": "AI",
+      "prediction": "Validity profile reduces deployment failure prediction error by > 20% vs scalar score alone",
+      "status": "Pending",
+      "test_protocol": "Collect production incident data; compare prediction accuracy"
+    },
+    {
+      "id": "F1",
+      "domain": "Both",
+      "prediction": "Proxy substitution drift direction in both domains is predictable from declared structural blindness",
+      "status": "ACTIVE",
+      "test_protocol": "Proxy swap experiments in both domains; test direction vs permutation null"
+    },
+    {
+      "id": "F2",
+      "domain": "Both",
+      "prediction": "Conflicts resolved by regime identification but not by model substitution are more frequent than the reverse",
+      "status": "Meth.",
+      "test_protocol": "Systematic conflict taxonomy in both domains; resolution scoring"
+    }
   ],
-
   "falsification_criteria": [
-    {"id": "F-BREAK 1", "name": "Regime-random residuals", "description": "LATENT, TRANSITION, FLOW residuals are statistically indistinguishable"},
-    {"id": "F-BREAK 2", "name": "Proxy-substitution drift is random", "description": "Drift direction cannot be predicted from declared blindness"},
-    {"id": "F-BREAK 3", "name": "Episenter shift produces random redistribution", "description": "Rank changes after metric substitution are indistinguishable from random"},
-    {"id": "F-BREAK 4", "name": "Hubble tension survives full regime-compatibility test", "description": "Tension persists at full significance after all three placement dimensions made compatible"},
-    {"id": "F-BREAK 5", "name": "Null results are regime-random", "description": "Null results distributed uniformly across regimes"}
+    {
+      "id": "F-BREAK 1",
+      "name": "Regime-random residuals",
+      "description": "LATENT, TRANSITION, FLOW residuals are statistically indistinguishable"
+    },
+    {
+      "id": "F-BREAK 2",
+      "name": "Proxy-substitution drift is random",
+      "description": "Drift direction cannot be predicted from declared blindness"
+    },
+    {
+      "id": "F-BREAK 3",
+      "name": "Episenter shift produces random redistribution",
+      "description": "Rank changes after metric substitution are indistinguishable from random"
+    },
+    {
+      "id": "F-BREAK 4",
+      "name": "Hubble tension survives full regime-compatibility test",
+      "description": "Tension persists at full significance after all three placement dimensions made compatible"
+    },
+    {
+      "id": "F-BREAK 5",
+      "name": "Null results are regime-random",
+      "description": "Null results distributed uniformly across regimes"
+    }
   ],
-
   "genuine_test_criteria": [
-    {"id": "C1", "name": "Pre-specification", "description": "Prediction stated before test, protocol locked"},
-    {"id": "C2", "name": "Discriminability", "description": "Prediction distinguishable from competing explanation"},
-    {"id": "C3", "name": "Directionality", "description": "Direction and approximate magnitude specified"},
-    {"id": "C4", "name": "Regime-scope declaration", "description": "Regime in which prediction holds is declared"}
+    {
+      "id": "C1",
+      "name": "Pre-specification",
+      "description": "Prediction stated before test, protocol locked"
+    },
+    {
+      "id": "C2",
+      "name": "Discriminability",
+      "description": "Prediction distinguishable from competing explanation"
+    },
+    {
+      "id": "C3",
+      "name": "Directionality",
+      "description": "Direction and approximate magnitude specified"
+    },
+    {
+      "id": "C4",
+      "name": "Regime-scope declaration",
+      "description": "Regime in which prediction holds is declared"
+    }
   ],
-
   "falsification_protocol": [
-    {"id": "FC1", "requirement": "Pre-registered test"},
-    {"id": "FC2", "requirement": "Adequate statistical power"},
-    {"id": "FC3", "requirement": "Regime-compatible execution"}
+    {
+      "id": "FC1",
+      "requirement": "Pre-registered test"
+    },
+    {
+      "id": "FC2",
+      "requirement": "Adequate statistical power"
+    },
+    {
+      "id": "FC3",
+      "requirement": "Regime-compatible execution"
+    }
   ],
-
   "references": [
-    {"key": "[1]", "doi": "10.6084/m9.figshare.31231522", "title": "BAO transfer test"},
-    {"key": "[2]", "doi": "10.6084/m9.figshare.31304980", "title": "Four-channel background coupling"},
-    {"key": "[3]", "doi": "10.6084/m9.figshare.31305550", "title": "SCE: EFC vs LCDM"},
-    {"key": "[4]", "doi": "10.6084/m9.figshare.31211437", "title": "R(k,S) framework"},
-    {"key": "[5]", "doi": "10.6084/m9.figshare.31215259", "title": "WP3 first empirical slice"},
-    {"key": "[6]", "doi": "10.6084/m9.figshare.31368433", "title": "CMB+LSS localization"},
-    {"key": "[7]", "doi": "10.6084/m9.figshare.31332730", "title": "MVP-G1 growth robustness"},
-    {"key": "[8]", "doi": "10.6084/m9.figshare.31222903", "title": "EBE Core Principles"},
-    {"key": "[9]", "doi": "10.6084/m9.figshare.31222900", "title": "RCMP"},
-    {"key": "[10]", "doi": "10.6084/m9.figshare.31224247", "title": "Hubble Tension as Regime Mismatch"},
-    {"key": "[11]", "doi": "10.6084/m9.figshare.31293745", "title": "SCE Framework"},
-    {"key": "[12]", "doi": "10.6084/m9.figshare.31122970", "title": "Validity-Aware AI"},
-    {"key": "[13]", "doi": "10.6084/m9.figshare.31223650", "title": "Regime-Based World Modeling"},
-    {"key": "[14]", "doi": "10.6084/m9.figshare.31562200", "title": "EFC EFT Ansatz"}
-  ]
+    {
+      "key": "[1]",
+      "doi": "10.6084/m9.figshare.31231522",
+      "title": "BAO transfer test"
+    },
+    {
+      "key": "[2]",
+      "doi": "10.6084/m9.figshare.31304980",
+      "title": "Four-channel background coupling"
+    },
+    {
+      "key": "[3]",
+      "doi": "10.6084/m9.figshare.31305550",
+      "title": "SCE: EFC vs LCDM"
+    },
+    {
+      "key": "[4]",
+      "doi": "10.6084/m9.figshare.31211437",
+      "title": "R(k,S) framework"
+    },
+    {
+      "key": "[5]",
+      "doi": "10.6084/m9.figshare.31215259",
+      "title": "WP3 first empirical slice"
+    },
+    {
+      "key": "[6]",
+      "doi": "10.6084/m9.figshare.31368433",
+      "title": "CMB+LSS localization"
+    },
+    {
+      "key": "[7]",
+      "doi": "10.6084/m9.figshare.31332730",
+      "title": "MVP-G1 growth robustness"
+    },
+    {
+      "key": "[8]",
+      "doi": "10.6084/m9.figshare.31222903",
+      "title": "EBE Core Principles"
+    },
+    {
+      "key": "[9]",
+      "doi": "10.6084/m9.figshare.31222900",
+      "title": "RCMP"
+    },
+    {
+      "key": "[10]",
+      "doi": "10.6084/m9.figshare.31224247",
+      "title": "Hubble Tension as Regime Mismatch"
+    },
+    {
+      "key": "[11]",
+      "doi": "10.6084/m9.figshare.31293745",
+      "title": "SCE Framework"
+    },
+    {
+      "key": "[12]",
+      "doi": "10.6084/m9.figshare.31122970",
+      "title": "Validity-Aware AI"
+    },
+    {
+      "key": "[13]",
+      "doi": "10.6084/m9.figshare.31223650",
+      "title": "Regime-Based World Modeling"
+    },
+    {
+      "key": "[14]",
+      "doi": "10.6084/m9.figshare.31562200",
+      "title": "EFC EFT Ansatz"
+    }
+  ],
+  "doi": "10.6084/m9.figshare.31564123"
 }

--- a/docs/papers/efc/Regime_Locked_Measurement/index.json
+++ b/docs/papers/efc/Regime_Locked_Measurement/index.json
@@ -7,15 +7,24 @@
   "orcid": "0009-0002-4860-5095",
   "affiliation": "Symbiose Research, Sandnes, Norway",
   "date": "2026-03",
-
   "abstract": "Formalises regime-locked measurement as a general structural constraint. Shared structural pattern across six domains. Three contributions: alpha-score alpha(phi, R) in [0,1], blind-set taxonomy (ontological/methodological/instrumental), and five-step meta-regime protocol. Worked example identifies convergence drift in AI alignment.",
-
   "epistemic_status": [
-    {"level": "Definition", "status": "Formal", "content": "Regime, regime-locked measurement, CDVC, meta-regime, alpha-score, blind-set taxonomy"},
-    {"level": "Hypothesis", "status": "Testable", "content": "Shared pattern across domains; meta-regime detects blind spots; alpha outperforms binary"},
-    {"level": "Conjecture", "status": "Open", "content": "S0/S1 observational equivalence at gradient extremes"}
+    {
+      "level": "Definition",
+      "status": "Formal",
+      "content": "Regime, regime-locked measurement, CDVC, meta-regime, alpha-score, blind-set taxonomy"
+    },
+    {
+      "level": "Hypothesis",
+      "status": "Testable",
+      "content": "Shared pattern across domains; meta-regime detects blind spots; alpha outperforms binary"
+    },
+    {
+      "level": "Conjecture",
+      "status": "Open",
+      "content": "S0/S1 observational equivalence at gradient extremes"
+    }
   ],
-
   "formal_framework": {
     "regime": {
       "definition": "R = (I, V, B, G)",
@@ -33,13 +42,20 @@
       "equation": "alpha(phi, R_i) = |phi ∩ V(R_i)| / |phi| in [0, 1]",
       "at_1": "Regime fully appropriate",
       "at_0": "Phenomenon entirely in blind set",
-      "estimation_methods": ["Residual structure fraction", "Cross-regime recovery rate", "Bayesian evidence ratio"],
+      "estimation_methods": [
+        "Residual structure fraction",
+        "Cross-regime recovery rate",
+        "Bayesian evidence ratio"
+      ],
       "selection": "arg max_i alpha(phi, R_i)"
     },
     "cdvc": {
       "definition": "sigma in intersection V(R_k) for N >= 3 domains",
       "status": "Indicator, not proof",
-      "conditions": ["Independent generation", "Predictive content"],
+      "conditions": [
+        "Independent generation",
+        "Predictive content"
+      ],
       "alternative": "Could reflect shared cognitive bias"
     },
     "meta_regime": {
@@ -56,31 +72,99 @@
       "connection": "Identifiability problem in inverse problems / latent-variable models"
     }
   },
-
   "blind_set_taxonomy": [
-    {"type": "B_ont", "name": "Ontological", "character": "Outside instrument's physical reach", "detection": "New instrument class"},
-    {"type": "B_meth", "name": "Methodological", "character": "Excluded by framework assumptions", "detection": "Cross-regime comparison; assumption audit"},
-    {"type": "B_inst", "name": "Instrumental", "character": "Within reach but below sensitivity", "detection": "Instrument upgrade; residual analysis"}
+    {
+      "type": "B_ont",
+      "name": "Ontological",
+      "character": "Outside instrument's physical reach",
+      "detection": "New instrument class"
+    },
+    {
+      "type": "B_meth",
+      "name": "Methodological",
+      "character": "Excluded by framework assumptions",
+      "detection": "Cross-regime comparison; assumption audit"
+    },
+    {
+      "type": "B_inst",
+      "name": "Instrumental",
+      "character": "Within reach but below sensitivity",
+      "detection": "Instrument upgrade; residual analysis"
+    }
   ],
-
   "domains": [
-    {"domain": "Cosmology", "instrument_sees": "Model-predicted signals", "instrument_misses": "Alternative mechanisms", "B_type": "meth", "residual_signal": "Hubble tension as structured residual"},
-    {"domain": "AI Alignment", "instrument_sees": "Deviation from norms", "instrument_misses": "Convergence drift", "B_type": "meth", "residual_signal": "Persistent high-quality outputs not flagged"},
-    {"domain": "Cyber Security", "instrument_sees": "Known signatures", "instrument_misses": "Regime-boundary exploits", "B_type": "meth", "residual_signal": "SolarWinds, Stuxnet exploited trusted zones"},
-    {"domain": "Intelligence", "instrument_sees": "In-scope threats", "instrument_misses": "Out-of-doctrine threats", "B_type": "meth", "residual_signal": "Pre-9/11 cross-agency signals in each B"},
-    {"domain": "Economics", "instrument_sees": "In-regime behaviour", "instrument_misses": "Regime transitions", "B_type": "inst", "residual_signal": "2008 crisis: low-volatility calibration blind at boundary"},
-    {"domain": "Consciousness", "instrument_sees": "Neural correlates", "instrument_misses": "Subjective experience", "B_type": "ont", "residual_signal": "Hard problem"}
+    {
+      "domain": "Cosmology",
+      "instrument_sees": "Model-predicted signals",
+      "instrument_misses": "Alternative mechanisms",
+      "B_type": "meth",
+      "residual_signal": "Hubble tension as structured residual"
+    },
+    {
+      "domain": "AI Alignment",
+      "instrument_sees": "Deviation from norms",
+      "instrument_misses": "Convergence drift",
+      "B_type": "meth",
+      "residual_signal": "Persistent high-quality outputs not flagged"
+    },
+    {
+      "domain": "Cyber Security",
+      "instrument_sees": "Known signatures",
+      "instrument_misses": "Regime-boundary exploits",
+      "B_type": "meth",
+      "residual_signal": "SolarWinds, Stuxnet exploited trusted zones"
+    },
+    {
+      "domain": "Intelligence",
+      "instrument_sees": "In-scope threats",
+      "instrument_misses": "Out-of-doctrine threats",
+      "B_type": "meth",
+      "residual_signal": "Pre-9/11 cross-agency signals in each B"
+    },
+    {
+      "domain": "Economics",
+      "instrument_sees": "In-regime behaviour",
+      "instrument_misses": "Regime transitions",
+      "B_type": "inst",
+      "residual_signal": "2008 crisis: low-volatility calibration blind at boundary"
+    },
+    {
+      "domain": "Consciousness",
+      "instrument_sees": "Neural correlates",
+      "instrument_misses": "Subjective experience",
+      "B_type": "ont",
+      "residual_signal": "Hard problem"
+    }
   ],
-
   "protocol": {
     "name": "Meta-Regime Evaluation Protocol (Algorithm 1)",
     "input": "Instrument I, target phenomenon phi, candidate regimes {R_1,...,R_n}",
     "steps": [
-      {"step": 1, "name": "Regime Identification", "action": "Characterise R = (I, V, B, G)"},
-      {"step": 2, "name": "Blind Set Elicitation", "action": "Enumerate B_known; classify as B_ont/B_meth/B_inst"},
-      {"step": 3, "name": "Cross-Regime Check", "action": "For each b in B_i, test if b in V_j for some j != i"},
-      {"step": 4, "name": "Residual Analysis", "action": "Test residuals for structure -> B_inferred candidates"},
-      {"step": 5, "name": "Alpha-Scoring", "action": "Estimate alpha; flag if below threshold; report B types"}
+      {
+        "step": 1,
+        "name": "Regime Identification",
+        "action": "Characterise R = (I, V, B, G)"
+      },
+      {
+        "step": 2,
+        "name": "Blind Set Elicitation",
+        "action": "Enumerate B_known; classify as B_ont/B_meth/B_inst"
+      },
+      {
+        "step": 3,
+        "name": "Cross-Regime Check",
+        "action": "For each b in B_i, test if b in V_j for some j != i"
+      },
+      {
+        "step": 4,
+        "name": "Residual Analysis",
+        "action": "Test residuals for structure -> B_inferred candidates"
+      },
+      {
+        "step": 5,
+        "name": "Alpha-Scoring",
+        "action": "Estimate alpha; flag if below threshold; report B types"
+      }
     ],
     "alpha_estimation": [
       "Residual structure fraction (higher -> lower alpha)",
@@ -96,7 +180,6 @@
       "step5": "alpha ~ 0.5-0.7 (heuristic). B_meth indicates closeable by paradigm expansion."
     }
   },
-
   "falsification": {
     "framework_level": [
       "Measurement system demonstrated with B = empty (no blind spots across boundaries)",
@@ -110,7 +193,6 @@
       "General method reliably distinguishes S0/S1 from output alone"
     ]
   },
-
   "limitations": [
     "Self-reference: R_meta has unknown B_meta",
     "CDVC: indicator, not proof (shared cognitive bias possible)",
@@ -120,26 +202,69 @@
     "Provenance: regime concept from thermodynamic cosmology",
     "Evidential asymmetry: some cases well-sourced, others conceptual"
   ],
-
   "implications": {
     "scientific_methodology": "No single methodology can claim observational completeness",
     "ai_governance": "Alignment evaluation should include convergence monitoring alongside deviation monitoring",
     "intelligence_security": "Proactive blind-spot identification via steps 2-3"
   },
-
   "references": [
-    {"key": "[1]", "doi": "10.6084/m9.figshare.30478916", "title": "EFC-v2.1"},
-    {"key": "[2]", "doi": "10.6084/m9.figshare.31112536", "title": "L0-L3 Regime Architecture"},
-    {"key": "[3]", "doi": "10.6084/m9.figshare.31222900", "title": "RCMP"},
-    {"key": "[4]", "doi": "10.6084/m9.figshare.31224247", "title": "Hubble Tension as Regime Mismatch"},
-    {"key": "[5]", "doi": "10.6084/m9.figshare.31122970", "title": "Validity-Aware AI"},
-    {"key": "[6]", "title": "Anthropic AI Safety Recommendations (2025)"},
-    {"key": "[7]", "title": "Greenblatt et al., Alignment Faking (2024)"},
-    {"key": "[8]", "title": "Scaling Monosemanticity (2024)"},
-    {"key": "[9]", "title": "9/11 Commission Report (2004)"},
-    {"key": "[10]", "title": "Taleb, The Black Swan (2007)"},
-    {"key": "[11]", "title": "CISA SolarWinds Alert (2021)"},
-    {"key": "[12]", "title": "Langner, Stuxnet (2011)"},
-    {"key": "[13]", "title": "Chalmers, Hard Problem (1995)"}
-  ]
+    {
+      "key": "[1]",
+      "doi": "10.6084/m9.figshare.30478916",
+      "title": "EFC-v2.1"
+    },
+    {
+      "key": "[2]",
+      "doi": "10.6084/m9.figshare.31112536",
+      "title": "L0-L3 Regime Architecture"
+    },
+    {
+      "key": "[3]",
+      "doi": "10.6084/m9.figshare.31222900",
+      "title": "RCMP"
+    },
+    {
+      "key": "[4]",
+      "doi": "10.6084/m9.figshare.31224247",
+      "title": "Hubble Tension as Regime Mismatch"
+    },
+    {
+      "key": "[5]",
+      "doi": "10.6084/m9.figshare.31122970",
+      "title": "Validity-Aware AI"
+    },
+    {
+      "key": "[6]",
+      "title": "Anthropic AI Safety Recommendations (2025)"
+    },
+    {
+      "key": "[7]",
+      "title": "Greenblatt et al., Alignment Faking (2024)"
+    },
+    {
+      "key": "[8]",
+      "title": "Scaling Monosemanticity (2024)"
+    },
+    {
+      "key": "[9]",
+      "title": "9/11 Commission Report (2004)"
+    },
+    {
+      "key": "[10]",
+      "title": "Taleb, The Black Swan (2007)"
+    },
+    {
+      "key": "[11]",
+      "title": "CISA SolarWinds Alert (2021)"
+    },
+    {
+      "key": "[12]",
+      "title": "Langner, Stuxnet (2011)"
+    },
+    {
+      "key": "[13]",
+      "title": "Chalmers, Hard Problem (1995)"
+    }
+  ],
+  "doi": "10.6084/m9.figshare.31833076"
 }

--- a/docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models/index.json
+++ b/docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models/index.json
@@ -82,7 +82,7 @@
   "parameters": {
     "G": 6.674e-11,
     "G_unit": "m³ kg⁻¹ s⁻²",
-    "c": 2.998e8,
+    "c": 299800000.0,
     "c_unit": "m/s",
     "Lambda_m2": 1.11e-52,
     "a0_m_s2": 1.2e-10,
@@ -120,8 +120,17 @@
   ],
   "files": {
     "paper": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models.pdf",
-    "documentation": ["README.md", "QUICKSTART.md", "MANIFEST.md"],
-    "metadata": ["CITATION.cff", "index.json", "RegimeStructureEntropicFlowOntology.jsonld", "schema.json"],
+    "documentation": [
+      "README.md",
+      "QUICKSTART.md",
+      "MANIFEST.md"
+    ],
+    "metadata": [
+      "CITATION.cff",
+      "index.json",
+      "RegimeStructureEntropicFlowOntology.jsonld",
+      "schema.json"
+    ],
     "source_code": [
       "src/__init__.py",
       "src/interpolating_function.py",
@@ -137,5 +146,6 @@
       "examples/classify_regimes.py",
       "examples/functional_sectors.py"
     ]
-  }
+  },
+  "doi": "10.6084/m9.figshare.31348417"
 }

--- a/docs/papers/efc/efc_formal_spec/index.json
+++ b/docs/papers/efc/efc_formal_spec/index.json
@@ -15,5 +15,6 @@
   ],
   "layer": "docs",
   "type": "paper",
-  "version": "1.0"
+  "version": "1.0",
+  "doi": "10.6084/m9.figshare.30630500"
 }

--- a/docs/papers/efc/variable-light-s0-s1/index.json
+++ b/docs/papers/efc/variable-light-s0-s1/index.json
@@ -13,5 +13,6 @@
   "keywords": [],
   "summary": "In Energy-Flow Cosmology (EFC), the effective speed of light is not a primitive constant but an emergent propagation limit determined by the entropic state of the grid. Two fundamental entropic phases---a low-entropy constraining state ($s_0$) and a high-entropy dissipative state ($s_1$)---govern th",
   "created": "2025-12-04",
-  "updated": "2025-12-04"
+  "updated": "2025-12-04",
+  "doi": "10.6084/m9.figshare.30642497"
 }

--- a/figshare/doi-map.json
+++ b/figshare/doi-map.json
@@ -1,44 +1,746 @@
 {
+  "10.6084/m9.figshare.31943361": {
+    "figshare_id": 31943361,
+    "title": "ΛCDM as a Special Case of Entropy-Flow Cosmology",
+    "path": "docs/papers/efc/ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology",
+    "url": "https://doi.org/10.6084/m9.figshare.31943361"
+  },
+  "10.6084/m9.figshare.31942821": {
+    "figshare_id": 31942821,
+    "title": "Derivation of the Entropy Production Function Γ(ρ) from Grid-Mode Bose–Einstein Statistics",
+    "path": "docs/papers/efc/Derivation_of_the_Entropy_Production",
+    "url": "https://doi.org/10.6084/m9.figshare.31942821"
+  },
+  "10.6084/m9.figshare.31942800": {
+    "figshare_id": 31942800,
+    "title": "Density of States of Gravitationally Active Grid Modes",
+    "path": "docs/papers/efc/Density_of_States_of_Gravitationally",
+    "url": "https://doi.org/10.6084/m9.figshare.31942800"
+  },
+  "10.6084/m9.figshare.31942734": {
+    "figshare_id": 31942734,
+    "title": "The Cosmic Entropy Budget as Constraint on the EFC S-Field",
+    "path": "docs/papers/efc/EFC_Entropy_Budget_Working_Note",
+    "url": "https://doi.org/10.6084/m9.figshare.31942734"
+  },
+  "10.6084/m9.figshare.31942731": {
+    "figshare_id": 31942731,
+    "title": "The Cosmic Dipole Anomaly as Regime-Dependent Anisotropy",
+    "path": "docs/papers/efc/EFC_Cosmic_Dipole_Working_Note",
+    "url": "https://doi.org/10.6084/m9.figshare.31942731"
+  },
+  "10.6084/m9.figshare.31942677": {
+    "figshare_id": 31942677,
+    "title": "Density-Dependent Gravitational Coupling Predicts ISW Sign-Flip in Deep Voids",
+    "path": "docs/papers/efc/void_isw_signflip_v2.1_final",
+    "url": "https://doi.org/10.6084/m9.figshare.31942677"
+  },
+  "10.6084/m9.figshare.31941543": {
+    "figshare_id": 31941543,
+    "title": "Consistency of Scale-Dependent Gravitational Response in EFC",
+    "path": "docs/papers/efc/Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test",
+    "url": "https://doi.org/10.6084/m9.figshare.31941543"
+  },
+  "10.6084/m9.figshare.31941465": {
+    "figshare_id": 31941465,
+    "title": "Gradient-Coupled Grid Action: Derivation of E ∝ √g from First Principles",
+    "path": "docs/papers/efc/EFC_Gradient_Coupled_Grid_Action",
+    "url": "https://doi.org/10.6084/m9.figshare.31941465"
+  },
+  "10.6084/m9.figshare.31940604": {
+    "figshare_id": 31940604,
+    "title": "HOMO FLUXUS: A Civilization Map Through Energy-Flow Cosmology",
+    "path": "docs/papers/efc/Homo_Fluxus",
+    "url": "https://doi.org/10.6084/m9.figshare.31940604"
+  },
+  "10.6084/m9.figshare.31940547": {
+    "figshare_id": 31940547,
+    "title": "Cross-Domain Bridge Equations for the EFC Framework",
+    "path": "docs/papers/efc/Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge",
+    "url": "https://doi.org/10.6084/m9.figshare.31940547"
+  },
+  "10.6084/m9.figshare.31940535": {
+    "figshare_id": 31940535,
+    "title": "Reinforcement Learning from Human Feedback as Thermodynamic Entropy Minimisation",
+    "path": "docs/papers/efc/Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3",
+    "url": "https://doi.org/10.6084/m9.figshare.31940535"
+  },
+  "10.6084/m9.figshare.31940505": {
+    "figshare_id": 31940505,
+    "title": "EFC-C A Thermodynamic Framework for Cognitive Entropy and Psychiatric Biomarkers",
+    "path": "docs/papers/efc/EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2",
+    "url": "https://doi.org/10.6084/m9.figshare.31940505"
+  },
+  "10.6084/m9.figshare.31940469": {
+    "figshare_id": 31940469,
+    "title": "Energy-Flow Cosmology Empirical Validation of the EFC Screening Model",
+    "path": "docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1",
+    "url": "https://doi.org/10.6084/m9.figshare.31940469"
+  },
   "10.6084/m9.figshare.31940370": {
-    "id": 31940370,
-    "url": "https://figshare.com/articles/preprint/Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients_in_the_Human_Connectome/31940370",
+    "figshare_id": 31940370,
+    "title": "Local Degree Heterogeneity Predicts Functional Variability Gradients",
     "path": "docs/papers/efc/Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients",
-    "title": "Local Degree Heterogeneity Predicts Functional Variability Gradients in the Human Connectome"
+    "url": "https://doi.org/10.6084/m9.figshare.31940370"
+  },
+  "10.6084/m9.figshare.31878760": {
+    "figshare_id": 31878760,
+    "title": "From Grid Microphysics to the Radial Acceleration Relation",
+    "path": "docs/papers/efc/From_Grid_Microphysics_to_the_Radial_Acceleration",
+    "url": "https://doi.org/10.6084/m9.figshare.31878760"
+  },
+  "10.6084/m9.figshare.31878334": {
+    "figshare_id": 31878334,
+    "title": "Covariant EFT for Entropy-Driven Gravitational Modification",
+    "path": "docs/papers/efc/Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints",
+    "url": "https://doi.org/10.6084/m9.figshare.31878334"
+  },
+  "10.6084/m9.figshare.31876324": {
+    "figshare_id": 31876324,
+    "title": "EFC Relativistic Action: Field Equations, Perturbation Theory, and Extraction of μ, Σ, η",
+    "path": "docs/papers/efc/EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction",
+    "url": "https://doi.org/10.6084/m9.figshare.31876324"
+  },
+  "10.6084/m9.figshare.31864993": {
+    "figshare_id": 31864993,
+    "title": "Natural and Mechanical Entropy: Intention Detection via Episenter–Resonance Analysis",
+    "path": "docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems",
+    "url": "https://doi.org/10.6084/m9.figshare.31864993"
+  },
+  "10.6084/m9.figshare.31833076": {
+    "figshare_id": 31833076,
+    "title": "Regime-Locked Measurement as a General Structural Constraint",
+    "path": "docs/papers/efc/Regime_Locked_Measurement",
+    "url": "https://doi.org/10.6084/m9.figshare.31833076"
+  },
+  "10.6084/m9.figshare.31564129": {
+    "figshare_id": 31564129,
+    "title": "Double-Slit as Grid-Resolution Phenomenon in GRC",
+    "path": "docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis",
+    "url": "https://doi.org/10.6084/m9.figshare.31564129"
+  },
+  "10.6084/m9.figshare.31564123": {
+    "figshare_id": 31564123,
+    "title": "Regime-Bound Measurement in Complex Systems",
+    "path": "docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity",
+    "url": "https://doi.org/10.6084/m9.figshare.31564123"
+  },
+  "10.6084/m9.figshare.31562200": {
+    "figshare_id": 31562200,
+    "title": "",
+    "path": "docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients",
+    "url": "https://doi.org/10.6084/m9.figshare.31562200"
+  },
+  "10.6084/m9.figshare.31368433": {
+    "figshare_id": 31368433,
+    "title": "Systematic Localization of Late-Time Cosmological Signals in Modified Gravity",
+    "path": "docs/papers/efc/Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier",
+    "url": "https://doi.org/10.6084/m9.figshare.31368433"
+  },
+  "10.6084/m9.figshare.31348417": {
+    "figshare_id": 31348417,
+    "title": "",
+    "path": "docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models",
+    "url": "https://doi.org/10.6084/m9.figshare.31348417"
+  },
+  "10.6084/m9.figshare.31348414": {
+    "figshare_id": 31348414,
+    "title": "",
+    "path": "docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity",
+    "url": "https://doi.org/10.6084/m9.figshare.31348414"
+  },
+  "10.6084/m9.figshare.31348411": {
+    "figshare_id": 31348411,
+    "title": "Discrete Entropic Gravity on a Cubic Graph",
+    "path": "docs/papers/efc/Discrete_Entropic_Gravity_on_a_Cubic_Graph_Emergent_Newton_and_MOND_Regimes_with_Λ-Locked_Screening",
+    "url": "https://doi.org/10.6084/m9.figshare.31348411"
+  },
+  "10.6084/m9.figshare.31333600": {
+    "figshare_id": 31333600,
+    "title": "Perturbation-Level σ₈ Suppression via μ(a) < 1",
+    "path": "docs/papers/efc/Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications",
+    "url": "https://doi.org/10.6084/m9.figshare.31333600"
+  },
+  "10.6084/m9.figshare.31333414": {
+    "figshare_id": 31333414,
+    "title": "EFCLASS Sign Structure: Background Channel σ₈ Exclusion",
+    "path": "docs/papers/efc/EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation",
+    "url": "https://doi.org/10.6084/m9.figshare.31333414"
+  },
+  "10.6084/m9.figshare.31332730": {
+    "figshare_id": 31332730,
+    "title": "Robustness of the EFC Growth-Sector Signal",
+    "path": "docs/papers/efc/Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel",
+    "url": "https://doi.org/10.6084/m9.figshare.31332730"
+  },
+  "10.6084/m9.figshare.31329082": {
+    "figshare_id": 31329082,
+    "title": "ISW Consistency Audit and Revision Patch",
+    "path": "docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions",
+    "url": "https://doi.org/10.6084/m9.figshare.31329082"
+  },
+  "10.6084/m9.figshare.31314922": {
+    "figshare_id": 31314922,
+    "title": "Covariance-Aware BAO Consistency Test Using BOSS DR12",
+    "path": "docs/papers/efc/efc_boss_bao_cobaya_research_note",
+    "url": "https://doi.org/10.6084/m9.figshare.31314922"
+  },
+  "10.6084/m9.figshare.31305550": {
+    "figshare_id": 31305550,
+    "title": "Structural Coherence Evaluation for Energy-Flow Cosmology",
+    "path": "docs/papers/efc/efc_state_vs_stageIII",
+    "url": "https://doi.org/10.6084/m9.figshare.31305550"
+  },
+  "10.6084/m9.figshare.31305421": {
+    "figshare_id": 31305421,
+    "title": "Toward a Quantitative c_eff(a)",
+    "path": "docs/papers/efc/c_eff_parameterization",
+    "url": "https://doi.org/10.6084/m9.figshare.31305421"
+  },
+  "10.6084/m9.figshare.31304995": {
+    "figshare_id": 31304995,
+    "title": "Regime Consistency: Lyα, BAO and RSD Tests",
+    "path": "docs/papers/efc/regime_consistency_lya_bao_rsd_sce",
+    "url": "https://doi.org/10.6084/m9.figshare.31304995"
+  },
+  "10.6084/m9.figshare.31304980": {
+    "figshare_id": 31304980,
+    "title": "A One-Parameter, Four-Channel Consistency Test",
+    "path": "docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
+    "url": "https://doi.org/10.6084/m9.figshare.31304980"
+  },
+  "10.6084/m9.figshare.31301953": {
+    "figshare_id": 31301953,
+    "title": "ISW Cross-Correlation Predictions",
+    "path": "docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers",
+    "url": "https://doi.org/10.6084/m9.figshare.31301953"
+  },
+  "10.6084/m9.figshare.31293745": {
+    "figshare_id": 31293745,
+    "title": "Structural Coherence Evaluation for Physical Theories",
+    "path": "docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories",
+    "url": "https://doi.org/10.6084/m9.figshare.31293745"
+  },
+  "10.6084/m9.figshare.31292827": {
+    "figshare_id": 31292827,
+    "title": "From RSD to Clusters: A Parameter-Locked Test",
+    "path": "docs/papers/efc/paper_rsd_to_clusters",
+    "url": "https://doi.org/10.6084/m9.figshare.31292827"
+  },
+  "10.6084/m9.figshare.31289806": {
+    "figshare_id": 31289806,
+    "title": "Consciousness as Field Resonance",
+    "path": "docs/papers/efc/EFC-C_Consciousness_Field_Resonance",
+    "url": "https://doi.org/10.6084/m9.figshare.31289806"
+  },
+  "10.6084/m9.figshare.31288063": {
+    "figshare_id": 31288063,
+    "title": "Directional Lensing Residuals at Cluster Merger Shock Fronts",
+    "path": "docs/papers/efc/Directional_Lensing_Residuals",
+    "url": "https://doi.org/10.6084/m9.figshare.31288063"
+  },
+  "10.6084/m9.figshare.31286368": {
+    "figshare_id": 31286368,
+    "title": "A Pre-Registered Test of Entropy–Structure Coupling",
+    "path": "docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters",
+    "url": "https://doi.org/10.6084/m9.figshare.31286368"
+  },
+  "10.6084/m9.figshare.31271917": {
+    "figshare_id": 31271917,
+    "title": "A Regime-Activated Lensing Response Improves KiDS-1000",
+    "path": "docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes",
+    "url": "https://doi.org/10.6084/m9.figshare.31271917"
+  },
+  "10.6084/m9.figshare.31271707": {
+    "figshare_id": 31271707,
+    "title": "Persistent Cognitive Architectures for Human-AI Co-Reasoning",
+    "path": "docs/papers/efc/Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence",
+    "url": "https://doi.org/10.6084/m9.figshare.31271707"
+  },
+  "10.6084/m9.figshare.31267297": {
+    "figshare_id": 31267297,
+    "title": "Triangulation Test for Thermodynamic-Lensing Coupling",
+    "path": "docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic",
+    "url": "https://doi.org/10.6084/m9.figshare.31267297"
+  },
+  "10.6084/m9.figshare.31244827": {
+    "figshare_id": 31244827,
+    "title": "PPN Recovery via Density Saturation",
+    "path": "docs/papers/efc/EFC_v1_3_PPN_Recovery_via_Density_Saturation",
+    "url": "https://doi.org/10.6084/m9.figshare.31244827"
+  },
+  "10.6084/m9.figshare.31243828": {
+    "figshare_id": 31243828,
+    "title": "Phenomenological constraints from BOSS DR12",
+    "path": "docs/papers/efc/Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12",
+    "url": "https://doi.org/10.6084/m9.figshare.31243828"
+  },
+  "10.6084/m9.figshare.31231522": {
+    "figshare_id": 31231522,
+    "title": "Cross-Survey Transfer from DESI DR2 to BOSS DR12",
+    "path": "docs/papers/efc/WP4_BOSS_validation",
+    "url": "https://doi.org/10.6084/m9.figshare.31231522"
+  },
+  "10.6084/m9.figshare.31230703": {
+    "figshare_id": 31230703,
+    "title": "Regime-Transition Fit to DESI DR2 BAO",
+    "path": "docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation",
+    "url": "https://doi.org/10.6084/m9.figshare.31230703"
+  },
+  "10.6084/m9.figshare.31224538": {
+    "figshare_id": 31224538,
+    "title": "EFC Phase 3 SPARC Validation",
+    "path": "docs/papers/efc/EFC_Phase_3__SPARC_Validation",
+    "url": "https://doi.org/10.6084/m9.figshare.31224538"
+  },
+  "10.6084/m9.figshare.31224466": {
+    "figshare_id": 31224466,
+    "title": "",
+    "path": "docs/papers/efc/EFC_Closure_Conjectures",
+    "url": "https://doi.org/10.6084/m9.figshare.31224466"
+  },
+  "10.6084/m9.figshare.31224247": {
+    "figshare_id": 31224247,
+    "title": "The Hubble Tension as Regime Mismatch",
+    "path": "docs/papers/efc/The_Hubble_Tension_as_Regime_Mismatch",
+    "url": "https://doi.org/10.6084/m9.figshare.31224247"
+  },
+  "10.6084/m9.figshare.31223908": {
+    "figshare_id": 31223908,
+    "title": "Unified Origin of RAR and Hubble Tension",
+    "path": "docs/papers/efc/Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification",
+    "url": "https://doi.org/10.6084/m9.figshare.31223908"
+  },
+  "10.6084/m9.figshare.31223668": {
+    "figshare_id": 31223668,
+    "title": "",
+    "path": "docs/papers/efc/EFC_Ontological_Foundations",
+    "url": "https://doi.org/10.6084/m9.figshare.31223668"
+  },
+  "10.6084/m9.figshare.31223650": {
+    "figshare_id": 31223650,
+    "title": "Regime-Based World Modeling",
+    "path": "docs/papers/efc/Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System",
+    "url": "https://doi.org/10.6084/m9.figshare.31223650"
+  },
+  "10.6084/m9.figshare.31223503": {
+    "figshare_id": 31223503,
+    "title": "Core Lock v1.0",
+    "path": "docs/papers/efc/Core-Lock",
+    "url": "https://doi.org/10.6084/m9.figshare.31223503"
+  },
+  "10.6084/m9.figshare.31222903": {
+    "figshare_id": 31222903,
+    "title": "EBE Core Principles v1.0",
+    "path": "docs/papers/efc/EBE-Core-Principles",
+    "url": "https://doi.org/10.6084/m9.figshare.31222903"
+  },
+  "10.6084/m9.figshare.31222900": {
+    "figshare_id": 31222900,
+    "title": "",
+    "path": "docs/papers/efc/The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics",
+    "url": "https://doi.org/10.6084/m9.figshare.31222900"
+  },
+  "10.6084/m9.figshare.31222696": {
+    "figshare_id": 31222696,
+    "title": "",
+    "path": "docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
+    "url": "https://doi.org/10.6084/m9.figshare.31222696"
+  },
+  "10.6084/m9.figshare.31215613": {
+    "figshare_id": 31215613,
+    "title": "Unified Analysis of BAO, SN Ia, and RSD",
+    "path": "docs/papers/efc/Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
+    "url": "https://doi.org/10.6084/m9.figshare.31215613"
+  },
+  "10.6084/m9.figshare.31215259": {
+    "figshare_id": 31215259,
+    "title": "WP3: First Empirical Slice Through R(k,S)",
+    "path": "docs/papers/efc/WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
+    "url": "https://doi.org/10.6084/m9.figshare.31215259"
+  },
+  "10.6084/m9.figshare.31211437": {
+    "figshare_id": 31211437,
+    "title": "R(k,S) as a Regime Response Surface",
+    "path": "docs/papers/efc/R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
+    "url": "https://doi.org/10.6084/m9.figshare.31211437"
+  },
+  "10.6084/m9.figshare.31190233": {
+    "figshare_id": 31190233,
+    "title": "",
+    "path": "docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves",
+    "url": "https://doi.org/10.6084/m9.figshare.31190233"
+  },
+  "10.6084/m9.figshare.31188193": {
+    "figshare_id": 31188193,
+    "title": "EFC Weak Lensing Phenomenology",
+    "path": "docs/papers/efc/efc-weak-lensing-phenomenology",
+    "url": "https://doi.org/10.6084/m9.figshare.31188193"
+  },
+  "10.6084/m9.figshare.31173850": {
+    "figshare_id": 31173850,
+    "title": "Structural Constraints from Cluster Merger Geometry",
+    "path": "docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry",
+    "url": "https://doi.org/10.6084/m9.figshare.31173850"
+  },
+  "10.6084/m9.figshare.31144030": {
+    "figshare_id": 31144030,
+    "title": "",
+    "path": "docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
+    "url": "https://doi.org/10.6084/m9.figshare.31144030"
+  },
+  "10.6084/m9.figshare.31140000": {
+    "figshare_id": 31140000,
+    "title": "",
+    "path": "docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
+    "url": "https://doi.org/10.6084/m9.figshare.31140000"
+  },
+  "10.6084/m9.figshare.31135597": {
+    "figshare_id": 31135597,
+    "title": "Foundations of EFC: Regime Architecture",
+    "path": "docs/papers/efc/Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism",
+    "url": "https://doi.org/10.6084/m9.figshare.31135597"
+  },
+  "10.6084/m9.figshare.31127380": {
+    "figshare_id": 31127380,
+    "title": "",
+    "path": "docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis",
+    "url": "https://doi.org/10.6084/m9.figshare.31127380"
+  },
+  "10.6084/m9.figshare.31122970": {
+    "figshare_id": 31122970,
+    "title": "Validity-Aware AI",
+    "path": "docs/papers/efc/validity-aware-ai",
+    "url": "https://doi.org/10.6084/m9.figshare.31122970"
+  },
+  "10.6084/m9.figshare.31112536": {
+    "figshare_id": 31112536,
+    "title": "L0–L3 Regime Architecture in EBE",
+    "path": "docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism",
+    "url": "https://doi.org/10.6084/m9.figshare.31112536"
+  },
+  "10.6084/m9.figshare.31096951": {
+    "figshare_id": 31096951,
+    "title": "EFC Regime Transition Framework",
+    "path": "docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology",
+    "url": "https://doi.org/10.6084/m9.figshare.31096951"
+  },
+  "10.6084/m9.figshare.31095466": {
+    "figshare_id": 31095466,
+    "title": "Systematic CMB Constraints",
+    "path": "docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results",
+    "url": "https://doi.org/10.6084/m9.figshare.31095466"
+  },
+  "10.6084/m9.figshare.31064929": {
+    "figshare_id": 31064929,
+    "title": "CMB Thermodynamic Interpretation",
+    "path": "docs/papers/efc/CMB-Thermodynamic-Interpretation",
+    "url": "https://doi.org/10.6084/m9.figshare.31064929"
+  },
+  "10.6084/m9.figshare.31061872": {
+    "figshare_id": 31061872,
+    "title": "Regime-Dependent Structure Formation",
+    "path": "docs/papers/efc/energy-flow-cosmology-and-regime-dependent-structure-formation",
+    "url": "https://doi.org/10.6084/m9.figshare.31061872"
+  },
+  "10.6084/m9.figshare.31061665": {
+    "figshare_id": 31061665,
+    "title": "Regime-Dependent Breakdown of ΛCDM",
+    "path": "docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time",
+    "url": "https://doi.org/10.6084/m9.figshare.31061665"
+  },
+  "10.6084/m9.figshare.31059964": {
+    "figshare_id": 31059964,
+    "title": "JWST COSMOS-Web Abundance Excess",
+    "path": "docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web",
+    "url": "https://doi.org/10.6084/m9.figshare.31059964"
+  },
+  "10.6084/m9.figshare.31047703": {
+    "figshare_id": 31047703,
+    "title": "EBE SPARC175 Complete Documentation",
+    "path": "docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation",
+    "url": "https://doi.org/10.6084/m9.figshare.31047703"
+  },
+  "10.6084/m9.figshare.31045126": {
+    "figshare_id": 31045126,
+    "title": "175 SPARC galaxies regime-dependent validity",
+    "path": "docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling",
+    "url": "https://doi.org/10.6084/m9.figshare.31045126"
+  },
+  "10.6084/m9.figshare.31042678": {
+    "figshare_id": 31042678,
+    "title": "Bridging Scales: EFC and FEP",
+    "path": "docs/papers/efc/EFC-Bridging-Scales-FEP",
+    "url": "https://doi.org/10.6084/m9.figshare.31042678"
+  },
+  "10.6084/m9.figshare.31026151": {
+    "figshare_id": 31026151,
+    "title": "H₀ and S8 Tensions: Inference Separation",
+    "path": "docs/papers/efc/EFC-H0-S8-Tensions",
+    "url": "https://doi.org/10.6084/m9.figshare.31026151"
+  },
+  "10.6084/m9.figshare.31007248": {
+    "figshare_id": 31007248,
+    "title": "Regime-Dependent Validity from SPARC",
+    "path": "docs/papers/efc/EFC-R-SPARC-Regime-Validity",
+    "url": "https://doi.org/10.6084/m9.figshare.31007248"
   },
   "10.6084/m9.figshare.30773684": {
-    "id": 30773684,
-    "url": "https://figshare.com/articles/preprint/Symbiosis_A_Human_AI_Co-Reflection_Architecture_Using_Graph_Vector_Memory_for_Long-Horizon_Thinking/30773684"
+    "figshare_id": 30773684,
+    "title": "Symbiosis Architecture",
+    "path": "docs/papers/efc/Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking",
+    "url": "https://doi.org/10.6084/m9.figshare.30773684"
   },
   "10.6084/m9.figshare.30656828": {
-    "id": 30656828,
-    "url": "https://figshare.com/articles/preprint/AUTH_Layer_Origin_Provenance_and_Structural_Signature_of_Energy-Flow_Cosmology/30656828"
-  },
-  "10.6084/m9.figshare.30656351": {
-    "id": 30656351,
-    "url": "https://figshare.com/articles/preprint/Symbiotic_Insight_Framework_SIF_A_Human_System_Methodology_for_High-Scale_Scientific_Reasoning/30656351"
+    "figshare_id": 30656828,
+    "title": "AUTH Layer",
+    "path": "docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology",
+    "url": "https://doi.org/10.6084/m9.figshare.30656828"
   },
   "10.6084/m9.figshare.30642497": {
-    "id": 30642497,
-    "url": "https://figshare.com/articles/preprint/Variable_Effective_Light_Speed_in_Entropic_Transition_States/30642497"
+    "figshare_id": 30642497,
+    "title": "Variable Effective Light Speed",
+    "path": "docs/papers/efc/variable-light-s0-s1",
+    "url": "https://doi.org/10.6084/m9.figshare.30642497"
   },
   "10.6084/m9.figshare.30636863": {
-    "id": 30636863,
-    "url": "https://figshare.com/articles/preprint/AI-Augmented_Scientific_Workflow_Framework/30636863"
+    "figshare_id": 30636863,
+    "title": "AI-Augmented Scientific Workflow",
+    "path": "docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework",
+    "url": "https://doi.org/10.6084/m9.figshare.30636863"
   },
   "10.6084/m9.figshare.30630500": {
-    "id": 30630500,
-    "url": "https://figshare.com/articles/preprint/Energy-Flow_Cosmology_Formal_Master_Specification_v1_0/30630500"
-  },
-  "10.6084/m9.figshare.30604004": {
-    "id": 30604004,
-    "url": "https://figshare.com/articles/dataset/_/30604004"
+    "figshare_id": 30630500,
+    "title": "Formal Master Specification v1.0",
+    "path": "docs/papers/efc/efc_formal_spec",
+    "url": "https://doi.org/10.6084/m9.figshare.30630500"
   },
   "10.6084/m9.figshare.30563738": {
-    "id": 30563738,
-    "url": "https://figshare.com/articles/preprint/Energy_Flow_Cosmology_v1_2_Foundational_Framework_and_Cross-Field_Continuity/30563738"
+    "figshare_id": 30563738,
+    "title": "EFC v1.2 Foundational Framework",
+    "path": "docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
+    "url": "https://doi.org/10.6084/m9.figshare.30563738"
   },
   "10.6084/m9.figshare.30530156": {
-    "id": 30530156,
-    "url": "https://figshare.com/articles/preprint/Applied_Energy-Flow_Cosmology_v2_2_Cross-Field_Integration_Summary_2025_/30530156"
+    "figshare_id": 30530156,
+    "title": "Applied EFC v2.2 Cross-Field Integration",
+    "path": "docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary",
+    "url": "https://doi.org/10.6084/m9.figshare.30530156"
+  },
+  "10.6084/m9.figshare.30478916": {
+    "figshare_id": 30478916,
+    "title": "EFC v2.1 Unified Thermodynamic Framework",
+    "path": "docs/papers/efc/EFC-v2.1-Complete-Edition",
+    "url": "https://doi.org/10.6084/m9.figshare.30478916"
+  },
+  "10.6084/m9.figshare.30468737": {
+    "figshare_id": 30468737,
+    "title": "Energy-Flow Interface / Grid-Higgs Framework",
+    "path": "docs/papers/efc/EFC-The-Energy-Flow-Interface",
+    "url": "https://doi.org/10.6084/m9.figshare.30468737"
+  },
+  "10.6084/m9.figshare.30455237": {
+    "figshare_id": 30455237,
+    "title": "EFC v2.1 Modular Synthesis",
+    "path": "docs/papers/efc/EFC-v2.1-Modular-Synthesis",
+    "url": "https://doi.org/10.6084/m9.figshare.30455237"
+  },
+  "10.6084/m9.figshare.30421807": {
+    "figshare_id": 30421807,
+    "title": "Field Equations for Entropy-Driven Spacetime",
+    "path": "docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime",
+    "url": "https://doi.org/10.6084/m9.figshare.30421807"
+  },
+  "10.6084/m9.figshare.30402427": {
+    "figshare_id": 30402427,
+    "title": "Thermodynamic Bridge Between GR and QFT",
+    "path": "docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT",
+    "url": "https://doi.org/10.6084/m9.figshare.30402427"
+  },
+  "10.6084/m9.figshare.30275947": {
+    "figshare_id": 30275947,
+    "title": "CEM-Cosmos: Consciousness Coupled to EFC",
+    "path": "docs/papers/efc/CEM-Consciousness-Ego-Mirror",
+    "url": "https://doi.org/10.6084/m9.figshare.30275947"
+  },
+  "10.6084/m9.figshare.28578263": {
+    "figshare_id": 28578263,
+    "title": "Emergence of Time from Energy Flow and Entropy",
+    "path": "docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy",
+    "url": "https://doi.org/10.6084/m9.figshare.28578263"
+  },
+  "10.6084/m9.figshare.28570088": {
+    "figshare_id": 28570088,
+    "title": "CMB as Thermodynamic Temperature Gradient",
+    "path": "docs/papers/efc/EFC-CMB-Thermodynamic-Gradient",
+    "url": "https://doi.org/10.6084/m9.figshare.28570088"
+  },
+  "10.6084/m9.figshare.28560935": {
+    "figshare_id": 28560935,
+    "title": "Paradigm Shift - Grid-Higgs Framework",
+    "path": "docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift",
+    "url": "https://doi.org/10.6084/m9.figshare.28560935"
+  },
+  "10.6084/m9.figshare.28559510": {
+    "figshare_id": 28559510,
+    "title": "Grid-Higgs Framework: Gravity, Dark Matter, Black Holes",
+    "path": "docs/papers/efc/EFC-Grid-Higgs-Framework",
+    "url": "https://doi.org/10.6084/m9.figshare.28559510"
+  },
+  "10.6084/m9.figshare.28559423": {
+    "figshare_id": 28559423,
+    "title": "The Grid Model: Entropy-Based Alternative",
+    "path": "docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics",
+    "url": "https://doi.org/10.6084/m9.figshare.28559423"
+  },
+  "10.6084/m9.figshare.28557281": {
+    "figshare_id": 28557281,
+    "title": "Interrelation of Energy Flow, Entropy, Structural Dynamics",
+    "path": "docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy",
+    "url": "https://doi.org/10.6084/m9.figshare.28557281"
+  },
+  "10.6084/m9.figshare.28114370": {
+    "figshare_id": 28114370,
+    "title": "A Deep Dive into the Halo Concept",
+    "path": "docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept",
+    "url": "https://doi.org/10.6084/m9.figshare.28114370"
+  },
+  "10.6084/m9.figshare.28113542": {
+    "figshare_id": 28113542,
+    "title": "Energy Flow as Fundamental Dynamic",
+    "path": "docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe",
+    "url": "https://doi.org/10.6084/m9.figshare.28113542"
+  },
+  "10.6084/m9.figshare.28112096": {
+    "figshare_id": 28112096,
+    "title": "Flow, Entropy, Spacetime Distortion in Clusters",
+    "path": "docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters",
+    "url": "https://doi.org/10.6084/m9.figshare.28112096"
+  },
+  "10.6084/m9.figshare.28112036": {
+    "figshare_id": 28112036,
+    "title": "Role of Light Speed in Cosmic Dynamics",
+    "path": "docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit",
+    "url": "https://doi.org/10.6084/m9.figshare.28112036"
+  },
+  "10.6084/m9.figshare.28111925": {
+    "figshare_id": 28111925,
+    "title": "Light-Speed as Regulator of Energy Flow",
+    "path": "docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe",
+    "url": "https://doi.org/10.6084/m9.figshare.28111925"
+  },
+  "10.6084/m9.figshare.28098386": {
+    "figshare_id": 28098386,
+    "title": "Time, Space, Consciousness thru Energy",
+    "path": "docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System",
+    "url": "https://doi.org/10.6084/m9.figshare.28098386"
+  },
+  "10.6084/m9.figshare.28098380": {
+    "figshare_id": 28098380,
+    "title": "What Happens at the Universe's Extremes",
+    "path": "docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes",
+    "url": "https://doi.org/10.6084/m9.figshare.28098380"
+  },
+  "10.6084/m9.figshare.28098371": {
+    "figshare_id": 28098371,
+    "title": "How Does Energy Flow Sustain Space-Time?",
+    "path": "docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime",
+    "url": "https://doi.org/10.6084/m9.figshare.28098371"
+  },
+  "10.6084/m9.figshare.28098365": {
+    "figshare_id": 28098365,
+    "title": "Observational Evidence for Energy Flow",
+    "path": "docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow",
+    "url": "https://doi.org/10.6084/m9.figshare.28098365"
+  },
+  "10.6084/m9.figshare.28098353": {
+    "figshare_id": 28098353,
+    "title": "Can Entropy Drive Cosmic Evolution?",
+    "path": "docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution",
+    "url": "https://doi.org/10.6084/m9.figshare.28098353"
+  },
+  "10.6084/m9.figshare.28098350": {
+    "figshare_id": 28098350,
+    "title": "The Universe as an Energy-Driven System",
+    "path": "docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters",
+    "url": "https://doi.org/10.6084/m9.figshare.28098350"
+  },
+  "10.6084/m9.figshare.28098347": {
+    "figshare_id": 28098347,
+    "title": "Is Consciousness Linked to Entropy",
+    "path": "docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy",
+    "url": "https://doi.org/10.6084/m9.figshare.28098347"
+  },
+  "10.6084/m9.figshare.28098344": {
+    "figshare_id": 28098344,
+    "title": "Balance Between Order and Chaos",
+    "path": "docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos",
+    "url": "https://doi.org/10.6084/m9.figshare.28098344"
+  },
+  "10.6084/m9.figshare.28098341": {
+    "figshare_id": 28098341,
+    "title": "Introduction to Energy Flow in Space-Time",
+    "path": "docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time",
+    "url": "https://doi.org/10.6084/m9.figshare.28098341"
+  },
+  "10.6084/m9.figshare.28098338": {
+    "figshare_id": 28098338,
+    "title": "How Does Balance Shape Universal Structures?",
+    "path": "docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures",
+    "url": "https://doi.org/10.6084/m9.figshare.28098338"
+  },
+  "10.6084/m9.figshare.28098332": {
+    "figshare_id": 28098332,
+    "title": "Technical Documentation: Energy Flow in Space-Time",
+    "path": "docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time",
+    "url": "https://doi.org/10.6084/m9.figshare.28098332"
+  },
+  "10.6084/m9.figshare.28098326": {
+    "figshare_id": 28098326,
+    "title": "How Does Entropy Interact with Energy Flow?",
+    "path": "docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy",
+    "url": "https://doi.org/10.6084/m9.figshare.28098326"
+  },
+  "10.6084/m9.figshare.28098320": {
+    "figshare_id": 28098320,
+    "title": "Introduction to Entropy in Cosmic Evolution",
+    "path": "docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution",
+    "url": "https://doi.org/10.6084/m9.figshare.28098320"
+  },
+  "10.6084/m9.figshare.28098317": {
+    "figshare_id": 28098317,
+    "title": "Can EnergyFlow Be Observed in Galactic Clusters?",
+    "path": "docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters",
+    "url": "https://doi.org/10.6084/m9.figshare.28098317"
+  },
+  "10.6084/m9.figshare.28098314": {
+    "figshare_id": 28098314,
+    "title": "Mathematical Framework for Energy Flow in Space-Time",
+    "path": "docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time",
+    "url": "https://doi.org/10.6084/m9.figshare.28098314"
+  },
+  "10.6084/m9.figshare.28098311": {
+    "figshare_id": 28098311,
+    "title": "Connection Between Energy Flow and the Now",
+    "path": "docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now",
+    "url": "https://doi.org/10.6084/m9.figshare.28098311"
+  },
+  "10.6084/m9.figshare.28098308": {
+    "figshare_id": 28098308,
+    "title": "Applications and Implications",
+    "path": "docs/papers/efc/EFC-Applications-and-Implications",
+    "url": "https://doi.org/10.6084/m9.figshare.28098308"
+  },
+  "10.6084/m9.figshare.28098305": {
+    "figshare_id": 28098305,
+    "title": "Why is Light-Speed a Cosmic Limit",
+    "path": "docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit",
+    "url": "https://doi.org/10.6084/m9.figshare.28098305"
+  },
+  "10.6084/m9.figshare.28098299": {
+    "figshare_id": 28098299,
+    "title": "Entropy's Role in Cosmic Evolution",
+    "path": "docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution",
+    "url": "https://doi.org/10.6084/m9.figshare.28098299"
   }
 }


### PR DESCRIPTION
Complete DOI→directory mapping from ORCID profile (0009-0002-4860-5095):
- 124 DOIs mapped to paper directories in docs/papers/efc/
- 61 index.json files updated with previously missing DOI fields
- doi-map.json upgraded from 10 to 124 entries (sorted newest-first)
- 4 DOIs remain unmapped (datasets/frameworks without paper dirs)

https://claude.ai/code/session_012Tf9r7G7HE7YmiFRr6yK2e