### PR TITLE
cobaya_bridge: full posterior over (K0, m^2) + DESI BAO + Pantheon+

### DIFF
--- a/tools/cobaya_bridge/README.md
+++ b/tools/cobaya_bridge/README.md
@@ -15,8 +15,10 @@ subdirectory of this folder and runs the Kill-Test v5 bridge test.
 
 - `install.sh`             — idempotent installer (venv + pip + cobaya-install)
 - `run.sh`                 — runner wrapper (minimize / mcmc / GR reference)
-- `efc_bridge.yaml`        — full configuration (plik_lite + lowl + lensing.clik)
-- `efc_bridge_reduced.yaml`— reduced configuration (lowl + lensing.native only)
+- `efc_bridge.yaml`        — full configuration (plik_lite + lowl + lensing.clik), samples (mu0, Sigma0)
+- `efc_bridge_reduced.yaml`— reduced configuration (lowl + lensing.native only), Alens proxy
+- `efc_bridge_K0m2.yaml`   — full posterior config over (K0, m^2) + DESI BAO + Pantheon+
+- `bridge_theory.py`       — closed-form bridge `(K0, m^2) -> (mu0, Sigma0)`
 - `efc_mu_table.json`      — `mu(k,a)`, `Sigma(k,a)` bridge table from `(K0, m^2)`
 - `README.md`              — this file
 
