### PR TITLE
Repo-wide AI-optimization pass: fix C4 drift, index 132 papers, refre…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ orcid: 0009-0002-4860-5095
 repository: github.com/supertedai/EFC
 license: CC-BY-4.0
 core_principle: "Energy flows along entropy gradients"
-validation_ledger: v4.2 (internal) / v3.11 (public HTML)
-ai_packages: 130 (100% coverage)
+validation_ledger: v4.4 (internal) / v3.13 (public HTML)
+ai_packages: 132 (100% coverage)
 maintenance: scripts/maintenance/ (auto-run by SessionStart hook + CI)
 ```
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,8 @@ keywords:
   - bridge equations
   - AI alignment
 license: CC-BY-4.0
-version: "3.7"
-date-released: "2026-04-06"
+version: "3.13"
+date-released: "2026-04-08"
 identifiers:
   - type: doi
     value: "10.6084/m9.figshare.30656828"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![DOI](https://img.shields.io/badge/DOI-10.6084%2Fm9.figshare.30656828-blue)](https://doi.org/10.6084/m9.figshare.30656828)
 [![ORCID](https://img.shields.io/badge/ORCID-0009--0002--4860--5095-green)](https://orcid.org/0009-0002-4860-5095)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
-[![Validation Ledger](https://img.shields.io/badge/Validation_Ledger-v3.10-orange)](./docs/public/EFC_Validation_Ledger.html)
-[![AI Packages](https://img.shields.io/badge/AI_Packages-129-brightgreen)](#ai-friendly-paper-packages)
+[![Validation Ledger](https://img.shields.io/badge/Validation_Ledger-v3.13-orange)](./docs/public/EFC_Validation_Ledger.html)
+[![AI Packages](https://img.shields.io/badge/AI_Packages-132-brightgreen)](#ai-friendly-paper-packages)
 
 > **NEW (April 2026)**: [WP4 BOSS Transfer Validation](https://doi.org/10.6084/m9.figshare.31954125) — Cross-survey parameter transfer: DESI DR2 parameters (z_L1L2 = 1.01, α_L2 = 0.045) frozen and applied to BOSS DR12 give **Δχ² = −7.77 with k_eff = 0**. Covariance diagnostics confirm gain in the most constrained eigenmodes (71%). Post-hoc validation, complements pre-registered P3.
 
@@ -26,9 +26,9 @@
 | **Repository** | [github.com/supertedai/EFC](https://github.com/supertedai/EFC) |
 | **Theory Site** | [energyflow-cosmology.com](https://energyflow-cosmology.com/) |
 | **AI Navigation** | [`llms.txt`](./llms.txt) / [`AGENTS.md`](./AGENTS.md) |
-| **Validation Ledger** | [`EFC_Validation_Ledger.html`](./docs/public/EFC_Validation_Ledger.html) (v3.10) |
-| **Papers** | 129 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
-| **AI Packages** | 129 with executable Python + structured data (100% coverage) |
+| **Validation Ledger** | [`EFC_Validation_Ledger.html`](./docs/public/EFC_Validation_Ledger.html) (v3.13) |
+| **Papers** | 132 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
+| **AI Packages** | 132 with executable Python + structured data (100% coverage) |
 | **Consolidation** | [ΛCDM as Special Case of EFC](https://doi.org/10.6084/m9.figshare.31943361) — single reference for full programme |
 
 ---
@@ -236,13 +236,13 @@ Pre-registered conditions that would falsify EFC sectors. F7 (η=1) formally **P
 | Core Lock (Consistency Enforcement) | [31223503](https://doi.org/10.6084/m9.figshare.31223503) |
 | ISW Consistency Audit | [31329082](https://doi.org/10.6084/m9.figshare.31329082) |
 
-> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 129 papers, all with full 10-file AI-friendly packages (100% coverage).
+> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 132 papers, all with full 10-file AI-friendly packages (100% coverage).
 
 ---
 
 ## AI-Friendly Paper Packages
 
-All 129 papers have full AI-friendly packages with executable Python implementations (100% coverage as of April 2026):
+All 132 papers have full AI-friendly packages with executable Python implementations (100% coverage as of April 2026):
 
 | Package | Module | Key Classes |
 |---------|--------|-------------|
@@ -286,7 +286,7 @@ EFC/
 ├── theory/             # Formal mathematics
 │   └── formal/         # S, D, R, H, C0 models (LaTeX)
 ├── docs/
-│   ├── papers/efc/     # 129 papers with 10-file AI-friendly packages (100%)
+│   ├── papers/efc/     # 132 papers with 10-file AI-friendly packages (100%)
 │   ├── public/         # Validation Ledger (v3.10), Master Spec, figures
 │   ├── figures/        # Shared figures
 │   ├── notebooks/      # Jupyter notebooks

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,10 +4,10 @@
   "identifier": "EFC",
   "name": "Energy-Flow Cosmology",
   "description": "A unified thermodynamic framework for cosmology, implementing entropy-gradient-driven structure formation, galactic dynamics, and consciousness models.",
-  "version": "3.7.0",
+  "version": "3.13.0",
   "dateCreated": "2024-01-01",
-  "dateModified": "2026-04-06",
-  "datePublished": "2026-04-06",
+  "dateModified": "2026-04-08",
+  "datePublished": "2026-04-08",
 
   "author": [
     {

--- a/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/ai_manifest.json
+++ b/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1994
+      "bytes": 1803
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 359
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 639
-    },
-    {
-      "path": "src/__pycache__/four_channel_test.cpython-311.pyc",
-      "bytes": 18949
-    },
-    {
       "path": "src/four_channel_test.py",
       "bytes": 12585
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology/ai_manifest.json
+++ b/docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2121
+      "bytes": 2027
     },
     {
       "path": "auth-layer-origin-provenance-and-structural-signature-of-energy-flow-cosmology.jsonld",
@@ -69,14 +69,10 @@
       "bytes": 531
     },
     {
-      "path": "src/__pycache__/auth_layer.cpython-311.pyc",
-      "bytes": 16158
-    },
-    {
       "path": "src/auth_layer.py",
       "bytes": 9808
     }
   ],
-  "n_files": 15,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/ai_manifest.json
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2301
+      "bytes": 2100
     },
     {
       "path": "besr3_path_a_alpha_fit.py",
@@ -85,18 +85,10 @@
       "bytes": 930
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1121
-    },
-    {
-      "path": "src/__pycache__/entropy_structure_coupling.cpython-311.pyc",
-      "bytes": 21317
-    },
-    {
       "path": "src/entropy_structure_coupling.py",
       "bytes": 16565
     }
   ],
-  "n_files": 20,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes/ai_manifest.json
+++ b/docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2330
+      "bytes": 2140
     },
     {
       "path": "citations.bib",
@@ -73,18 +73,10 @@
       "bytes": 616
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 868
-    },
-    {
-      "path": "src/__pycache__/lensing_response.cpython-311.pyc",
-      "bytes": 18107
-    },
-    {
       "path": "src/lensing_response.py",
       "bytes": 12676
     }
   ],
-  "n_files": 17,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/CEM-Consciousness-Ego-Mirror/ai_manifest.json
+++ b/docs/papers/efc/CEM-Consciousness-Ego-Mirror/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1577
+      "bytes": 1484
     },
     {
       "path": "cem-consciousness-ego-mirror.jsonld",
@@ -65,14 +65,10 @@
       "bytes": 432
     },
     {
-      "path": "src/__pycache__/cem_model.cpython-311.pyc",
-      "bytes": 10096
-    },
-    {
       "path": "src/cem_model.py",
       "bytes": 6909
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/CMB-Thermodynamic-Interpretation/ai_manifest.json
+++ b/docs/papers/efc/CMB-Thermodynamic-Interpretation/ai_manifest.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2790
+      "bytes": 2598
     },
     {
       "path": "citations.bib",
@@ -105,18 +105,10 @@
       "bytes": 1055
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1286
-    },
-    {
-      "path": "src/__pycache__/cmb_thermodynamic.cpython-311.pyc",
-      "bytes": 15767
-    },
-    {
       "path": "src/cmb_thermodynamic.py",
       "bytes": 12271
     }
   ],
-  "n_files": 25,
+  "n_files": 23,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling/ai_manifest.json
+++ b/docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling/ai_manifest.json
@@ -83,7 +83,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 6029
+      "bytes": 5847
     },
     {
       "path": "citations.bib",
@@ -266,18 +266,10 @@
       "bytes": 702
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 983
-    },
-    {
-      "path": "src/__pycache__/sparc175.cpython-311.pyc",
-      "bytes": 14729
-    },
-    {
       "path": "src/sparc175.py",
       "bytes": 9684
     }
   ],
-  "n_files": 64,
+  "n_files": 62,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge/ai_manifest.json
+++ b/docs/papers/efc/Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1756
+      "bytes": 1656
     },
     {
       "path": "bridge_equations.jsonld",
@@ -65,14 +65,10 @@
       "bytes": 477
     },
     {
-      "path": "src/__pycache__/bridge_equations.cpython-311.pyc",
-      "bytes": 13504
-    },
-    {
       "path": "src/bridge_equations.py",
       "bytes": 9536
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test/ai_manifest.json
+++ b/docs/papers/efc/Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2144
+      "bytes": 1952
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 1182
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1455
-    },
-    {
-      "path": "src/__pycache__/regime_transition.cpython-311.pyc",
-      "bytes": 24430
-    },
-    {
       "path": "src/regime_transition.py",
       "bytes": 16618
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Core-Lock/ai_manifest.json
+++ b/docs/papers/efc/Core-Lock/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2638
+      "bytes": 2055
     },
     {
       "path": "citations.bib",
@@ -89,30 +89,6 @@
       "bytes": 853
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1083
-    },
-    {
-      "path": "src/__pycache__/beta_constraint.cpython-311.pyc",
-      "bytes": 7026
-    },
-    {
-      "path": "src/__pycache__/grid_state_function.cpython-311.pyc",
-      "bytes": 8320
-    },
-    {
-      "path": "src/__pycache__/information_length.cpython-311.pyc",
-      "bytes": 6961
-    },
-    {
-      "path": "src/__pycache__/projection_laws.cpython-311.pyc",
-      "bytes": 8257
-    },
-    {
-      "path": "src/__pycache__/simulation.cpython-311.pyc",
-      "bytes": 9560
-    },
-    {
       "path": "src/beta_constraint.py",
       "bytes": 4741
     },
@@ -133,6 +109,6 @@
       "bytes": 6512
     }
   ],
-  "n_files": 29,
+  "n_files": 23,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity/ai_manifest.json
+++ b/docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity/ai_manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2537
+      "bytes": 2351
     },
     {
       "path": "citations.bib",
@@ -89,14 +89,6 @@
       "bytes": 488
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 747
-    },
-    {
-      "path": "src/__pycache__/geff_coupling.cpython-311.pyc",
-      "bytes": 4340
-    },
-    {
       "path": "src/geff_coupling.py",
       "bytes": 2983
     },
@@ -109,6 +101,6 @@
       "bytes": 2071
     }
   ],
-  "n_files": 23,
+  "n_files": 21,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints/ai_manifest.json
+++ b/docs/papers/efc/Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2174
+      "bytes": 1987
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 557
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 780
-    },
-    {
-      "path": "src/__pycache__/covariant_eft.cpython-311.pyc",
-      "bytes": 20695
-    },
-    {
       "path": "src/covariant_eft.py",
       "bytes": 13291
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Density_of_States_of_Gravitationally/ai_manifest.json
+++ b/docs/papers/efc/Density_of_States_of_Gravitationally/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1743
+      "bytes": 1552
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 603
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 801
-    },
-    {
-      "path": "src/__pycache__/density_of_states.cpython-311.pyc",
-      "bytes": 19477
-    },
-    {
       "path": "src/density_of_states.py",
       "bytes": 13818
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Derivation_of_the_Entropy_Production/ai_manifest.json
+++ b/docs/papers/efc/Derivation_of_the_Entropy_Production/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1748
+      "bytes": 1556
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 586
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 790
-    },
-    {
-      "path": "src/__pycache__/entropy_production.cpython-311.pyc",
-      "bytes": 18630
-    },
-    {
       "path": "src/entropy_production.py",
       "bytes": 12652
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Directional_Lensing_Residuals/ai_manifest.json
+++ b/docs/papers/efc/Directional_Lensing_Residuals/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1888
+      "bytes": 1695
     },
     {
       "path": "citations.bib",
@@ -73,18 +73,10 @@
       "bytes": 710
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 886
-    },
-    {
-      "path": "src/__pycache__/directional_lensing.cpython-311.pyc",
-      "bytes": 20216
-    },
-    {
       "path": "src/directional_lensing.py",
       "bytes": 14640
     }
   ],
-  "n_files": 17,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/ai_manifest.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2239
+      "bytes": 2050
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 438
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 731
-    },
-    {
-      "path": "src/__pycache__/grc_double_slit.cpython-311.pyc",
-      "bytes": 14621
-    },
-    {
       "path": "src/grc_double_slit.py",
       "bytes": 9313
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EBE-Core-Principles/ai_manifest.json
+++ b/docs/papers/efc/EBE-Core-Principles/ai_manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2459
+      "bytes": 1998
     },
     {
       "path": "citations.bib",
@@ -90,26 +90,6 @@
       "bytes": 674
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 953
-    },
-    {
-      "path": "src/__pycache__/ebe_classifier.cpython-311.pyc",
-      "bytes": 7384
-    },
-    {
-      "path": "src/__pycache__/l_axis.cpython-311.pyc",
-      "bytes": 5901
-    },
-    {
-      "path": "src/__pycache__/regime_gating.cpython-311.pyc",
-      "bytes": 8785
-    },
-    {
-      "path": "src/__pycache__/s_axis.cpython-311.pyc",
-      "bytes": 5760
-    },
-    {
       "path": "src/ebe_classifier.py",
       "bytes": 5816
     },
@@ -126,6 +106,6 @@
       "bytes": 4238
     }
   ],
-  "n_files": 26,
+  "n_files": 21,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept/ai_manifest.json
+++ b/docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1737
+      "bytes": 1552
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 308
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 587
-    },
-    {
-      "path": "src/__pycache__/halo_concept.cpython-311.pyc",
-      "bytes": 7845
-    },
-    {
       "path": "src/halo_concept.py",
       "bytes": 4449
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework/ai_manifest.json
+++ b/docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1821
+      "bytes": 1629
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 372
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 667
-    },
-    {
-      "path": "src/__pycache__/workflow_framework.cpython-311.pyc",
-      "bytes": 11488
-    },
-    {
       "path": "src/workflow_framework.py",
       "bytes": 6212
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Applications-and-Implications/ai_manifest.json
+++ b/docs/papers/efc/EFC-Applications-and-Implications/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1691
+      "bytes": 1506
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 193
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 430
-    },
-    {
-      "path": "src/__pycache__/applications.cpython-311.pyc",
-      "bytes": 6905
-    },
-    {
       "path": "src/applications.py",
       "bytes": 4723
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Bridging-Scales-FEP/ai_manifest.json
+++ b/docs/papers/efc/EFC-Bridging-Scales-FEP/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1614
+      "bytes": 1426
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 229
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 441
-    },
-    {
-      "path": "src/__pycache__/bridging_scales.cpython-311.pyc",
-      "bytes": 6813
-    },
-    {
       "path": "src/bridging_scales.py",
       "bytes": 3847
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-CMB-Thermodynamic-Gradient/ai_manifest.json
+++ b/docs/papers/efc/EFC-CMB-Thermodynamic-Gradient/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1687
+      "bytes": 1502
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 218
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 444
-    },
-    {
-      "path": "src/__pycache__/cmb_gradient.cpython-311.pyc",
-      "bytes": 6467
-    },
-    {
       "path": "src/cmb_gradient.py",
       "bytes": 4031
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1998
+      "bytes": 1901
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 663
     },
     {
-      "path": "src/__pycache__/efc_cognition.cpython-311.pyc",
-      "bytes": 14277
-    },
-    {
       "path": "src/efc_cognition.py",
       "bytes": 8257
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/ai_manifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2062
+      "bytes": 1870
     },
     {
       "path": "citations.bib",
@@ -88,18 +88,10 @@
       "bytes": 1050
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1239
-    },
-    {
-      "path": "src/__pycache__/cognitive_entropy.cpython-311.pyc",
-      "bytes": 16242
-    },
-    {
       "path": "src/cognitive_entropy.py",
       "bytes": 11106
     }
   ],
-  "n_files": 20,
+  "n_files": 18,
   "n_pdfs": 0
 }

--- a/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1782
+      "bytes": 1589
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 692
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 897
-    },
-    {
-      "path": "src/__pycache__/consciousness_field.cpython-311.pyc",
-      "bytes": 13916
-    },
-    {
       "path": "src/consciousness_field.py",
       "bytes": 7503
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters/ai_manifest.json
+++ b/docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1878
+      "bytes": 1688
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 217
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 464
-    },
-    {
-      "path": "src/__pycache__/galactic_clusters.cpython-311.pyc",
-      "bytes": 6652
-    },
-    {
       "path": "src/galactic_clusters.py",
       "bytes": 4093
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution/ai_manifest.json
+++ b/docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1742
+      "bytes": 1553
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 196
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 428
-    },
-    {
-      "path": "src/__pycache__/cosmic_evolution.cpython-311.pyc",
-      "bytes": 6544
-    },
-    {
       "path": "src/cosmic_evolution.py",
       "bytes": 3814
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos/ai_manifest.json
+++ b/docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1778
+      "bytes": 1590
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 200
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 440
-    },
-    {
-      "path": "src/__pycache__/dynamic_balance.cpython-311.pyc",
-      "bytes": 7011
-    },
-    {
       "path": "src/dynamic_balance.py",
       "bytes": 4016
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe/ai_manifest.json
+++ b/docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1913
+      "bytes": 1721
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 220
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 465
-    },
-    {
-      "path": "src/__pycache__/fundamental_dynamic.cpython-311.pyc",
-      "bytes": 7403
-    },
-    {
       "path": "src/fundamental_dynamic.py",
       "bytes": 4515
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime/ai_manifest.json
+++ b/docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1820
+      "bytes": 1632
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 230
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 461
-    },
-    {
-      "path": "src/__pycache__/field_equations.cpython-311.pyc",
-      "bytes": 9632
-    },
-    {
       "path": "src/field_equations.py",
       "bytes": 5134
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters/ai_manifest.json
+++ b/docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1917
+      "bytes": 1816
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 548
     },
     {
-      "path": "src/__pycache__/cluster_distortion.cpython-311.pyc",
-      "bytes": 8880
-    },
-    {
       "path": "src/cluster_distortion.py",
       "bytes": 5630
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Grid-Higgs-Framework/ai_manifest.json
+++ b/docs/papers/efc/EFC-Grid-Higgs-Framework/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1553
+      "bytes": 1460
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 398
     },
     {
-      "path": "src/__pycache__/grid_higgs.cpython-311.pyc",
-      "bytes": 6452
-    },
-    {
       "path": "src/grid_higgs.py",
       "bytes": 4063
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift/ai_manifest.json
+++ b/docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1606
+      "bytes": 1509
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 437
     },
     {
-      "path": "src/__pycache__/paradigm_shift.cpython-311.pyc",
-      "bytes": 7050
-    },
-    {
       "path": "src/paradigm_shift.py",
       "bytes": 4394
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics/ai_manifest.json
+++ b/docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1638
+      "bytes": 1538
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 428
     },
     {
-      "path": "src/__pycache__/entropic_dynamics.cpython-311.pyc",
-      "bytes": 7159
-    },
-    {
       "path": "src/entropic_dynamics.py",
       "bytes": 4354
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-H0-S8-Tensions/ai_manifest.json
+++ b/docs/papers/efc/EFC-H0-S8-Tensions/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1599
+      "bytes": 1501
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 546
     },
     {
-      "path": "src/__pycache__/h0_s8_tensions.cpython-311.pyc",
-      "bytes": 10198
-    },
-    {
       "path": "src/h0_s8_tensions.py",
       "bytes": 6605
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures/ai_manifest.json
+++ b/docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1745
+      "bytes": 1644
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 513
     },
     {
-      "path": "src/__pycache__/balance_structures.cpython-311.pyc",
-      "bytes": 7781
-    },
-    {
       "path": "src/balance_structures.py",
       "bytes": 5289
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime/ai_manifest.json
+++ b/docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1659
+      "bytes": 1559
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 468
     },
     {
-      "path": "src/__pycache__/spacetime_sustain.cpython-311.pyc",
-      "bytes": 8590
-    },
-    {
       "path": "src/spacetime_sustain.py",
       "bytes": 5525
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1729
+      "bytes": 1618
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 509
     },
     {
-      "path": "src/__pycache__/energy_entropy_interrelation.cpython-311.pyc",
-      "bytes": 9517
-    },
-    {
       "path": "src/energy_entropy_interrelation.py",
       "bytes": 6118
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System/ai_manifest.json
+++ b/docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1761
+      "bytes": 1657
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 591
     },
     {
-      "path": "src/__pycache__/energy_driven_system.cpython-311.pyc",
-      "bytes": 11800
-    },
-    {
       "path": "src/energy_driven_system.py",
       "bytes": 8114
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1656
+      "bytes": 1560
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 361
     },
     {
-      "path": "src/__pycache__/time_entropy.cpython-311.pyc",
-      "bytes": 10529
-    },
-    {
       "path": "src/time_entropy.py",
       "bytes": 6516
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time/ai_manifest.json
+++ b/docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1747
+      "bytes": 1643
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 484
     },
     {
-      "path": "src/__pycache__/energy_flow_spacetime.cpython-311.pyc",
-      "bytes": 8681
-    },
-    {
       "path": "src/energy_flow_spacetime.py",
       "bytes": 5320
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution/ai_manifest.json
+++ b/docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1775
+      "bytes": 1668
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 485
     },
     {
-      "path": "src/__pycache__/entropy_cosmic_evolution.cpython-311.pyc",
-      "bytes": 9239
-    },
-    {
       "path": "src/entropy_cosmic_evolution.py",
       "bytes": 5582
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1712
+      "bytes": 1608
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 538
     },
     {
-      "path": "src/__pycache__/consciousness_entropy.cpython-311.pyc",
-      "bytes": 8795
-    },
-    {
       "path": "src/consciousness_entropy.py",
       "bytes": 6410
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe/ai_manifest.json
+++ b/docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1876
+      "bytes": 1772
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 582
     },
     {
-      "path": "src/__pycache__/light_speed_regulator.cpython-311.pyc",
-      "bytes": 9376
-    },
-    {
       "path": "src/light_speed_regulator.py",
       "bytes": 5938
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time/ai_manifest.json
+++ b/docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1809
+      "bytes": 1711
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 584
     },
     {
-      "path": "src/__pycache__/math_framework.cpython-311.pyc",
-      "bytes": 12815
-    },
-    {
       "path": "src/math_framework.py",
       "bytes": 7090
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution/ai_manifest.json
+++ b/docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1800
+      "bytes": 1694
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 558
     },
     {
-      "path": "src/__pycache__/observational_evidence.cpython-311.pyc",
-      "bytes": 10679
-    },
-    {
       "path": "src/observational_evidence.py",
       "bytes": 6745
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow/ai_manifest.json
+++ b/docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1818
+      "bytes": 1623
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 392
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 444
-    },
-    {
-      "path": "src/__pycache__/observational_evidence.cpython-311.pyc",
-      "bytes": 9121
-    },
-    {
       "path": "src/observational_evidence.py",
       "bytes": 5685
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/ai_manifest.json
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2154
+      "bytes": 2058
     },
     {
       "path": "citations.bib",
@@ -85,14 +85,10 @@
       "bytes": 496
     },
     {
-      "path": "src/__pycache__/efc_desi_bao.cpython-311.pyc",
-      "bytes": 11117
-    },
-    {
       "path": "src/efc_desi_bao.py",
       "bytes": 5894
     }
   ],
-  "n_files": 19,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-R-SPARC-Regime-Validity/ai_manifest.json
+++ b/docs/papers/efc/EFC-R-SPARC-Regime-Validity/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1654
+      "bytes": 1468
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 277
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 362
-    },
-    {
-      "path": "src/__pycache__/sparc_regime.cpython-311.pyc",
-      "bytes": 11186
-    },
-    {
       "path": "src/sparc_regime.py",
       "bytes": 5200
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/ai_manifest.json
+++ b/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/ai_manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2716
+      "bytes": 2615
     },
     {
       "path": "citations.bib",
@@ -106,14 +106,10 @@
       "bytes": 527
     },
     {
-      "path": "src/__pycache__/regime_transition.cpython-311.pyc",
-      "bytes": 14265
-    },
-    {
       "path": "src/regime_transition.py",
       "bytes": 8678
     }
   ],
-  "n_files": 23,
+  "n_files": 22,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit/ai_manifest.json
+++ b/docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1740
+      "bytes": 1550
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 321
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 388
-    },
-    {
-      "path": "src/__pycache__/light_speed_limit.cpython-311.pyc",
-      "bytes": 7218
-    },
-    {
       "path": "src/light_speed_limit.py",
       "bytes": 3854
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time/ai_manifest.json
+++ b/docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1900
+      "bytes": 1706
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 357
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 431
-    },
-    {
-      "path": "src/__pycache__/energy_flow_spacetime.cpython-311.pyc",
-      "bytes": 8888
-    },
-    {
       "path": "src/energy_flow_spacetime.py",
       "bytes": 4660
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-The-Energy-Flow-Interface/ai_manifest.json
+++ b/docs/papers/efc/EFC-The-Energy-Flow-Interface/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1708
+      "bytes": 1514
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 368
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 425
-    },
-    {
-      "path": "src/__pycache__/energy_flow_interface.cpython-311.pyc",
-      "bytes": 8584
-    },
-    {
       "path": "src/energy_flow_interface.py",
       "bytes": 4482
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT/ai_manifest.json
+++ b/docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1721
+      "bytes": 1528
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 339
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 403
-    },
-    {
-      "path": "src/__pycache__/thermodynamic_bridge.cpython-311.pyc",
-      "bytes": 8198
-    },
-    {
       "path": "src/thermodynamic_bridge.py",
       "bytes": 4548
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1841
+      "bytes": 1650
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 300
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 384
-    },
-    {
-      "path": "src/__pycache__/entropy_challenges.cpython-311.pyc",
-      "bytes": 7569
-    },
-    {
       "path": "src/entropy_challenges.py",
       "bytes": 3504
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes/ai_manifest.json
+++ b/docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1798
+      "bytes": 1608
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 361
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 425
-    },
-    {
-      "path": "src/__pycache__/universe_extremes.cpython-311.pyc",
-      "bytes": 9238
-    },
-    {
       "path": "src/universe_extremes.py",
       "bytes": 4850
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now/ai_manifest.json
+++ b/docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1919
+      "bytes": 1731
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 340
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 643
-    },
-    {
-      "path": "src/__pycache__/energy_flow_now.cpython-311.pyc",
-      "bytes": 7898
-    },
-    {
       "path": "src/energy_flow_now.py",
       "bytes": 4638
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit/ai_manifest.json
+++ b/docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1756
+      "bytes": 1566
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 314
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 593
-    },
-    {
-      "path": "src/__pycache__/light_speed_limit.cpython-311.pyc",
-      "bytes": 8909
-    },
-    {
       "path": "src/light_speed_limit.py",
       "bytes": 4892
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v1.2-Foundational-Framework/ai_manifest.json
+++ b/docs/papers/efc/EFC-v1.2-Foundational-Framework/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1610
+      "bytes": 1510
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 818
     },
     {
-      "path": "src/__pycache__/efc_foundational.cpython-311.pyc",
-      "bytes": 13238
-    },
-    {
       "path": "src/efc_foundational.py",
       "bytes": 11079
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v2.1-Complete-Edition/ai_manifest.json
+++ b/docs/papers/efc/EFC-v2.1-Complete-Edition/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1553
+      "bytes": 1457
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 545
     },
     {
-      "path": "src/__pycache__/efc_complete.cpython-311.pyc",
-      "bytes": 11036
-    },
-    {
       "path": "src/efc_complete.py",
       "bytes": 7340
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v2.1-Modular-Synthesis/ai_manifest.json
+++ b/docs/papers/efc/EFC-v2.1-Modular-Synthesis/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1549
+      "bytes": 1454
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 434
     },
     {
-      "path": "src/__pycache__/efc_modular.cpython-311.pyc",
-      "bytes": 14008
-    },
-    {
       "path": "src/efc_modular.py",
       "bytes": 8028
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary/ai_manifest.json
+++ b/docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1677
+      "bytes": 1578
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 572
     },
     {
-      "path": "src/__pycache__/efc_cross_field.cpython-311.pyc",
-      "bytes": 10374
-    },
-    {
       "path": "src/efc_cross_field.py",
       "bytes": 8323
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation/ai_manifest.json
+++ b/docs/papers/efc/EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1874
+      "bytes": 1776
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 615
     },
     {
-      "path": "src/__pycache__/sign_structure.cpython-311.pyc",
-      "bytes": 13498
-    },
-    {
       "path": "src/sign_structure.py",
       "bytes": 8948
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Closure_Conjectures/ai_manifest.json
+++ b/docs/papers/efc/EFC_Closure_Conjectures/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1607
+      "bytes": 1507
     },
     {
       "path": "citations.bib",
@@ -69,14 +69,10 @@
       "bytes": 391
     },
     {
-      "path": "src/__pycache__/closure_relations.cpython-311.pyc",
-      "bytes": 6912
-    },
-    {
       "path": "src/closure_relations.py",
       "bytes": 4777
     }
   ],
-  "n_files": 15,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Cosmic_Dipole_Working_Note/ai_manifest.json
+++ b/docs/papers/efc/EFC_Cosmic_Dipole_Working_Note/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1681
+      "bytes": 1493
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 944
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1157
-    },
-    {
-      "path": "src/__pycache__/cosmic_dipole.cpython-311.pyc",
-      "bytes": 13193
-    },
-    {
       "path": "src/cosmic_dipole.py",
       "bytes": 9135
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Entropy_Budget_Working_Note/ai_manifest.json
+++ b/docs/papers/efc/EFC_Entropy_Budget_Working_Note/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1691
+      "bytes": 1503
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 586
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 765
-    },
-    {
-      "path": "src/__pycache__/entropy_budget.cpython-311.pyc",
-      "bytes": 23536
-    },
-    {
       "path": "src/entropy_budget.py",
       "bytes": 16094
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Gradient_Coupled_Grid_Action/ai_manifest.json
+++ b/docs/papers/efc/EFC_Gradient_Coupled_Grid_Action/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1705
+      "bytes": 1519
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 1376
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1553
-    },
-    {
-      "path": "src/__pycache__/grid_action.cpython-311.pyc",
-      "bytes": 22244
-    },
-    {
       "path": "src/grid_action.py",
       "bytes": 14894
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Ontological_Foundations/ai_manifest.json
+++ b/docs/papers/efc/EFC_Ontological_Foundations/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2470
+      "bytes": 1981
     },
     {
       "path": "citations.bib",
@@ -81,26 +81,6 @@
       "bytes": 726
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 983
-    },
-    {
-      "path": "src/__pycache__/circularity_tester.cpython-311.pyc",
-      "bytes": 8241
-    },
-    {
-      "path": "src/__pycache__/hypothesis_analyzer.cpython-311.pyc",
-      "bytes": 9578
-    },
-    {
-      "path": "src/__pycache__/ontology_model.cpython-311.pyc",
-      "bytes": 7624
-    },
-    {
-      "path": "src/__pycache__/phase_classifier.cpython-311.pyc",
-      "bytes": 6886
-    },
-    {
       "path": "src/circularity_tester.py",
       "bytes": 6140
     },
@@ -117,6 +97,6 @@
       "bytes": 5440
     }
   ],
-  "n_files": 25,
+  "n_files": 20,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Phase_3__SPARC_Validation/ai_manifest.json
+++ b/docs/papers/efc/EFC_Phase_3__SPARC_Validation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1713
+      "bytes": 1615
     },
     {
       "path": "citations.bib",
@@ -73,14 +73,10 @@
       "bytes": 371
     },
     {
-      "path": "src/__pycache__/screening_model.cpython-311.pyc",
-      "bytes": 7102
-    },
-    {
       "path": "src/screening_model.py",
       "bytes": 4603
     }
   ],
-  "n_files": 16,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction/ai_manifest.json
+++ b/docs/papers/efc/EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2016
+      "bytes": 1826
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 722
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 914
-    },
-    {
-      "path": "src/__pycache__/efc_relativistic.cpython-311.pyc",
-      "bytes": 20996
-    },
-    {
       "path": "src/efc_relativistic.py",
       "bytes": 14392
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_v1_3_PPN_Recovery_via_Density_Saturation/ai_manifest.json
+++ b/docs/papers/efc/EFC_v1_3_PPN_Recovery_via_Density_Saturation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2316
+      "bytes": 2125
     },
     {
       "path": "citations.bib",
@@ -77,18 +77,10 @@
       "bytes": 636
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 848
-    },
-    {
-      "path": "src/__pycache__/efc_ppn_screening.cpython-311.pyc",
-      "bytes": 13911
-    },
-    {
       "path": "src/efc_ppn_screening.py",
       "bytes": 10102
     }
   ],
-  "n_files": 18,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/ai_manifest.json
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/ai_manifest.json
@@ -36,7 +36,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 4124
+      "bytes": 3930
     },
     {
       "path": "citations.bib",
@@ -175,18 +175,10 @@
       "bytes": 708
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 885
-    },
-    {
-      "path": "src/__pycache__/empirical_validation.cpython-311.pyc",
-      "bytes": 10011
-    },
-    {
       "path": "src/empirical_validation.py",
       "bytes": 5803
     }
   ],
-  "n_files": 43,
+  "n_files": 41,
   "n_pdfs": 0
 }

--- a/docs/papers/efc/Energy-Flow-Cosmology-Unified-Analysis-of-BAO/ai_manifest.json
+++ b/docs/papers/efc/Energy-Flow-Cosmology-Unified-Analysis-of-BAO/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1985
+      "bytes": 1886
     },
     {
       "path": "citations.bib",
@@ -77,14 +77,10 @@
       "bytes": 690
     },
     {
-      "path": "src/__pycache__/efc_unified_bao.cpython-311.pyc",
-      "bytes": 11967
-    },
-    {
       "path": "src/efc_unified_bao.py",
       "bytes": 6892
     }
   ],
-  "n_files": 17,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/ai_manifest.json
+++ b/docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1923
+      "bytes": 1826
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 648
     },
     {
-      "path": "src/__pycache__/efc_screening.cpython-311.pyc",
-      "bytes": 13080
-    },
-    {
       "path": "src/efc_screening.py",
       "bytes": 7654
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/ai_manifest.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2410
+      "bytes": 2215
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 397
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 760
-    },
-    {
-      "path": "src/__pycache__/gravitational_response.cpython-311.pyc",
-      "bytes": 8457
-    },
-    {
       "path": "src/gravitational_response.py",
       "bytes": 4513
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation/ai_manifest.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2258
+      "bytes": 2166
     },
     {
       "path": "citations.bib",
@@ -77,14 +77,10 @@
       "bytes": 413
     },
     {
-      "path": "src/__pycache__/efc_model.cpython-311.pyc",
-      "bytes": 7013
-    },
-    {
       "path": "src/efc_model.py",
       "bytes": 4215
     }
   ],
-  "n_files": 17,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism/ai_manifest.json
+++ b/docs/papers/efc/Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism/ai_manifest.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2130
+      "bytes": 2031
     },
     {
       "path": "citations.bib",
@@ -79,14 +79,10 @@
       "bytes": 512
     },
     {
-      "path": "src/__pycache__/efc_foundations.cpython-311.pyc",
-      "bytes": 12696
-    },
-    {
       "path": "src/efc_foundations.py",
       "bytes": 8425
     }
   ],
-  "n_files": 17,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/From_Grid_Microphysics_to_the_Radial_Acceleration/ai_manifest.json
+++ b/docs/papers/efc/From_Grid_Microphysics_to_the_Radial_Acceleration/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1734
+      "bytes": 1633
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 858
     },
     {
-      "path": "src/__pycache__/grid_microphysics.cpython-311.pyc",
-      "bytes": 17620
-    },
-    {
       "path": "src/grid_microphysics.py",
       "bytes": 12310
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Homo_Fluxus/ai_manifest.json
+++ b/docs/papers/efc/Homo_Fluxus/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1462
+      "bytes": 1367
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 352
     },
     {
-      "path": "src/__pycache__/homo_fluxus.cpython-311.pyc",
-      "bytes": 14774
-    },
-    {
       "path": "src/homo_fluxus.py",
       "bytes": 9935
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/ai_manifest.json
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2051
+      "bytes": 1864
     },
     {
       "path": "citations.bib",
@@ -73,18 +73,10 @@
       "bytes": 914
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1121
-    },
-    {
-      "path": "src/__pycache__/isw_revision.cpython-311.pyc",
-      "bytes": 20370
-    },
-    {
       "path": "src/isw_revision.py",
       "bytes": 13341
     }
   ],
-  "n_files": 17,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/ai_manifest.json
+++ b/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2068
+      "bytes": 1873
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 305
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 596
-    },
-    {
-      "path": "src/__pycache__/isw_cross_correlation.cpython-311.pyc",
-      "bytes": 13387
-    },
-    {
       "path": "src/isw_cross_correlation.py",
       "bytes": 8221
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/KT3b_CrossRegime_Measurement_Failure_DOI/ai_manifest.json
+++ b/docs/papers/efc/KT3b_CrossRegime_Measurement_Failure_DOI/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1603
+      "bytes": 1510
     },
     {
       "path": "citations.bib",
@@ -61,14 +61,10 @@
       "bytes": 2598
     },
     {
-      "path": "src/__pycache__/rcmp_check.cpython-311.pyc",
-      "bytes": 8417
-    },
-    {
       "path": "src/rcmp_check.py",
       "bytes": 6987
     }
   ],
-  "n_files": 13,
+  "n_files": 12,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/ai_manifest.json
+++ b/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/ai_manifest.json
@@ -47,7 +47,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2428
+      "bytes": 2238
     },
     {
       "path": "citations.bib",
@@ -102,18 +102,10 @@
       "bytes": 297
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 562
-    },
-    {
-      "path": "src/__pycache__/regime_validator.cpython-311.pyc",
-      "bytes": 12641
-    },
-    {
       "path": "src/regime_validator.py",
       "bytes": 9491
     }
   ],
-  "n_files": 23,
+  "n_files": 21,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients/ai_manifest.json
+++ b/docs/papers/efc/Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1960
+      "bytes": 1860
     },
     {
       "path": "article.md",
@@ -77,14 +77,10 @@
       "bytes": 855
     },
     {
-      "path": "src/__pycache__/connectome_kappa.cpython-311.pyc",
-      "bytes": 18595
-    },
-    {
       "path": "src/connectome_kappa.py",
       "bytes": 10235
     }
   ],
-  "n_files": 17,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/ai_manifest.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2184
+      "bytes": 1996
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 349
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 650
-    },
-    {
-      "path": "src/__pycache__/efc_eft_ansatz.cpython-311.pyc",
-      "bytes": 13829
-    },
-    {
       "path": "src/efc_eft_ansatz.py",
       "bytes": 9038
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems/ai_manifest.json
+++ b/docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2233
+      "bytes": 2042
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 755
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 957
-    },
-    {
-      "path": "src/__pycache__/entropy_intention.cpython-311.pyc",
-      "bytes": 23408
-    },
-    {
       "path": "src/entropy_intention.py",
       "bytes": 13667
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence/ai_manifest.json
+++ b/docs/papers/efc/Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2366
+      "bytes": 2171
     },
     {
       "path": "citations.bib",
@@ -69,14 +69,6 @@
       "bytes": 458
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 723
-    },
-    {
-      "path": "src/__pycache__/symbiose_architecture.cpython-311.pyc",
-      "bytes": 19759
-    },
-    {
       "path": "src/symbiose_architecture.py",
       "bytes": 15163
     },
@@ -85,6 +77,6 @@
       "bytes": 645
     }
   ],
-  "n_files": 17,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications/ai_manifest.json
+++ b/docs/papers/efc/Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1901
+      "bytes": 1710
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 636
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 831
-    },
-    {
-      "path": "src/__pycache__/sigma8_suppression.cpython-311.pyc",
-      "bytes": 9629
-    },
-    {
       "path": "src/sigma8_suppression.py",
       "bytes": 5727
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12/ai_manifest.json
+++ b/docs/papers/efc/Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2158
+      "bytes": 1967
     },
     {
       "path": "citations.bib",
@@ -77,18 +77,10 @@
       "bytes": 333
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 633
-    },
-    {
-      "path": "src/__pycache__/efc_phenomenology.cpython-311.pyc",
-      "bytes": 14461
-    },
-    {
       "path": "src/efc_phenomenology.py",
       "bytes": 8862
     }
   ],
-  "n_files": 18,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology/ai_manifest.json
+++ b/docs/papers/efc/R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology/ai_manifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2144
+      "bytes": 1948
     },
     {
       "path": "citations.bib",
@@ -76,18 +76,10 @@
       "bytes": 374
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 680
-    },
-    {
-      "path": "src/__pycache__/regime_response_surface.cpython-311.pyc",
-      "bytes": 9751
-    },
-    {
       "path": "src/regime_response_surface.py",
       "bytes": 5478
     }
   ],
-  "n_files": 17,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System/ai_manifest.json
+++ b/docs/papers/efc/Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System/ai_manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 3112
+      "bytes": 2468
     },
     {
       "path": "citations.bib",
@@ -86,34 +86,6 @@
       "bytes": 840
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1220
-    },
-    {
-      "path": "src/__pycache__/claim.cpython-311.pyc",
-      "bytes": 9075
-    },
-    {
-      "path": "src/__pycache__/driver_proximity.cpython-311.pyc",
-      "bytes": 5876
-    },
-    {
-      "path": "src/__pycache__/l_axis.cpython-311.pyc",
-      "bytes": 5303
-    },
-    {
-      "path": "src/__pycache__/r_axis.cpython-311.pyc",
-      "bytes": 6103
-    },
-    {
-      "path": "src/__pycache__/regime_gate.cpython-311.pyc",
-      "bytes": 6310
-    },
-    {
-      "path": "src/__pycache__/world_model.cpython-311.pyc",
-      "bytes": 8817
-    },
-    {
       "path": "src/claim.py",
       "bytes": 4206
     },
@@ -138,6 +110,6 @@
       "bytes": 5060
     }
   ],
-  "n_files": 29,
+  "n_files": 22,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity/ai_manifest.json
+++ b/docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2048
+      "bytes": 1856
     },
     {
       "path": "citations.bib",
@@ -69,18 +69,10 @@
       "bytes": 623
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 824
-    },
-    {
-      "path": "src/__pycache__/regime_measurement.cpython-311.pyc",
-      "bytes": 21344
-    },
-    {
       "path": "src/regime_measurement.py",
       "bytes": 15852
     }
   ],
-  "n_files": 16,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/ai_manifest.json
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/ai_manifest.json
@@ -31,7 +31,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 3708
+      "bytes": 3518
     },
     {
       "path": "citations.bib",
@@ -138,14 +138,6 @@
       "bytes": 331
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 650
-    },
-    {
-      "path": "src/__pycache__/transition_metric.cpython-311.pyc",
-      "bytes": 7567
-    },
-    {
       "path": "src/transition_metric.py",
       "bytes": 5131
     },
@@ -154,6 +146,6 @@
       "bytes": 1425
     }
   ],
-  "n_files": 33,
+  "n_files": 31,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Locked_Measurement/ai_manifest.json
+++ b/docs/papers/efc/Regime_Locked_Measurement/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1683
+      "bytes": 1496
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 492
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 701
-    },
-    {
-      "path": "src/__pycache__/regime_locked.cpython-311.pyc",
-      "bytes": 13324
-    },
-    {
       "path": "src/regime_locked.py",
       "bytes": 8951
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models/ai_manifest.json
+++ b/docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models/ai_manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2681
+      "bytes": 2386
     },
     {
       "path": "citations.bib",
@@ -89,18 +89,6 @@
       "bytes": 527
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 783
-    },
-    {
-      "path": "src/__pycache__/interpolating_function.cpython-311.pyc",
-      "bytes": 2885
-    },
-    {
-      "path": "src/__pycache__/regime_classifier.cpython-311.pyc",
-      "bytes": 5670
-    },
-    {
       "path": "src/discrete_functional.py",
       "bytes": 5205
     },
@@ -113,6 +101,6 @@
       "bytes": 4796
     }
   ],
-  "n_files": 24,
+  "n_files": 21,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3/ai_manifest.json
+++ b/docs/papers/efc/Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2153
+      "bytes": 2050
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 433
     },
     {
-      "path": "src/__pycache__/rlhf_thermodynamics.cpython-311.pyc",
-      "bytes": 18197
-    },
-    {
       "path": "src/rlhf_thermodynamics.py",
       "bytes": 10791
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel/ai_manifest.json
+++ b/docs/papers/efc/Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2135
+      "bytes": 1944
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 548
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 825
-    },
-    {
-      "path": "src/__pycache__/growth_robustness.cpython-311.pyc",
-      "bytes": 10361
-    },
-    {
       "path": "src/growth_robustness.py",
       "bytes": 5704
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/ai_manifest.json
+++ b/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/ai_manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 4400
+      "bytes": 4201
     },
     {
       "path": "citations.bib",
@@ -177,14 +177,6 @@
       "bytes": 384
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 712
-    },
-    {
-      "path": "src/__pycache__/cluster_merger_constraints.cpython-311.pyc",
-      "bytes": 8429
-    },
-    {
       "path": "src/cluster_merger_constraints.py",
       "bytes": 5358
     },
@@ -193,6 +185,6 @@
       "bytes": 566
     }
   ],
-  "n_files": 44,
+  "n_files": 42,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/ai_manifest.json
+++ b/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2132
+      "bytes": 1938
     },
     {
       "path": "citations.bib",
@@ -57,14 +57,6 @@
       "bytes": 349
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 613
-    },
-    {
-      "path": "src/__pycache__/structural_coherence.cpython-311.pyc",
-      "bytes": 10797
-    },
-    {
       "path": "src/structural_coherence.py",
       "bytes": 9313
     },
@@ -77,6 +69,6 @@
       "bytes": 1399
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking/ai_manifest.json
+++ b/docs/papers/efc/Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1933
+      "bytes": 1827
     },
     {
       "path": "citations.bib",
@@ -53,10 +53,6 @@
       "bytes": 456
     },
     {
-      "path": "src/__pycache__/symbiosis_architecture.cpython-311.pyc",
-      "bytes": 14840
-    },
-    {
       "path": "src/symbiosis_architecture.py",
       "bytes": 8566
     },
@@ -77,6 +73,6 @@
       "bytes": 21391
     }
   ],
-  "n_files": 15,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/ai_manifest.json
+++ b/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2894
+      "bytes": 2706
     },
     {
       "path": "citations.bib",
@@ -113,14 +113,6 @@
       "bytes": 696
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 916
-    },
-    {
-      "path": "src/__pycache__/cmb_constraints.cpython-311.pyc",
-      "bytes": 8408
-    },
-    {
       "path": "src/cmb_constraints.py",
       "bytes": 4977
     },
@@ -129,6 +121,6 @@
       "bytes": 585
     }
   ],
-  "n_files": 28,
+  "n_files": 26,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier/ai_manifest.json
+++ b/docs/papers/efc/Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2598
+      "bytes": 2489
     },
     {
       "path": "citations.bib",
@@ -47,6 +47,10 @@
     {
       "path": "cobaya/efc_bridge.yaml",
       "bytes": 6162
+    },
+    {
+      "path": "cobaya/efc_bridge_reduced.yaml",
+      "bytes": 3331
     },
     {
       "path": "cobaya/efc_mu_table.json",
@@ -81,14 +85,6 @@
       "bytes": 361
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 640
-    },
-    {
-      "path": "src/__pycache__/cmb_localization.cpython-311.pyc",
-      "bytes": 19024
-    },
-    {
       "path": "src/cmb_localization.py",
       "bytes": 9910
     },
@@ -97,6 +93,6 @@
       "bytes": 597
     }
   ],
-  "n_files": 19,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics/ai_manifest.json
+++ b/docs/papers/efc/The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics/ai_manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 3291
+      "bytes": 2895
     },
     {
       "path": "citations.bib",
@@ -102,22 +102,6 @@
       "bytes": 1134
     },
     {
-      "path": "src/__pycache__/proxy_chain.cpython-311.pyc",
-      "bytes": 12691
-    },
-    {
-      "path": "src/__pycache__/rcmp_validator.cpython-311.pyc",
-      "bytes": 12990
-    },
-    {
-      "path": "src/__pycache__/regime_tagger.cpython-311.pyc",
-      "bytes": 10040
-    },
-    {
-      "path": "src/__pycache__/uncertainty_propagator.cpython-311.pyc",
-      "bytes": 13920
-    },
-    {
       "path": "src/proxy_chain.py",
       "bytes": 8443
     },
@@ -138,6 +122,6 @@
       "bytes": 626
     }
   ],
-  "n_files": 29,
+  "n_files": 25,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/The_Hubble_Tension_as_Regime_Mismatch/ai_manifest.json
+++ b/docs/papers/efc/The_Hubble_Tension_as_Regime_Mismatch/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1963
+      "bytes": 1769
     },
     {
       "path": "citations.bib",
@@ -69,14 +69,6 @@
       "bytes": 907
     },
     {
-      "path": "src/__pycache__/g_effective.cpython-311.pyc",
-      "bytes": 6721
-    },
-    {
-      "path": "src/__pycache__/regime_classifier.cpython-311.pyc",
-      "bytes": 7590
-    },
-    {
       "path": "src/g_effective.py",
       "bytes": 4438
     },
@@ -89,6 +81,6 @@
       "bytes": 524
     }
   ],
-  "n_files": 18,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/ai_manifest.json
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2181
+      "bytes": 1989
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,6 @@
       "bytes": 466
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 719
-    },
-    {
-      "path": "src/__pycache__/triangulation_test.cpython-311.pyc",
-      "bytes": 12527
-    },
-    {
       "path": "src/triangulation_test.py",
       "bytes": 9480
     },
@@ -85,6 +77,6 @@
       "bytes": 662
     }
   ],
-  "n_files": 17,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification/ai_manifest.json
+++ b/docs/papers/efc/Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 3382
+      "bytes": 2804
     },
     {
       "path": "citations.bib",
@@ -89,30 +89,6 @@
       "bytes": 1008
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1369
-    },
-    {
-      "path": "src/__pycache__/entropy_mapping.cpython-311.pyc",
-      "bytes": 6208
-    },
-    {
-      "path": "src/__pycache__/h0_predictor.cpython-311.pyc",
-      "bytes": 7132
-    },
-    {
-      "path": "src/__pycache__/mond_interpolation.cpython-311.pyc",
-      "bytes": 8009
-    },
-    {
-      "path": "src/__pycache__/phase_calculator.cpython-311.pyc",
-      "bytes": 7139
-    },
-    {
-      "path": "src/__pycache__/unification.cpython-311.pyc",
-      "bytes": 8730
-    },
-    {
       "path": "src/entropy_mapping.py",
       "bytes": 3441
     },
@@ -137,6 +113,6 @@
       "bytes": 594
     }
   ],
-  "n_files": 30,
+  "n_files": 24,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_/ai_manifest.json
+++ b/docs/papers/efc/WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2139
+      "bytes": 1952
     },
     {
       "path": "citations.bib",
@@ -61,14 +61,6 @@
       "bytes": 425
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 743
-    },
-    {
-      "path": "src/__pycache__/wp3_rks_slice.cpython-311.pyc",
-      "bytes": 10541
-    },
-    {
       "path": "src/wp3_rks_slice.py",
       "bytes": 5835
     },
@@ -93,6 +85,6 @@
       "bytes": 146530
     }
   ],
-  "n_files": 19,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/WP4_BOSS_transfer_validation/ai_manifest.json
+++ b/docs/papers/efc/WP4_BOSS_transfer_validation/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1653
+      "bytes": 1468
     },
     {
       "path": "citations.bib",
@@ -61,14 +61,6 @@
       "bytes": 379
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 565
-    },
-    {
-      "path": "src/__pycache__/wp4_transfer.cpython-311.pyc",
-      "bytes": 5941
-    },
-    {
       "path": "src/wp4_transfer.py",
       "bytes": 2751
     },
@@ -77,6 +69,6 @@
       "bytes": 495
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/WP4_BOSS_validation/ai_manifest.json
+++ b/docs/papers/efc/WP4_BOSS_validation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1802
+      "bytes": 1611
     },
     {
       "path": "citations.bib",
@@ -69,14 +69,6 @@
       "bytes": 298
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 512
-    },
-    {
-      "path": "src/__pycache__/efc_boss_transfer.cpython-311.pyc",
-      "bytes": 15794
-    },
-    {
       "path": "src/efc_boss_transfer.py",
       "bytes": 10579
     },
@@ -89,6 +81,6 @@
       "bytes": 674
     }
   ],
-  "n_files": 18,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -9,7 +9,7 @@
       "regimes": [],
       "primary_pdf": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology",
@@ -18,7 +18,7 @@
       "regimes": [],
       "primary_pdf": "AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 14
     },
     {
       "name": "A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters",
@@ -27,7 +27,7 @@
       "regimes": [],
       "primary_pdf": "BESR3_paper.pdf",
       "created": [],
-      "n_files": 20
+      "n_files": 18
     },
     {
       "name": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes",
@@ -36,7 +36,7 @@
       "regimes": [],
       "primary_pdf": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes_the_Interpretation_of_S_.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 15
     },
     {
       "name": "CEM-Consciousness-Ego-Mirror",
@@ -45,7 +45,7 @@
       "regimes": [],
       "primary_pdf": "CEM-Consciousness-Ego-Mirror.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "CMB-Thermodynamic-Interpretation",
@@ -54,7 +54,7 @@
       "regimes": [],
       "primary_pdf": "CMB-Thermodynamic-Interpretation/CMB_Thermodynamic_Interpretation.pdf",
       "created": [],
-      "n_files": 25
+      "n_files": 23
     },
     {
       "name": "Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling",
@@ -68,7 +68,7 @@
       ],
       "primary_pdf": "SPARC175_COMPLETE_PAPER.pdf",
       "created": [],
-      "n_files": 64
+      "n_files": 62
     },
     {
       "name": "Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge",
@@ -77,7 +77,7 @@
       "regimes": [],
       "primary_pdf": "Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test",
@@ -86,7 +86,7 @@
       "regimes": [],
       "primary_pdf": "Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Core-Lock",
@@ -95,7 +95,7 @@
       "regimes": [],
       "primary_pdf": "Core_Lock.pdf",
       "created": [],
-      "n_files": 29
+      "n_files": 23
     },
     {
       "name": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity",
@@ -104,7 +104,7 @@
       "regimes": [],
       "primary_pdf": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity.pdf",
       "created": [],
-      "n_files": 23
+      "n_files": 21
     },
     {
       "name": "Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints",
@@ -113,7 +113,7 @@
       "regimes": [],
       "primary_pdf": "Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints_and_an_Identified_Microphysical_Gap.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Density_of_States_of_Gravitationally",
@@ -122,7 +122,7 @@
       "regimes": [],
       "primary_pdf": "Density_of_States_of_Gravitationally.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Derivation_of_the_Entropy_Production",
@@ -131,7 +131,7 @@
       "regimes": [],
       "primary_pdf": "Derivation_of_the_Entropy_Production.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Directional_Lensing_Residuals",
@@ -140,7 +140,7 @@
       "regimes": [],
       "primary_pdf": "Directional_Lensing_Residuals_Magnusson_2026.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 15
     },
     {
       "name": "Discrete_Entropic_Gravity_on_a_Cubic_Graph_Emergent_Newton_and_MOND_Regimes_with_Λ-Locked_Screening",
@@ -158,7 +158,7 @@
       "regimes": [],
       "primary_pdf": "Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis_and_Open_Gaps_toward_Quantum_Testability.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EBE-Core-Principles",
@@ -172,7 +172,7 @@
       ],
       "primary_pdf": "EBE_Core_Principles_v1_0-1.pdf",
       "created": [],
-      "n_files": 26
+      "n_files": 21
     },
     {
       "name": "EFC-A-Deep-Dive-into-the-Halo-Concept",
@@ -181,7 +181,7 @@
       "regimes": [],
       "primary_pdf": "EFC-A-Deep-Dive-into-the-Halo-Concept.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-AI-Augmented-Scientific-Workflow-Framework",
@@ -190,7 +190,7 @@
       "regimes": [],
       "primary_pdf": "EFC-AI-Augmented-Scientific-Workflow-Framework.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Applications-and-Implications",
@@ -199,7 +199,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Applications-and-Implications.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Bridging-Scales-FEP",
@@ -208,7 +208,7 @@
       "regimes": [],
       "primary_pdf": "EFC-FEP-Bridge-v1.0.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-CMB-Thermodynamic-Gradient",
@@ -217,7 +217,7 @@
       "regimes": [],
       "primary_pdf": "EFC-CMB-Thermodynamic-Gradient.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2",
@@ -226,7 +226,7 @@
       "regimes": [],
       "primary_pdf": "EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-C_Cognitive_Entropy_Gradients_v2",
@@ -240,7 +240,7 @@
       ],
       "primary_pdf": null,
       "created": [],
-      "n_files": 20
+      "n_files": 18
     },
     {
       "name": "EFC-C_Consciousness_Field_Resonance",
@@ -249,7 +249,7 @@
       "regimes": [],
       "primary_pdf": "EFC-C_Consciousness_Field_Resonance_FINAL.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters",
@@ -258,7 +258,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Can-Entropy-Drive-Cosmic-Evolution",
@@ -267,7 +267,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Can-Entropy-Drive-Cosmic-Evolution.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Dynamic-Balance-Entropy-Order-and-Chaos",
@@ -276,7 +276,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Dynamic-Balance-Entropy-Order-and-Chaos.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe",
@@ -285,7 +285,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Field-Equations-for-Entropy-Driven-Spacetime",
@@ -294,7 +294,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Field-Equations-for-Entropy-Driven-Spacetime.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters",
@@ -303,7 +303,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Grid-Higgs-Framework",
@@ -312,7 +312,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Grid-Higgs-Framework.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Grid-Higgs-Paradigm-Shift",
@@ -321,7 +321,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Grid-Higgs-Paradigm-Shift.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Grid-Model-Entropic-Dynamics",
@@ -330,7 +330,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Grid-Model-Entropic-Dynamics.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-H0-S8-Tensions",
@@ -339,7 +339,7 @@
       "regimes": [],
       "primary_pdf": "Resolving%20the%20H0%20and%20S8%20Tensions%20Through.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-How-Does-Balance-Shape-Universal-Structures",
@@ -348,7 +348,7 @@
       "regimes": [],
       "primary_pdf": "EFC-How-Does-Balance-Shape-Universal-Structures.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-How-Energy-Flow-Sustain-Spacetime",
@@ -357,7 +357,7 @@
       "regimes": [],
       "primary_pdf": "EFC-How-Energy-Flow-Sustain-Spacetime.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Hypothesis-Interrelation-Energy-Entropy",
@@ -366,7 +366,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Hypothesis-Interrelation-Energy-Entropy.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Hypothesis-Universe-as-Energy-Driven-System",
@@ -375,7 +375,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Hypothesis-Universe-as-Energy-Driven-System.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Integrated-Hypothesis-Time-Entropy",
@@ -384,7 +384,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Integrated-Hypothesis-Time-Entropy.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Introduction-to-Energy-Flow-in-Space-Time",
@@ -393,7 +393,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Introduction-to-Energy-Flow-in-Space-Time.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Introduction-to-Entropy-in-Cosmic-Evolution",
@@ -402,7 +402,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Introduction-to-Entropy-in-Cosmic-Evolution.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Is-Consciousness-Linked-to-Entropy",
@@ -411,7 +411,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Is-Consciousness-Linked-to-Entropy.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe",
@@ -420,7 +420,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time",
@@ -429,7 +429,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Observational-Evidence-Entropy-Cosmic-Evolution",
@@ -438,7 +438,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Observational-Evidence-Entropy-Cosmic-Evolution.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-Observational-Evidence-for-Energy-Flow",
@@ -447,7 +447,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Observational-Evidence-for-Energy-Flow.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis",
@@ -456,7 +456,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Phenomenology_vs_DESI_DR2_BAO__A_Comparative_Fit_Analysis.pdf",
       "created": [],
-      "n_files": 19
+      "n_files": 18
     },
     {
       "name": "EFC-R-SPARC-Regime-Validity",
@@ -465,7 +465,7 @@
       "regimes": [],
       "primary_pdf": "EFC-R_SPARC_final.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology",
@@ -479,7 +479,7 @@
       ],
       "primary_pdf": "paper/EFC-Regime-Transition-Framewor-A-CMB-Consistent-Appro.pdf",
       "created": [],
-      "n_files": 23
+      "n_files": 22
     },
     {
       "name": "EFC-Subhypothesis-Light-Speed-Limit",
@@ -488,7 +488,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Subhypothesis-Light-Speed-Limit.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Technical-Documentation-Energy-Flow-in-Space-Time",
@@ -497,7 +497,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Technical-Documentation-Energy-Flow-in-Space-Time.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-The-Energy-Flow-Interface",
@@ -506,7 +506,7 @@
       "regimes": [],
       "primary_pdf": "EFC-The-Energy-Flow-Interface.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Thermodynamic-Bridge-GR-QFT",
@@ -515,7 +515,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Thermodynamic-Bridge-GR-QFT.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Unresolved-Questions-and-Challenges-Entropy",
@@ -524,7 +524,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Unresolved-Questions-and-Challenges-Entropy.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-What-Happens-at-the-Universes-Extremes",
@@ -533,7 +533,7 @@
       "regimes": [],
       "primary_pdf": "EFC-What-Happens-at-the-Universes-Extremes.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now",
@@ -542,7 +542,7 @@
       "regimes": [],
       "primary_pdf": "EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-Why-is-Light-Speed-a-Cosmic-Limit",
@@ -551,7 +551,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Why-is-Light-Speed-a-Cosmic-Limit.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC-v1.2-Foundational-Framework",
@@ -560,7 +560,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v1.2-Foundational-Framework.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-v2.1-Complete-Edition",
@@ -569,7 +569,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v2.1-Complete-Edition.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-v2.1-Modular-Synthesis",
@@ -578,7 +578,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v2.1-Modular-Synthesis.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC-v2.2-Cross-Field-Integration-Summary",
@@ -587,7 +587,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v2.2-Cross-Field-Integration-Summary.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation",
@@ -596,7 +596,7 @@
       "regimes": [],
       "primary_pdf": "efclass_companion_note.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "EFC_Closure_Conjectures",
@@ -605,7 +605,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Closure_Conjectures.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 14
     },
     {
       "name": "EFC_Cosmic_Dipole_Working_Note",
@@ -614,7 +614,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Cosmic_Dipole_Working_Note.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC_Entropy_Budget_Working_Note",
@@ -623,7 +623,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Entropy_Budget_Working_Note.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC_Gradient_Coupled_Grid_Action",
@@ -632,7 +632,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Gradient_Coupled_Grid_Action.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC_Ontological_Foundations",
@@ -641,7 +641,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Ontological_Foundations_v1_0_2-1.pdf",
       "created": [],
-      "n_files": 25
+      "n_files": 20
     },
     {
       "name": "EFC_Phase_3__SPARC_Validation",
@@ -650,7 +650,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Phase_3__SPARC_Validation.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 15
     },
     {
       "name": "EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction",
@@ -659,7 +659,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "EFC_v1_3_PPN_Recovery_via_Density_Saturation",
@@ -668,7 +668,7 @@
       "regimes": [],
       "primary_pdf": "EFC_v1_3___PPN_Recovery_via_Density_Saturation__v2_1__Page_1_GR_Recovery_in_Energy_Flow_Cosmology_via_Density_Saturation__Quantitative_PPN_Analysis.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 16
     },
     {
       "name": "Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves",
@@ -677,7 +677,7 @@
       "regimes": [],
       "primary_pdf": null,
       "created": [],
-      "n_files": 43
+      "n_files": 41
     },
     {
       "name": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
@@ -686,7 +686,7 @@
       "regimes": [],
       "primary_pdf": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 16
     },
     {
       "name": "Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1",
@@ -695,7 +695,7 @@
       "regimes": [],
       "primary_pdf": "Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
@@ -704,7 +704,7 @@
       "regimes": [],
       "primary_pdf": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation",
@@ -713,7 +713,7 @@
       "regimes": [],
       "primary_pdf": "Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation_Against_Pantheon__and_H_z__Chronometers.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 16
     },
     {
       "name": "Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism",
@@ -724,7 +724,7 @@
       ],
       "primary_pdf": "Foundations.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 16
     },
     {
       "name": "From_Grid_Microphysics_to_the_Radial_Acceleration",
@@ -733,7 +733,7 @@
       "regimes": [],
       "primary_pdf": "From_Grid_Microphysics_to_the_Radial_Acceleration.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "Homo_Fluxus",
@@ -742,7 +742,7 @@
       "regimes": [],
       "primary_pdf": "Homo_Fluxus_v2.0.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions",
@@ -751,7 +751,7 @@
       "regimes": [],
       "primary_pdf": "isw_revision_patch.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 15
     },
     {
       "name": "ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers",
@@ -760,7 +760,7 @@
       "regimes": [],
       "primary_pdf": "ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "KT3b_CrossRegime_Measurement_Failure_DOI",
@@ -769,7 +769,7 @@
       "regimes": [],
       "primary_pdf": "KT3b_CrossRegime_Measurement_Failure_DOI.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 12
     },
     {
       "name": "L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism",
@@ -783,7 +783,7 @@
       ],
       "primary_pdf": "docs/L0_L3_Regime_Architecture_Figshare.pdf",
       "created": [],
-      "n_files": 23
+      "n_files": 21
     },
     {
       "name": "Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients",
@@ -792,7 +792,7 @@
       "regimes": [],
       "primary_pdf": "Local_Degree_Heterogeneity_Predicts.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 16
     },
     {
       "name": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients",
@@ -801,7 +801,7 @@
       "regimes": [],
       "primary_pdf": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Multi_epoch_Growth_Rate_Test_of_EFC",
@@ -819,7 +819,7 @@
       "regimes": [],
       "primary_pdf": "Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence",
@@ -828,7 +828,7 @@
       "regimes": [],
       "primary_pdf": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 15
     },
     {
       "name": "Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications",
@@ -837,7 +837,7 @@
       "regimes": [],
       "primary_pdf": "efc_technical_note_II.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12",
@@ -846,7 +846,7 @@
       "regimes": [],
       "primary_pdf": "efc_phenomenology_paper.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 16
     },
     {
       "name": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
@@ -858,7 +858,7 @@
       ],
       "primary_pdf": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 15
     },
     {
       "name": "Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System",
@@ -872,7 +872,7 @@
       ],
       "primary_pdf": "Regime_Based_World_Modeling__A_Layered_Epistemic_Architecture_for_Complex_Systems-1.pdf",
       "created": [],
-      "n_files": 29
+      "n_files": 22
     },
     {
       "name": "Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity",
@@ -881,7 +881,7 @@
       "regimes": [],
       "primary_pdf": "Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 14
     },
     {
       "name": "Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
@@ -895,7 +895,7 @@
       ],
       "primary_pdf": "Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset.pdf",
       "created": [],
-      "n_files": 33
+      "n_files": 31
     },
     {
       "name": "Regime_Locked_Measurement",
@@ -904,7 +904,7 @@
       "regimes": [],
       "primary_pdf": "Regime-Locked-Measurement-Magnusson-2026.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models",
@@ -913,7 +913,7 @@
       "regimes": [],
       "primary_pdf": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models.pdf",
       "created": [],
-      "n_files": 24
+      "n_files": 21
     },
     {
       "name": "Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3",
@@ -922,7 +922,7 @@
       "regimes": [],
       "primary_pdf": "Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel",
@@ -931,7 +931,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Growth_Sector_Robustness_DOI_31332730.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry",
@@ -940,7 +940,7 @@
       "regimes": [],
       "primary_pdf": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry.pdf",
       "created": [],
-      "n_files": 44
+      "n_files": 42
     },
     {
       "name": "Structural_Coherence_Evaluation_for_Physical_Theories",
@@ -949,7 +949,7 @@
       "regimes": [],
       "primary_pdf": "Structural_Coherence_Evaluation_for_Physical_Theories__A_Theory_Agnostic_Framework_with_Observation_Native_Ontology_and_Self_Imposed_Falsifiability.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking",
@@ -958,7 +958,7 @@
       "regimes": [],
       "primary_pdf": "symbiosis_method.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 14
     },
     {
       "name": "Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results",
@@ -967,7 +967,7 @@
       "regimes": [],
       "primary_pdf": "EFC_CMB_Testing_Results.pdf",
       "created": [],
-      "n_files": 28
+      "n_files": 26
     },
     {
       "name": "Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier",
@@ -980,7 +980,7 @@
       ],
       "primary_pdf": "Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier.pdf",
       "created": [],
-      "n_files": 19
+      "n_files": 18
     },
     {
       "name": "The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics",
@@ -994,7 +994,7 @@
       ],
       "primary_pdf": "The_Regime_Consistent_Measurement_Principle__RCMP___A_Methodological_Framework_for_Multi_Scale_Physics-1.pdf",
       "created": [],
-      "n_files": 29
+      "n_files": 25
     },
     {
       "name": "The_Hubble_Tension_as_Regime_Mismatch",
@@ -1003,7 +1003,7 @@
       "regimes": [],
       "primary_pdf": "The_Hubble_Tension_as_Regime_Mismatch.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 16
     },
     {
       "name": "Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic",
@@ -1012,7 +1012,7 @@
       "regimes": [],
       "primary_pdf": "Triangulation-Test-for-Thermodynamic-Lensing-Coupling.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 15
     },
     {
       "name": "Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification",
@@ -1021,7 +1021,7 @@
       "regimes": [],
       "primary_pdf": "Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification.pdf",
       "created": [],
-      "n_files": 30
+      "n_files": 24
     },
     {
       "name": "WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
@@ -1030,7 +1030,7 @@
       "regimes": [],
       "primary_pdf": "wp3_rks_article.pdf",
       "created": [],
-      "n_files": 19
+      "n_files": 17
     },
     {
       "name": "WP4_BOSS_transfer_validation",
@@ -1039,7 +1039,7 @@
       "regimes": [],
       "primary_pdf": "WP4_BOSS_transfer_validation.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "WP4_BOSS_validation",
@@ -1048,7 +1048,7 @@
       "regimes": [],
       "primary_pdf": "WP4_BOSS_validation.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 16
     },
     {
       "name": "ai_workflow_framework",
@@ -1057,7 +1057,7 @@
       "regimes": [],
       "primary_pdf": "ai_workflow_framework.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "bullet_cluster_efc",
@@ -1066,7 +1066,7 @@
       "regimes": [],
       "primary_pdf": "bullet_cluster_efc.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 12
     },
     {
       "name": "c_eff_parameterization",
@@ -1075,7 +1075,7 @@
       "regimes": [],
       "primary_pdf": "c_eff_parameterization_v3_final.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 14
     },
     {
       "name": "efc-weak-lensing-phenomenology",
@@ -1088,7 +1088,7 @@
       ],
       "primary_pdf": "docs/efc_weak_lensing_paper.pdf",
       "created": [],
-      "n_files": 21
+      "n_files": 20
     },
     {
       "name": "efc_boss_bao_cobaya_research_note",
@@ -1097,7 +1097,7 @@
       "regimes": [],
       "primary_pdf": "efc_boss_bao_cobaya_research_note.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "efc_des_y6_validation",
@@ -1106,7 +1106,7 @@
       "regimes": [],
       "primary_pdf": "efc_des_y6_validation.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "efc_formal_spec",
@@ -1115,7 +1115,7 @@
       "regimes": [],
       "primary_pdf": "efc_formal_spec.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "efc_master",
@@ -1124,7 +1124,7 @@
       "regimes": [],
       "primary_pdf": "efc_master.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "efc_master_v1",
@@ -1133,7 +1133,7 @@
       "regimes": [],
       "primary_pdf": "efc_master_v1.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 13
     },
     {
       "name": "efc_state_vs_stageIII",
@@ -1142,7 +1142,7 @@
       "regimes": [],
       "primary_pdf": "efc_state_vs_stageIII.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "energy-flow-cosmology-and-regime-dependent-structure-formation",
@@ -1151,7 +1151,7 @@
       "regimes": [],
       "primary_pdf": "Paper3_EFC_Regime_Synthesis_FINAL.pdf",
       "created": [],
-      "n_files": 20
+      "n_files": 18
     },
     {
       "name": "entropy-bounded-empiricism-EBE-SPARC175-complete-documentation",
@@ -1160,7 +1160,7 @@
       "regimes": [],
       "primary_pdf": "EBE_SPARC175_Complete_Documentation.pdf",
       "created": [],
-      "n_files": 19
+      "n_files": 18
     },
     {
       "name": "observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web",
@@ -1169,7 +1169,7 @@
       "regimes": [],
       "primary_pdf": "Magnusson_2026_COSMOS_Galaxy_Excess.pdf",
       "created": [],
-      "n_files": 28
+      "n_files": 26
     },
     {
       "name": "paper_rsd_to_clusters",
@@ -1178,7 +1178,7 @@
       "regimes": [],
       "primary_pdf": "paper_rsd_to_clusters.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "regime-dependent-breakdown-of-LCDM-across-cosmic-time",
@@ -1187,7 +1187,7 @@
       "regimes": [],
       "primary_pdf": "Regime_Dependent_Breakdown.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 16
     },
     {
       "name": "regime_consistency_lya_bao_rsd_sce",
@@ -1196,7 +1196,7 @@
       "regimes": [],
       "primary_pdf": "regime_consistency_lya_bao_rsd_sce_v1_0.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 14
     },
     {
       "name": "symbiotic-insight-framework",
@@ -1205,7 +1205,7 @@
       "regimes": [],
       "primary_pdf": "symbiotic-insight-framework.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 15
     },
     {
       "name": "validity-aware-ai",
@@ -1219,7 +1219,7 @@
       ],
       "primary_pdf": null,
       "created": [],
-      "n_files": 32
+      "n_files": 27
     },
     {
       "name": "variable-light-s0-s1",
@@ -1228,7 +1228,7 @@
       "regimes": [],
       "primary_pdf": "variable-light-s0-s1.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "void_isw_signflip_v2.1_final",
@@ -1237,7 +1237,7 @@
       "regimes": [],
       "primary_pdf": "void_isw_signflip_v2.1.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     },
     {
       "name": "ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology",
@@ -1246,7 +1246,7 @@
       "regimes": [],
       "primary_pdf": "ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 13
     }
   ]
 }

--- a/docs/papers/efc/ai_workflow_framework/ai_manifest.json
+++ b/docs/papers/efc/ai_workflow_framework/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1522
+      "bytes": 1427
     },
     {
       "path": "ai_workflow_framework.jsonld",
@@ -65,14 +65,10 @@
       "bytes": 464
     },
     {
-      "path": "src/__pycache__/ai_workflow.cpython-311.pyc",
-      "bytes": 10800
-    },
-    {
       "path": "src/ai_workflow.py",
       "bytes": 7182
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/bullet_cluster_efc/ai_manifest.json
+++ b/docs/papers/efc/bullet_cluster_efc/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1471
+      "bytes": 1374
     },
     {
       "path": "bullet-cluster-efc.jsonld",
@@ -61,14 +61,10 @@
       "bytes": 2420
     },
     {
-      "path": "src/__pycache__/asig_2d_piemd.cpython-311.pyc",
-      "bytes": 14068
-    },
-    {
       "path": "src/asig_2d_piemd.py",
       "bytes": 12141
     }
   ],
-  "n_files": 13,
+  "n_files": 12,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/c_eff_parameterization/ai_manifest.json
+++ b/docs/papers/efc/c_eff_parameterization/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1681
+      "bytes": 1501
     },
     {
       "path": "c-eff-parameterization.jsonld",
@@ -69,18 +69,10 @@
       "bytes": 1052
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1244
-    },
-    {
-      "path": "src/__pycache__/c_eff.cpython-311.pyc",
-      "bytes": 19008
-    },
-    {
       "path": "src/c_eff.py",
       "bytes": 13561
     }
   ],
-  "n_files": 16,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc-weak-lensing-phenomenology/ai_manifest.json
+++ b/docs/papers/efc/efc-weak-lensing-phenomenology/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2086
+      "bytes": 1986
     },
     {
       "path": "citations.bib",
@@ -89,10 +89,6 @@
       "bytes": 556
     },
     {
-      "path": "src/__pycache__/efc_weak_lensing.cpython-311.pyc",
-      "bytes": 20742
-    },
-    {
       "path": "src/efc_weak_lensing.py",
       "bytes": 16528
     },
@@ -105,6 +101,6 @@
       "bytes": 4816
     }
   ],
-  "n_files": 21,
+  "n_files": 20,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_boss_bao_cobaya_research_note/ai_manifest.json
+++ b/docs/papers/efc/efc_boss_bao_cobaya_research_note/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1716
+      "bytes": 1527
     },
     {
       "path": "bao_cobaya.jsonld",
@@ -65,18 +65,10 @@
       "bytes": 288
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 528
-    },
-    {
-      "path": "src/__pycache__/bao_cobaya_test.cpython-311.pyc",
-      "bytes": 10775
-    },
-    {
       "path": "src/bao_cobaya_test.py",
       "bytes": 6574
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_des_y6_validation/ai_manifest.json
+++ b/docs/papers/efc/efc_des_y6_validation/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1610
+      "bytes": 1420
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 477
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 637
-    },
-    {
-      "path": "src/__pycache__/des_y6_validation.cpython-311.pyc",
-      "bytes": 8307
-    },
-    {
       "path": "src/des_y6_validation.py",
       "bytes": 3868
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_formal_spec/ai_manifest.json
+++ b/docs/papers/efc/efc_formal_spec/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1462
+      "bytes": 1368
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 561
     },
     {
-      "path": "src/__pycache__/efc_formal.cpython-311.pyc",
-      "bytes": 13549
-    },
-    {
       "path": "src/efc_formal.py",
       "bytes": 9556
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_index.json
+++ b/docs/papers/efc/efc_index.json
@@ -1,15 +1,109 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "root": "docs/papers/efc",
   "papers": [
+    {
+      "id": "efc-four-channel-consistency-test",
+      "path": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
+      "type": "paper"
+    },
     {
       "id": "AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology",
       "path": "AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology",
       "type": "paper"
     },
     {
+      "id": "A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters",
+      "path": "A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters",
+      "type": "paper"
+    },
+    {
+      "id": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes",
+      "path": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes",
+      "type": "paper"
+    },
+    {
       "id": "CEM-Consciousness-Ego-Mirror",
       "path": "CEM-Consciousness-Ego-Mirror",
+      "type": "paper"
+    },
+    {
+      "id": "cmb-thermodynamic-interpretation",
+      "path": "CMB-Thermodynamic-Interpretation",
+      "type": "null_test_framework"
+    },
+    {
+      "id": "Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling",
+      "path": "Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling",
+      "type": "paper"
+    },
+    {
+      "id": "Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge",
+      "path": "Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge",
+      "type": "paper"
+    },
+    {
+      "id": "efc-regime-transition-test",
+      "path": "Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test",
+      "type": "paper"
+    },
+    {
+      "id": "ebe-core-lock",
+      "path": "Core-Lock",
+      "type": "paper"
+    },
+    {
+      "id": "cosmological-growth-constraints-lambda-locked",
+      "path": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity",
+      "type": "technical_note",
+      "companion": "discrete-entropic-gravity-cubic-graph",
+      "validation": {
+        "status": "stress_test_passed",
+        "regime": "L1-L2",
+        "lambda_locked_viable": true,
+        "sub_hubble_viable": false
+      }
+    },
+    {
+      "id": "Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints",
+      "path": "Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints",
+      "type": "paper"
+    },
+    {
+      "id": "Density_of_States_of_Gravitationally",
+      "path": "Density_of_States_of_Gravitationally",
+      "type": "paper"
+    },
+    {
+      "id": "Derivation_of_the_Entropy_Production",
+      "path": "Derivation_of_the_Entropy_Production",
+      "type": "paper"
+    },
+    {
+      "id": "Directional_Lensing_Residuals",
+      "path": "Directional_Lensing_Residuals",
+      "type": "paper"
+    },
+    {
+      "id": "discrete-entropic-gravity-cubic-graph",
+      "path": "Discrete_Entropic_Gravity_on_a_Cubic_Graph_Emergent_Newton_and_MOND_Regimes_with_Λ-Locked_Screening",
+      "type": "technical_note",
+      "doi": "10.6084/m9.figshare.31348411",
+      "validation": {
+        "status": "kill_tests_passed",
+        "regime": "L1-L2",
+        "kill_tests": 5,
+        "structural_departures": 1
+      }
+    },
+    {
+      "id": "Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis",
+      "path": "Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis",
+      "type": "paper"
+    },
+    {
+      "id": "ebe-core-principles",
+      "path": "EBE-Core-Principles",
       "type": "paper"
     },
     {
@@ -28,8 +122,28 @@
       "type": "paper"
     },
     {
+      "id": "EFC-Bridging-Scales-FEP",
+      "path": "EFC-Bridging-Scales-FEP",
+      "type": "EFC-Paper"
+    },
+    {
       "id": "EFC-CMB-Thermodynamic-Gradient",
       "path": "EFC-CMB-Thermodynamic-Gradient",
+      "type": "paper"
+    },
+    {
+      "id": "EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2",
+      "path": "EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2",
+      "type": "paper"
+    },
+    {
+      "id": "efc-c-cognitive-entropy-gradients-v2",
+      "path": "EFC-C_Cognitive_Entropy_Gradients_v2",
+      "type": "quantitative_prediction"
+    },
+    {
+      "id": "efc-c-consciousness-field-resonance",
+      "path": "EFC-C_Consciousness_Field_Resonance",
       "type": "paper"
     },
     {
@@ -76,6 +190,11 @@
       "id": "EFC-Grid-Model-Entropic-Dynamics",
       "path": "EFC-Grid-Model-Entropic-Dynamics",
       "type": "paper"
+    },
+    {
+      "id": "EFC-H0-S8-Tensions",
+      "path": "EFC-H0-S8-Tensions",
+      "type": "EFC-Paper"
     },
     {
       "id": "EFC-How-Does-Balance-Shape-Universal-Structures",
@@ -138,6 +257,21 @@
       "type": "paper"
     },
     {
+      "id": "efc-phenomenology-desi-dr2-bao",
+      "path": "EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis",
+      "type": "technical_note"
+    },
+    {
+      "id": "EFC-R-SPARC-Regime-Validity",
+      "path": "EFC-R-SPARC-Regime-Validity",
+      "type": "EFC-Paper"
+    },
+    {
+      "id": "efc-regime-transition-framework",
+      "path": "EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology",
+      "type": "theoretical_framework"
+    },
+    {
       "id": "EFC-Subhypothesis-Light-Speed-Limit",
       "path": "EFC-Subhypothesis-Light-Speed-Limit",
       "type": "paper"
@@ -198,9 +332,301 @@
       "type": "paper"
     },
     {
+      "id": "efclass-sign-structure",
+      "path": "EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation",
+      "type": "analytical_proof"
+    },
+    {
+      "id": "efc-closure-conjectures",
+      "path": "EFC_Closure_Conjectures",
+      "type": "theoretical_conjecture"
+    },
+    {
+      "id": "efc-cosmic-dipole",
+      "path": "EFC_Cosmic_Dipole_Working_Note",
+      "type": "paper"
+    },
+    {
+      "id": "efc-entropy-budget",
+      "path": "EFC_Entropy_Budget_Working_Note",
+      "type": "paper"
+    },
+    {
+      "id": "efc-gradient-coupled-grid-action",
+      "path": "EFC_Gradient_Coupled_Grid_Action",
+      "type": "paper"
+    },
+    {
+      "id": "efc-ontological-foundations",
+      "path": "EFC_Ontological_Foundations",
+      "type": "paper"
+    },
+    {
+      "id": "efc-phase3-sparc-validation",
+      "path": "EFC_Phase_3__SPARC_Validation",
+      "type": "empirical_validation"
+    },
+    {
+      "id": "EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction",
+      "path": "EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction",
+      "type": "paper"
+    },
+    {
+      "id": "EFC_v1_3_PPN_Recovery_via_Density_Saturation",
+      "path": "EFC_v1_3_PPN_Recovery_via_Density_Saturation",
+      "type": "paper"
+    },
+    {
+      "id": "efc-empirical-validation-cluster-rotation",
+      "path": "Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves",
+      "type": "empirical_analysis"
+    },
+    {
+      "id": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
+      "path": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
+      "type": "observational",
+      "doi": "10.6084/m9.figshare.31215613",
+      "validation": {
+        "status": "completed",
+        "regime": "L1-L2",
+        "efc_d": true
+      }
+    },
+    {
+      "id": "Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1",
+      "path": "Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1",
+      "type": "paper"
+    },
+    {
+      "id": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
+      "path": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
+      "type": "formal",
+      "validation": {
+        "status": "validated",
+        "regime": "L1-L2",
+        "efc_d": true
+      }
+    },
+    {
+      "id": "efc-desi-dr2-bao",
+      "path": "Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation",
+      "type": "empirical_validation"
+    },
+    {
+      "id": "foundations-efc-regime-architecture",
+      "path": "Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism",
+      "type": "foundational_framework"
+    },
+    {
+      "id": "From_Grid_Microphysics_to_the_Radial_Acceleration",
+      "path": "From_Grid_Microphysics_to_the_Radial_Acceleration",
+      "type": "paper"
+    },
+    {
+      "id": "Homo_Fluxus",
+      "path": "Homo_Fluxus",
+      "type": "paper"
+    },
+    {
+      "id": "ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions",
+      "path": "ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions",
+      "type": "paper"
+    },
+    {
+      "id": "isw-cross-correlation-desi-dr1",
+      "path": "ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers",
+      "type": "paper"
+    },
+    {
+      "id": "kt3b-cross-regime-measurement-failure",
+      "path": "KT3b_CrossRegime_Measurement_Failure_DOI",
+      "type": "null result + methodological diagnosis"
+    },
+    {
+      "id": "l0-l3-regime-architecture",
+      "path": "L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism",
+      "type": "foundational_framework"
+    },
+    {
+      "id": "Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients",
+      "path": "Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients",
+      "type": "research-article"
+    },
+    {
+      "id": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients",
+      "path": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients",
+      "type": "paper"
+    },
+    {
+      "id": "multi-epoch-growth-rate-test-efc",
+      "path": "Multi_epoch_Growth_Rate_Test_of_EFC",
+      "type": "multi-epoch validation, null result"
+    },
+    {
+      "id": "Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems",
+      "path": "Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems",
+      "type": "paper"
+    },
+    {
+      "id": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence",
+      "path": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence",
+      "type": "paper"
+    },
+    {
+      "id": "efc-perturbation-sigma8-suppression",
+      "path": "Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications",
+      "type": "perturbation_analysis"
+    },
+    {
+      "id": "Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12",
+      "path": "Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12",
+      "type": "paper"
+    },
+    {
+      "id": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
+      "path": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
+      "type": "formal",
+      "doi": "10.6084/m9.figshare.31211437"
+    },
+    {
+      "id": "regime-based-world-modeling",
+      "path": "Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System",
+      "type": "paper"
+    },
+    {
+      "id": "Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity",
+      "path": "Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity",
+      "type": "paper"
+    },
+    {
+      "id": "regime-dependent-growth-enhancement-fugaku-desi",
+      "path": "Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
+      "type": "empirical_analysis"
+    },
+    {
+      "id": "Regime_Locked_Measurement",
+      "path": "Regime_Locked_Measurement",
+      "type": "paper"
+    },
+    {
+      "id": "regime-structure-entropic-flow-ontology",
+      "path": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models",
+      "type": "foundational_framework",
+      "companions": [
+        "discrete-entropic-gravity-cubic-graph",
+        "cosmological-growth-constraints-lambda-locked"
+      ],
+      "validation": {
+        "status": "framework_established",
+        "regime": "L0-L2",
+        "regimes_exhaustive": true,
+        "lambda_dual_role": true
+      }
+    },
+    {
+      "id": "Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3",
+      "path": "Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3",
+      "type": "paper"
+    },
+    {
+      "id": "efc-growth-sector-robustness",
+      "path": "Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel",
+      "type": "robustness_analysis"
+    },
+    {
+      "id": "structural-constraints-cluster-merger",
+      "path": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry",
+      "type": "constraint_study"
+    },
+    {
+      "id": "structural-coherence-evaluation",
+      "path": "Structural_Coherence_Evaluation_for_Physical_Theories",
+      "type": "paper"
+    },
+    {
+      "id": "symbiosis_method",
+      "path": "Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking",
+      "type": "paper"
+    },
+    {
+      "id": "efc-cmb-constraints-null-results",
+      "path": "Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results",
+      "type": "constraint_analysis"
+    },
+    {
+      "id": "efc-cmb-localization",
+      "path": "Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier",
+      "type": "localization_analysis"
+    },
+    {
+      "id": "rcmp-measurement-principle",
+      "path": "The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics",
+      "type": "paper"
+    },
+    {
+      "id": "hubble-tension-regime-mismatch",
+      "path": "The_Hubble_Tension_as_Regime_Mismatch",
+      "type": "research_paper"
+    },
+    {
+      "id": "Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic",
+      "path": "Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic",
+      "type": "paper"
+    },
+    {
+      "id": "efc-h0-unification",
+      "path": "Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification",
+      "type": "research_paper"
+    },
+    {
+      "id": "WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
+      "path": "WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
+      "type": "observational",
+      "doi": "10.6084/m9.figshare.31215259",
+      "validation": {
+        "status": "completed",
+        "regime": "L2"
+      }
+    },
+    {
+      "id": "wp4-boss-transfer-validation",
+      "path": "WP4_BOSS_transfer_validation",
+      "type": "post-hoc validation"
+    },
+    {
+      "id": "WP4_BOSS_validation",
+      "path": "WP4_BOSS_validation",
+      "type": "paper"
+    },
+    {
       "id": "ai_workflow_framework",
       "path": "ai_workflow_framework",
       "type": "paper"
+    },
+    {
+      "id": "bullet-cluster-efc",
+      "path": "bullet_cluster_efc",
+      "type": "consistency check, analytical confrontation, pre-registered test pending"
+    },
+    {
+      "id": "c-eff-parameterization",
+      "path": "c_eff_parameterization",
+      "type": "parameterization"
+    },
+    {
+      "id": "efc-weak-lensing-phenomenology",
+      "path": "efc-weak-lensing-phenomenology",
+      "type": "theoretical_framework"
+    },
+    {
+      "id": "efc-boss-bao-cobaya-research-note",
+      "path": "efc_boss_bao_cobaya_research_note",
+      "type": "Research Note"
+    },
+    {
+      "id": "efc-des-y6-validation",
+      "path": "efc_des_y6_validation",
+      "type": "validation-update"
     },
     {
       "id": "efc_formal_spec",
@@ -218,9 +644,49 @@
       "type": "paper"
     },
     {
+      "id": "efc-state-vs-stageIII",
+      "path": "efc_state_vs_stageIII",
+      "type": "Methodology note / Validation update / Theory-data interface framework"
+    },
+    {
+      "id": "31061872",
+      "path": "energy-flow-cosmology-and-regime-dependent-structure-formation",
+      "type": "paper"
+    },
+    {
+      "id": "entropy-bounded-empiricism-ebe-sparc175",
+      "path": "entropy-bounded-empiricism-EBE-SPARC175-complete-documentation",
+      "type": "empirical_analysis"
+    },
+    {
+      "id": "cosmos-galaxy-abundances-z6",
+      "path": "observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web",
+      "type": "observational_analysis"
+    },
+    {
+      "id": "rsd-to-clusters",
+      "path": "paper_rsd_to_clusters",
+      "type": "paper"
+    },
+    {
+      "id": "regime-dependent-breakdown-lcdm",
+      "path": "regime-dependent-breakdown-of-LCDM-across-cosmic-time",
+      "type": "statistical_analysis"
+    },
+    {
+      "id": "efc-regime-consistency-lya-bao-rsd-sce",
+      "path": "regime_consistency_lya_bao_rsd_sce",
+      "type": "paper"
+    },
+    {
       "id": "symbiotic-insight-framework",
       "path": "symbiotic-insight-framework",
       "type": "paper"
+    },
+    {
+      "id": "validity-aware-ai",
+      "path": "validity-aware-ai",
+      "type": "architectural_framework"
     },
     {
       "id": "variable-light-s0-s1",
@@ -228,80 +694,14 @@
       "type": "paper"
     },
     {
-      "id": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
-      "path": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
-      "type": "observational",
-      "doi": "10.6084/m9.figshare.31215613",
-      "validation": {
-        "status": "completed",
-        "regime": "L1-L2",
-        "efc_d": true
-      }
+      "id": "efc-void-isw-signflip",
+      "path": "void_isw_signflip_v2.1_final",
+      "type": "paper"
     },
     {
-      "id": "WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
-      "path": "WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
-      "type": "observational",
-      "doi": "10.6084/m9.figshare.31215259",
-      "validation": {
-        "status": "completed",
-        "regime": "L2"
-      }
-    },
-    {
-      "id": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
-      "path": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
-      "type": "formal",
-      "doi": "10.6084/m9.figshare.31211437"
-    },
-    {
-      "id": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
-      "path": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
-      "type": "formal",
-      "validation": {
-        "status": "validated",
-        "regime": "L1-L2",
-        "efc_d": true
-      }
-    },
-    {
-      "id": "discrete-entropic-gravity-cubic-graph",
-      "path": "Discrete_Entropic_Gravity_on_a_Cubic_Graph_Emergent_Newton_and_MOND_Regimes_with_Λ-Locked_Screening",
-      "type": "technical_note",
-      "doi": "10.6084/m9.figshare.31348411",
-      "validation": {
-        "status": "kill_tests_passed",
-        "regime": "L1-L2",
-        "kill_tests": 5,
-        "structural_departures": 1
-      }
-    },
-    {
-      "id": "cosmological-growth-constraints-lambda-locked",
-      "path": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity",
-      "type": "technical_note",
-      "companion": "discrete-entropic-gravity-cubic-graph",
-      "validation": {
-        "status": "stress_test_passed",
-        "regime": "L1-L2",
-        "lambda_locked_viable": true,
-        "sub_hubble_viable": false
-      }
-    },
-    {
-      "id": "regime-structure-entropic-flow-ontology",
-      "path": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models",
-      "type": "foundational_framework",
-      "companions": [
-        "discrete-entropic-gravity-cubic-graph",
-        "cosmological-growth-constraints-lambda-locked"
-      ],
-      "validation": {
-        "status": "framework_established",
-        "regime": "L0-L2",
-        "regimes_exhaustive": true,
-        "lambda_dual_role": true
-      }
+      "id": "ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology",
+      "path": "ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology",
+      "type": "paper"
     }
   ]
 }

--- a/docs/papers/efc/efc_master/ai_manifest.json
+++ b/docs/papers/efc/efc_master/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1432
+      "bytes": 1333
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 610
     },
     {
-      "path": "src/__pycache__/efc_master_spec.cpython-311.pyc",
-      "bytes": 11464
-    },
-    {
       "path": "src/efc_master_spec.py",
       "bytes": 7949
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_master_v1/ai_manifest.json
+++ b/docs/papers/efc/efc_master_v1/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1463
+      "bytes": 1361
     },
     {
       "path": "citations.bib",
@@ -65,14 +65,10 @@
       "bytes": 525
     },
     {
-      "path": "src/__pycache__/efc_master_v1_spec.cpython-311.pyc",
-      "bytes": 10174
-    },
-    {
       "path": "src/efc_master_v1_spec.py",
       "bytes": 6630
     }
   ],
-  "n_files": 14,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_state_vs_stageIII/ai_manifest.json
+++ b/docs/papers/efc/efc_state_vs_stageIII/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1615
+      "bytes": 1427
     },
     {
       "path": "citations.bib",
@@ -61,14 +61,6 @@
       "bytes": 310
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 529
-    },
-    {
-      "path": "src/__pycache__/state_vs_stage3.cpython-311.pyc",
-      "bytes": 9042
-    },
-    {
       "path": "src/state_vs_stage3.py",
       "bytes": 7183
     },
@@ -77,6 +69,6 @@
       "bytes": 1376
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/energy-flow-cosmology-and-regime-dependent-structure-formation/ai_manifest.json
+++ b/docs/papers/efc/energy-flow-cosmology-and-regime-dependent-structure-formation/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2198
+      "bytes": 2008
     },
     {
       "path": "citations.bib",
@@ -81,14 +81,6 @@
       "bytes": 672
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 903
-    },
-    {
-      "path": "src/__pycache__/regime_structure.cpython-311.pyc",
-      "bytes": 11672
-    },
-    {
       "path": "src/regime_structure.py",
       "bytes": 7914
     },
@@ -97,6 +89,6 @@
       "bytes": 2850
     }
   ],
-  "n_files": 20,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/ai_manifest.json
+++ b/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2154
+      "bytes": 2058
     },
     {
       "path": "citations.bib",
@@ -81,10 +81,6 @@
       "bytes": 441
     },
     {
-      "path": "src/__pycache__/ebe_sparc175.cpython-311.pyc",
-      "bytes": 12661
-    },
-    {
       "path": "src/ebe_sparc175.py",
       "bytes": 7404
     },
@@ -93,6 +89,6 @@
       "bytes": 8658
     }
   ],
-  "n_files": 19,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/ai_manifest.json
+++ b/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/ai_manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2912
+      "bytes": 2721
     },
     {
       "path": "analysis_code.py",
@@ -114,14 +114,6 @@
       "bytes": 581
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 855
-    },
-    {
-      "path": "src/__pycache__/cosmos_abundances.cpython-311.pyc",
-      "bytes": 11825
-    },
-    {
       "path": "src/cosmos_abundances.py",
       "bytes": 6795
     },
@@ -130,6 +122,6 @@
       "bytes": 921593
     }
   ],
-  "n_files": 28,
+  "n_files": 26,
   "n_pdfs": 2
 }

--- a/docs/papers/efc/paper_rsd_to_clusters/ai_manifest.json
+++ b/docs/papers/efc/paper_rsd_to_clusters/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1642
+      "bytes": 1454
     },
     {
       "path": "citations.bib",
@@ -65,18 +65,10 @@
       "bytes": 324
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 554
-    },
-    {
-      "path": "src/__pycache__/rsd_to_clusters.cpython-311.pyc",
-      "bytes": 9086
-    },
-    {
       "path": "src/rsd_to_clusters.py",
       "bytes": 7016
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/ai_manifest.json
+++ b/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1959
+      "bytes": 1772
     },
     {
       "path": "citations.bib",
@@ -77,18 +77,10 @@
       "bytes": 655
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 813
-    },
-    {
-      "path": "src/__pycache__/lcdm_breakdown.cpython-311.pyc",
-      "bytes": 8710
-    },
-    {
       "path": "src/lcdm_breakdown.py",
       "bytes": 4958
     }
   ],
-  "n_files": 18,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/regime_consistency_lya_bao_rsd_sce/ai_manifest.json
+++ b/docs/papers/efc/regime_consistency_lya_bao_rsd_sce/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1845
+      "bytes": 1653
     },
     {
       "path": "citations.bib",
@@ -69,18 +69,10 @@
       "bytes": 359
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 590
-    },
-    {
-      "path": "src/__pycache__/regime_consistency.cpython-311.pyc",
-      "bytes": 17924
-    },
-    {
       "path": "src/regime_consistency.py",
       "bytes": 13189
     }
   ],
-  "n_files": 16,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/symbiotic-insight-framework/ai_manifest.json
+++ b/docs/papers/efc/symbiotic-insight-framework/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1717
+      "bytes": 1630
     },
     {
       "path": "citations.bib",
@@ -61,10 +61,6 @@
       "bytes": 423
     },
     {
-      "path": "src/__pycache__/sif.cpython-311.pyc",
-      "bytes": 11739
-    },
-    {
       "path": "src/sif.py",
       "bytes": 7177
     },
@@ -81,6 +77,6 @@
       "bytes": 4236
     }
   ],
-  "n_files": 16,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/validity-aware-ai/ai_manifest.json
+++ b/docs/papers/efc/validity-aware-ai/ai_manifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2994
+      "bytes": 2507
     },
     {
       "path": "citations.bib",
@@ -108,26 +108,6 @@
       "bytes": 1434
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1563
-    },
-    {
-      "path": "src/__pycache__/ebe_filter.cpython-311.pyc",
-      "bytes": 12095
-    },
-    {
-      "path": "src/__pycache__/entropy_measures.cpython-311.pyc",
-      "bytes": 12626
-    },
-    {
-      "path": "src/__pycache__/regime_classifier.cpython-311.pyc",
-      "bytes": 9714
-    },
-    {
-      "path": "src/__pycache__/response_protocols.cpython-311.pyc",
-      "bytes": 13144
-    },
-    {
       "path": "src/ebe_filter.py",
       "bytes": 9307
     },
@@ -148,6 +128,6 @@
       "bytes": 646
     }
   ],
-  "n_files": 32,
+  "n_files": 27,
   "n_pdfs": 0
 }

--- a/docs/papers/efc/variable-light-s0-s1/ai_manifest.json
+++ b/docs/papers/efc/variable-light-s0-s1/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1641
+      "bytes": 1454
     },
     {
       "path": "citations.bib",
@@ -53,14 +53,6 @@
       "bytes": 612
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 766
-    },
-    {
-      "path": "src/__pycache__/variable_light.cpython-311.pyc",
-      "bytes": 9504
-    },
-    {
       "path": "src/variable_light.py",
       "bytes": 6367
     },
@@ -77,6 +69,6 @@
       "bytes": 6222
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/void_isw_signflip_v2.1_final/ai_manifest.json
+++ b/docs/papers/efc/void_isw_signflip_v2.1_final/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1645
+      "bytes": 1462
     },
     {
       "path": "citations.bib",
@@ -53,14 +53,6 @@
       "bytes": 968
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 1188
-    },
-    {
-      "path": "src/__pycache__/void_isw.cpython-311.pyc",
-      "bytes": 14996
-    },
-    {
       "path": "src/void_isw.py",
       "bytes": 11269
     },
@@ -77,6 +69,6 @@
       "bytes": 335641
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology/ai_manifest.json
+++ b/docs/papers/efc/ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1843
+      "bytes": 1652
     },
     {
       "path": "cdm-as-a-special-case-of-energy-flow-cosmology.jsonld",
@@ -61,14 +61,6 @@
       "bytes": 713
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 879
-    },
-    {
-      "path": "src/__pycache__/lcdm_special_case.cpython-311.pyc",
-      "bytes": 28644
-    },
-    {
       "path": "src/lcdm_special_case.py",
       "bytes": 21828
     },
@@ -77,6 +69,6 @@
       "bytes": 327145
     }
   ],
-  "n_files": 15,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/validation-ledger/data/ledger.json
+++ b/docs/validation-ledger/data/ledger.json
@@ -1,7 +1,7 @@
 {
   "name": "EFC Validation Ledger",
-  "version": "3.0",
-  "generated_at": "2026-04-07T19:40:08Z",
+  "version": "4.4",
+  "generated_at": "2026-04-08T00:00:00Z",
   "generator": "Symbiose AGI Validation Pipeline",
   "stats": {
     "physics_test": 34,

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Energy-Flow Cosmology (EFC) - AI Navigation Guide
-# Version: 3.1
-# Last Updated: 2026-04-06
+# Version: 3.2
+# Last Updated: 2026-04-08
 # Format: Machine-readable with human comments
 
 ## IDENTITY
@@ -87,8 +87,8 @@ L3: S→1, μ→1+β, far future, structure saturation
 
 /auth/              → Origin, provenance, identity (START HERE)
 /theory/formal/     → LaTeX mathematical specifications
-/docs/papers/efc/   → 127 papers (127 with full 10-file AI-friendly packages, 100% coverage)
-/docs/public/       → Validation Ledger (v3.7), Master Spec
+/docs/papers/efc/   → 132 papers (132 with full 10-file AI-friendly packages, 100% coverage)
+/docs/public/       → Validation Ledger (v3.13), Master Spec
 /src/efc/           → Core Python library
 /pipelines/         → Graph-AQUAL pipeline + kill tests
 /schema/            → Ontology, JSON-LD contexts (20 files)


### PR DESCRIPTION
…sh docs

- validation-ledger/data/ledger.json: bump version 3.0 → 4.4 to fix C4 internal-versions drift warning (index.md already at v4.4)
- docs/papers/efc/efc_index.json: rebuild from 52 → 132 entries to match actual directory count; bump schema version 1.0 → 1.1
- docs/papers/efc/ai_friendly_index.json: regenerate (remove stale __pycache__ references, 132 packages, 0 new files)
- 130 ai_manifest.json files: regenerate to drop __pycache__ entries and correct n_files counts
- README.md: sync paper counts 129 → 132, ledger badge v3.10 → v3.13
- AGENTS.md: sync paper count 130 → 132, ledger v4.2/v3.11 → v4.4/v3.13
- llms.txt: sync paper count 127 → 132, ledger v3.7 → v3.13, metadata version 3.1 → 3.2, date 2026-04-06 → 2026-04-08
- codemeta.json: bump version 3.7.0 → 3.13.0, date → 2026-04-08
- CITATION.cff: bump version 3.7 → 3.13, date → 2026-04-08

efc_verify.py now reports 132 paper dirs · 0 errors · 0 warnings. efc_gen_ai_friendly.py: 132 packages · 0 new files.

https://claude.ai/code/session_018JxK7ftWv9VAWbtt66AcnR