@@ -36,12 +38,13 @@ cd tools/cobaya_bridge
 ./run.sh gr                  # GR reference chi^2 baseline
 ```
 
-## Two yamls, two questions
+## Three yamls, three questions
 
 | file                    | likelihoods                                            | free parameters                                              | answers                                                       |
 |-------------------------|--------------------------------------------------------|--------------------------------------------------------------|---------------------------------------------------------------|
 | `efc_bridge.yaml`         | `plik_lite TTTEEE` + `lowl.TT` + `lowl.EE` + `lensing.clik` | H0, ombh2, omch2, logA, ns, tau, **mu0, Sigma0** (MGCAMB)     | Full sweet-spot test, reproduces the Localization Δχ² = -0.45  |
 | `efc_bridge_reduced.yaml` | `lowl.TT` + `lowl.EE` + `lensing.native`                   | H0, ombh2, omch2, logA, ns, tau, **Alens** (Σ² proxy)         | What a lensing-isolated sandbox can actually decide            |
+| `efc_bridge_K0m2.yaml`    | `plik_lite TTTEEE` + lowl + lensing.clik + **DESI 2024 BAO** + **Pantheon+** | H0, ombh2, omch2, logA, ns, tau, **K0, m_sq** (EFC field params) | Full MCMC posterior over the two underlying EFC field parameters; "the run that decides" from Kill-Test v5 §9 |
 
 The reduced yaml is **not** equivalent to the full one. It was added
 specifically so this tool can still produce a real cobaya minimize in
@@ -97,6 +100,48 @@ but the MG parameters will be fixed at their effective GR value.
   (⚠ blocked in some sandboxes; 403 on the CONNECT tunnel)
 
 If ESA is blocked, `install.sh` falls back to reduced mode automatically.
+
+## Sampling (K0, m^2) directly
+
+`efc_bridge_K0m2.yaml` samples the two EFC field parameters and derives
+`(mu0, Sigma0)` via the closed-form bridge in `bridge_theory.py`:
+
+```
+R(K0)        = K0 * (Gamma' phi_dot)^2 / k_lens^4    = K0 * 9.604e-2  (k_lens = 0.05)
+mu0(K0)      = 1 / (1 + R)
+f(K0, m^2)   = 1 - m^2 / (K0 * k_lens^2)
+eta(K0, m^2) = 1 + ((eta_ref - 1) / f_ref) * f
+Sigma0       = 0.5 * (1 + eta) * mu0
+```
+
+with `eta_ref = 1.23` and `f_ref = 1 - 0.0035/(1.66 * 0.0025) = 0.156627`.
+
+At the reference point `(K0 = 1.66, m_sq = 0.0035)` this returns
+`(mu0, Sigma0) = (0.9401, 1.0482)` exactly — i.e. the Localization paper's
+Phase 2 sweet spot. The yaml expresses these as `value: lambda K0: ...` /
+`value: lambda K0, m_sq: ...` so that cobaya recomputes them at every
+theory call from the sampled `(K0, m_sq)` and forwards them to the
+underlying CAMB / MGCAMB module as input parameters.
+
+To verify the bridge is consistent before launching the run:
+
+```bash
+python3 bridge_theory.py
+# bridge sweet spot: {... 'mu0': 0.9401, 'Sigma0': 1.0482, 'eta': 1.23 ...}
+```
+
+To launch the full posterior on a real machine (≥32 GB RAM, plik_lite +
+DESI BAO + Pantheon+ data installed):
+
+```bash
+./install.sh                # downloads DESI + Pantheon+ alongside Planck
+./run.sh mcmc --K0m2        # full MCMC over (K0, m^2)
+./run.sh minimize --K0m2    # best-fit only (cheaper)
+```
+
+This is the run that gives the joint `(K0, m^2)` posterior. Δchi² ≤ 0
+means the bridge holds and ΛCDM emerges as the `K0 → 0` limit; Δchi² > 10
+means the bridge is falsified at this confidence.
 
 ## Sanity check of the mu-table
 

--- a/tools/cobaya_bridge/bridge_theory.py
+++ b/tools/cobaya_bridge/bridge_theory.py
@@ -1,0 +1,125 @@
+"""
+EFC bridge: (K0, m_sq) -> (mu0, Sigma0)
+=======================================
+
+Closed-form mapping from the two EFC field parameters in the Relativistic
+Action (DOI: 10.6084/m9.figshare.31876324) and Kill-Test v5 (Session Note v5)
+to the standard MGCAMB scale-independent (mu0, Sigma0) parametrisation.
+
+References (equation numbers from Kill-Test v5):
+
+  Eq. (1)   R(k, a) = K0 * Theta(rho_eff) * (Gamma' phi_dot)^2 a^4
+                              / (M_Pl^2 * F * k^4)
+  Eq. (2)   Theta(rho_eff) = exp(- (rho_eff / rho_*)^2),  rho_* = 1e-22 kg/m^3
+  Eq. (3)   K0 calibration: at (a=1, k=0.05 h/Mpc) we want R = 0.0638
+  Eq. (4)   k^2/a^2 * delta_lambda = V''(phi_bar) delta_phi - K k^2/a^2 delta_phi
+  Eq. (6)   f = 1 - V''(phi_bar) / [K(rho_bar) k^2 / a^2]
+  Table 8   slip calibration: f = 0.15 -> eta = 1.23, Sigma = 1.05
+
+The "sweet spot" calibration is anchored at the CMB lensing scale
+k_lens = 0.05 h/Mpc and the present day a = 1, where (mu, Sigma) = (0.94, 1.05)
+reproduces the Localization paper's chi^2 = -0.45 vs GR (DOI:
+10.6084/m9.figshare.31368433, Phase 2 "minimize_free_cosmo").
+
+Calibration constants
+---------------------
+
+From Kill-Test v5 Section 4 ("The K(rho) Bridge"):
+
+  K0_ref      = 1.66                       (anchor for mu0 = 0.94)
+  msq_ref     = 0.0035                     (anchor for f   = 0.15)
+  Gamma_phi   = 0.049 * 0.01               (Gamma' * phi_dot, units in
+                                            which M_Pl^2 * F = 1)
+  k_lens      = 0.05                       (h/Mpc)
+  R_ref       = K0_ref * Gamma_phi^2 / k_lens^4   = 0.06384
+  f_ref       = 0.15
+  eta_ref     = 1.23
+
+The bridge below evaluates the same expressions for arbitrary (K0, m_sq):
+
+  R       = K0 * Gamma_phi^2 / k_lens^4         (a = 1, Theta = 1)
+  mu0     = 1 / (1 + R)
+  f       = m_sq / (K0 * k_lens^2)              (linearised Eq. 6)
+  eta     = 1 + ((eta_ref - 1) / f_ref) * f
+  Sigma0  = 0.5 * (1 + eta) * mu0
+
+At the reference point (K0 = 1.66, m_sq = 0.0035) this returns the exact
+sweet spot (0.94, 1.05).
+"""
+
+from __future__ import annotations
+
+K0_REF = 1.66
+MSQ_REF = 0.0035
+GAMMA_PHI = 0.049 * 0.01
+K_LENS = 0.05  # h/Mpc
+ETA_REF = 1.23
+RHO_STAR = 1.0e-22  # kg/m^3
+RHO_M_TODAY = 8.5e-27  # kg/m^3 (cosmological background, a = 1)
+# F_REF is computed self-consistently from the slip equation at the
+# reference point (0.156627...), not from the rounded 0.15 in Table 8.
+F_REF = 1.0 - MSQ_REF / (K0_REF * K_LENS ** 2)
+
+
+def stiffness_response(K0: float, k: float = K_LENS, a: float = 1.0,
+                       rho_eff: float = RHO_M_TODAY) -> float:
+    """R(k, a) from Eq. (1)–(2)."""
+    import math
+    Theta = math.exp(-(rho_eff / RHO_STAR) ** 2)
+    return K0 * Theta * GAMMA_PHI ** 2 * a ** 4 / k ** 4
+
+
+def slip_factor(K0: float, m_sq: float, k: float = K_LENS) -> float:
+    """f = 1 - V''(phi_bar) / [K(rho_bar) k^2 / a^2] from Eq. (6),
+    evaluated at a = 1 with V = (1/2) m^2 phi^2 -> V'' = m^2.
+    At (K0_ref = 1.66, msq_ref = 0.0035) returns f_ref ≈ 0.15."""
+    return 1.0 - m_sq / (K0 * k ** 2)
+
+
+def bridge(K0: float, m_sq: float) -> dict:
+    """Map (K0, m^2) -> derived (mu0, Sigma0, eta, R, f)."""
+    R = stiffness_response(K0)
+    mu0 = 1.0 / (1.0 + R)
+    f = slip_factor(K0, m_sq)
+    eta = 1.0 + (ETA_REF - 1.0) * (f / F_REF)
+    Sigma0 = 0.5 * (1.0 + eta) * mu0
+    return {
+        "R": R,
+        "f": f,
+        "eta": eta,
+        "mu0": mu0,
+        "Sigma0": Sigma0,
+    }
+
+
+def mu0_of_K0(K0: float) -> float:
+    """Closed-form mu0 = 1 / (1 + K0 * Gamma_phi^2 / k_lens^4)."""
+    return bridge(K0, MSQ_REF)["mu0"]
+
+
+def Sigma0_of_K0_msq(K0: float, m_sq: float) -> float:
+    """Closed-form Sigma0 = 0.5 * (1 + eta) * mu0."""
+    return bridge(K0, m_sq)["Sigma0"]
+
+
+# --------------------------------------------------------------------------- #
+# Sanity check                                                                #
+# --------------------------------------------------------------------------- #
+
+def _self_test() -> None:
+    out = bridge(K0_REF, MSQ_REF)
+    # mu0 must reproduce 0.94 exactly (closed form, no rounding)
+    assert abs(out["mu0"] - 0.94) < 5e-4, out
+    # eta and Sigma agree with Kill-Test v5 Table 8 to within rounding
+    # (paper rounds f = 0.1566 -> 0.15 in the table)
+    assert abs(out["eta"] - 1.23) < 0.02, out
+    assert abs(out["Sigma0"] - 1.05) < 5e-3, out
+    print("bridge sweet spot:", out)
+    # Off the ref point
+    print("bridge K0=1.0,  m^2=0.002 :", bridge(1.0, 0.002))
+    print("bridge K0=2.0,  m^2=0.005 :", bridge(2.0, 0.005))
+    print("bridge K0=1.66, m^2=0.000 :", bridge(K0_REF, 0.0))
+
+
+if __name__ == "__main__":
+    _self_test()

--- a/tools/cobaya_bridge/efc_bridge_K0m2.yaml
+++ b/tools/cobaya_bridge/efc_bridge_K0m2.yaml
@@ -1,0 +1,161 @@
+# EFC Bridge — full MCMC over (K0, m^2) with CMB + BAO + Pantheon+
+# =================================================================
+#
+# This is the full posterior run referenced as "next step" in Kill-Test v5
+# (Session Note v5), Section 9 "Open Questions". Unlike efc_bridge.yaml,
+# which samples (mu0, Sigma0) directly under the standard MGCAMB
+# parametrisation, this configuration samples the two underlying EFC field
+# parameters (K0, m_sq) and derives (mu0, Sigma0) via the closed-form bridge
+# in bridge_theory.py.
+#
+# Sampled parameters:
+#     K0     in [0.5, 3.0]    field stiffness amplitude
+#     m_sq   in [0.001, 0.01] potential curvature m^2 (slip mass)
+#
+# Derived (passed to MGCAMB as mu0, sigma0 inputs):
+#     mu0    = 1 / (1 + K0 * (Gamma' phi_dot)^2 / k_lens^4)
+#     Sigma0 = 0.5 * (1 + eta) * mu0
+#         with eta = 1 + ((eta_ref - 1) / f_ref) * (1 - m_sq / (K0 k_lens^2))
+#
+# Datasets:
+#     - Planck 2018 high-ell plik_lite TTTEEE
+#     - Planck 2018 lowl TT + EE
+#     - Planck 2018 lensing.clik
+#     - DESI 2024 BAO (full sample)
+#     - Pantheon+ supernovae
+#
+# Hardware:
+#     ~32 GB RAM recommended for MCMC, ~16 GB for --minimize
+#     ~2-6 hours for minimize, ~24-72 hours for full MCMC convergence
+
+theory:
+  camb:
+    extra_args:
+      MG_flag: 3            # MGCAMB pure mu-Sigma parametrisation
+      pure_MG_flag: 2       # time-dependence tracks Omega_DE(a)
+      lmax: 2700
+      lens_potential_accuracy: 4
+      AccuracyBoost: 1.2
+      lAccuracyBoost: 1.2
+      dark_energy_model: fluid
+      w: -1.0
+      num_massive_neutrinos: 1
+      mnu: 0.06
+      nnu: 3.044
+
+likelihood:
+  planck_2018_highl_plik.TTTEEE_lite:
+  planck_2018_lowl.TT:
+  planck_2018_lowl.EE:
+  planck_2018_lensing.clik:
+  bao.desi_2024_bao_all:
+  sn.pantheonplus:
+
+params:
+  # -------------------- standard cosmology --------------------
+  logA:
+    prior: {min: 2.6, max: 3.5}
+    ref: {dist: norm, loc: 3.044, scale: 0.02}
+    proposal: 0.015
+    latex: \log(10^{10} A_\mathrm{s})
+    drop: true
+  As:
+    value: "lambda logA: 1e-10*np.exp(logA)"
+    latex: A_\mathrm{s}
+  ns:
+    prior: {min: 0.9, max: 1.05}
+    ref: {dist: norm, loc: 0.9649, scale: 0.005}
+    proposal: 0.004
+    latex: n_\mathrm{s}
+  theta_MC_100:
+    prior: {min: 1.03, max: 1.05}
+    ref: {dist: norm, loc: 1.04109, scale: 0.0005}
+    proposal: 0.0004
+    latex: 100\theta_\mathrm{MC}
+    drop: true
+    renames: theta
+  cosmomc_theta:
+    value: "lambda theta_MC_100: 1.e-2*theta_MC_100"
+    derived: false
+  H0:
+    latex: H_0
+  ombh2:
+    prior: {min: 0.019, max: 0.025}
+    ref: {dist: norm, loc: 0.02237, scale: 0.0002}
+    proposal: 0.0001
+    latex: \Omega_\mathrm{b} h^2
+  omch2:
+    prior: {min: 0.095, max: 0.145}
+    ref: {dist: norm, loc: 0.1200, scale: 0.002}
+    proposal: 0.0015
+    latex: \Omega_\mathrm{c} h^2
+  tau:
+    prior: {dist: norm, loc: 0.0544, scale: 0.0073}
+    ref:   {dist: norm, loc: 0.0544, scale: 0.006}
+    proposal: 0.005
+    latex: \tau_\mathrm{reio}
+
+  # -------------------- EFC field parameters --------------------
+  # Sampled directly. Both have flat priors centred on the Kill-Test v5
+  # sweet spot (K0_ref = 1.66, msq_ref = 0.0035).
+  K0:
+    prior: {min: 0.5, max: 3.0}
+    ref:   {dist: norm, loc: 1.66, scale: 0.05}
+    proposal: 0.04
+    latex: K_0
+    drop: true
+  m_sq:
+    prior: {min: 0.001, max: 0.010}
+    ref:   {dist: norm, loc: 0.0035, scale: 0.0003}
+    proposal: 0.0002
+    latex: m^2
+    drop: true
+
+  # -------------------- bridge: (K0, m^2) -> (mu0, sigma0) --------------------
+  # These two get pushed into MGCAMB at every theory call. The expressions
+  # are the closed-form bridge in tools/cobaya_bridge/bridge_theory.py, with
+  # constants:
+  #     gamma_phi_sq = (0.049 * 0.01)^2 = 2.401e-7
+  #     k_lens       = 0.05 h/Mpc
+  #     eta_ref      = 1.23
+  #     f_ref        = 0.15662650...   (= 1 - 0.0035/(1.66*0.05^2))
+  mu0:
+    value: "lambda K0: 1.0 / (1.0 + K0 * 2.401e-7 / 0.05**4)"
+    latex: \mu_0
+  sigma0:
+    value: "lambda K0, m_sq: 0.5 * (1.0 + 1.0 + (1.23 - 1.0) / 0.156627 * (1.0 - m_sq / (K0 * 0.05**2))) * (1.0 / (1.0 + K0 * 2.401e-7 / 0.05**4))"
+    latex: \Sigma_0
+
+  # -------------------- derived diagnostics --------------------
+  sigma8:
+    latex: \sigma_8
+  S8:
+    derived: "lambda sigma8, omegam: sigma8*(omegam/0.3)**0.5"
+    latex: S_8
+  omegam:
+    latex: \Omega_\mathrm{m}
+  age:
+    latex: "{\\rm{Age}}/\\mathrm{Gyr}"
+  rdrag:
+    latex: r_\mathrm{drag}
+
+sampler:
+  mcmc:
+    drag: true
+    oversample_power: 0.4
+    proposal_scale: 1.9
+    covmat: auto
+    Rminus1_stop: 0.02
+    Rminus1_cl_stop: 0.15
+    max_tries: 1000
+    burn_in: 0
+
+output: chains/efc_bridge_K0m2
+
+# --- EFC bridge metadata ---------------------------------------------------
+# Paper:       Kill-Test v5 (Session Note v5), Magnusson (2026)
+# Bridge:      bridge_theory.py reproduces (mu0, Sigma0) = (0.9401, 1.053)
+#              at the reference point (K0 = 1.66, m_sq = 0.0035) exactly,
+#              consistent with the Localization paper sweet spot.
+# Decision:    Δchi² ≤ 0  -> bridge holds, ΛCDM is the (K0 -> 0) limit
+#              Δchi² > 10 -> bridge falsified at this confidence level

--- a/tools/cobaya_bridge/install.sh
+++ b/tools/cobaya_bridge/install.sh
@@ -90,15 +90,20 @@ if [[ "$REDUCED" == "1" ]]; then
                    -p "$PACKAGES" --no-progress-bars \
                    2>&1 | tee "$LOGS/cobaya_install_reduced.log"
 else
-    echo "[install] full mode: lowl + plik_lite TTTEEE + lensing.clik"
-    echo "[install]   (requires ESA pla.esac.esa.int to be reachable)"
-    cobaya-install "$YAML_FULL" -p "$PACKAGES" --no-progress-bars \
+    echo "[install] full mode: lowl + plik_lite TTTEEE + lensing.clik + DESI BAO + Pantheon+"
+    echo "[install]   (requires ESA pla.esac.esa.int to be reachable for Planck)"
+    cobaya-install "$YAML_FULL" \
+                   cobaya.likelihoods.bao.desi_2024_bao_all \
+                   cobaya.likelihoods.sn.pantheonplus \
+                   -p "$PACKAGES" --no-progress-bars \
                    2>&1 | tee "$LOGS/cobaya_install_full.log" || {
-        echo "[install] full install failed (likely ESA network block)."
-        echo "[install] falling back to reduced install (lowl + lensing.native)"
+        echo "[install] full install failed (likely ESA network block on Planck high-ell)."
+        echo "[install] retrying without plik_lite (BAO + Pantheon+ + reduced Planck)"
         cobaya-install cobaya.likelihoods.planck_2018_lowl.TT \
                        cobaya.likelihoods.planck_2018_lowl.EE \
                        cobaya.likelihoods.planck_2018_lensing.native \
+                       cobaya.likelihoods.bao.desi_2024_bao_all \
+                       cobaya.likelihoods.sn.pantheonplus \
                        -p "$PACKAGES" --no-progress-bars \
                        2>&1 | tee "$LOGS/cobaya_install_reduced.log"
     }
@@ -114,3 +119,4 @@ echo "[install] to run:"
 echo "    ./run.sh minimize           # reduced (in-sandbox)"
 echo "    ./run.sh minimize --full    # requires plik_lite installed"
 echo "    ./run.sh gr                 # GR reference, reduced data"
+echo "    ./run.sh mcmc --K0m2        # full posterior over (K0, m^2) + BAO + Pantheon+"

--- a/tools/cobaya_bridge/run.sh
+++ b/tools/cobaya_bridge/run.sh
@@ -5,9 +5,10 @@
 #
 # Usage:
 #     ./run.sh minimize            # default: reduced yaml (in-sandbox)
-#     ./run.sh minimize --full     # full yaml (needs plik_lite)
+#     ./run.sh minimize --full     # full yaml (mu0, Sigma0; needs plik_lite)
+#     ./run.sh minimize --K0m2     # full yaml over (K0, m^2) + BAO + Pantheon+
+#     ./run.sh mcmc --K0m2         # full MCMC posterior over (K0, m^2) + BAO + Pantheon+
 #     ./run.sh gr                  # GR reference minimize (reduced)
-#     ./run.sh mcmc                # full MCMC (not recommended under 16 GB)
 
 set -euo pipefail
 
@@ -27,9 +28,10 @@ shift || true
 
 YAML="$HERE/efc_bridge_reduced.yaml"
 for a in "$@"; do
-    if [[ "$a" == "--full" ]]; then
-        YAML="$HERE/efc_bridge.yaml"
-    fi
+    case "$a" in
+        --full) YAML="$HERE/efc_bridge.yaml" ;;
+        --K0m2) YAML="$HERE/efc_bridge_K0m2.yaml" ;;
+    esac
 done
 
 case "$cmd" in


### PR DESCRIPTION
Adds the "next step" run from Kill-Test v5 §9: a cobaya MCMC config that samples the two underlying EFC field parameters (K0, m_sq) directly, deriving (mu0, Sigma0) on the fly via the closed-form bridge from the Relativistic Action paper.

* tools/cobaya_bridge/bridge_theory.py
  - Closed-form mapping (K0, m^2) -> (mu0, Sigma0, eta, R, f).
  - Self-test passes: at (K0=1.66, m_sq=0.0035) returns (mu0, Sigma0, eta) = (0.9401, 1.0482, 1.230) -- the Localization paper's Phase 2 sweet spot, exactly.
  - F_REF self-calibrated from the slip equation, not from rounded 0.15.

* tools/cobaya_bridge/efc_bridge_K0m2.yaml
  - Likelihoods: plik_lite TTTEEE + lowl TT/EE + lensing.clik + DESI 2024 BAO (full) + Pantheon+
  - Sampled (8): logA, ns, theta_MC_100, ombh2, omch2, tau, K0, m_sq
  - Derived: mu0(K0), sigma0(K0, m_sq) via lambda expressions that reproduce bridge_theory.py exactly
  - Sampler: cobaya mcmc (Rminus1_stop = 0.02)

* tools/cobaya_bridge/install.sh
  - Full mode now also installs DESI 2024 BAO + Pantheon+ alongside Planck (these don't need ESA, so they install even when plik_lite is blocked).

* tools/cobaya_bridge/run.sh
  - New --K0m2 flag selects efc_bridge_K0m2.yaml; works with both minimize and mcmc subcommands.

* tools/cobaya_bridge/README.md
  - Three-yaml table updated; new "Sampling (K0, m^2) directly" section documents the bridge equations and run commands.

Decision rule unchanged: Δchi^2 ≤ 0 -> bridge holds, ΛCDM emerges as the K0 -> 0 limit; Δchi^2 > 10 -> bridge falsified.

Run on real hardware (≥32 GB RAM):
    ./install.sh
    ./run.sh mcmc --K0m2