### PR TITLE
feat: Background NoGo Theorem package + full repo propagation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ repository: github.com/supertedai/EFC
 license: CC-BY-4.0
 core_principle: "Energy flows along entropy gradients"
 validation_ledger: v4.7 (internal) / v3.16 (public HTML)
-ai_packages: 135 (100% coverage)
+ai_packages: 136 (100% coverage)
 stage: non_rejectable_model (global verdict OPEN)
 maintenance: scripts/maintenance/ (auto-run by SessionStart hook + CI)
 ```
@@ -57,6 +57,7 @@ EFC is a unified thermodynamic framework where **energy flows along entropy grad
 |------------|---------------|
 | Galaxy rotation | Entropy gradient coupling (no dark matter particles) |
 | Cosmic acceleration | Thermodynamic expansion (no dark energy substance) |
+| Background H(z) no-go | Sign lemma: ΔE² ≤ 0 → background cannot suppress σ₈ → perturbation sector only |
 | Structure formation | Regime-dependent growth via R(k,S) |
 | S₈ tension | L1→L2 regime transition |
 | Brain functional variability | Local degree heterogeneity → entropy gradient (r ≈ −0.97) |
@@ -121,7 +122,7 @@ EFC/
 ├── theory/
 │   └── formal/         # LaTeX: S, D, R, H, C0 models
 ├── docs/
-│   ├── papers/efc/     # 127 papers (127 with AI-friendly packages, 100%)
+│   ├── papers/efc/     # 136 papers (136 with AI-friendly packages, 100%)
 │   └── public/         # Validation Ledger (v3.8), Master Spec
 ├── src/efc/            # Core Python library
 ├── pipelines/          # Graph-AQUAL pipeline + kill tests
@@ -138,9 +139,9 @@ EFC/
 
 ---
 
-## AI-Friendly Paper Packages (127)
+## AI-Friendly Paper Packages (136)
 
-All 127 papers have full executable Python packages (`src/`, `data/`, `examples/`):
+All 136 papers have full executable Python packages (`src/`, `data/`, `examples/`):
 
 ### Consolidation
 | Paper | Module | DOI |
@@ -171,6 +172,7 @@ All 127 papers have full executable Python packages (`src/`, `data/`, `examples/
 | Covariant EFT | `covariant_eft.py` | 31878334 |
 | EFC Relativistic Action | `efc_relativistic_action.py` | 31876324 |
 | CMB Localization / Lensing Barrier | `cmb_localization.py` | 31368433 |
+| **Background No-Go Theorem** | `background_nogo.py` | 31333414 |
 | Discrete Entropic Gravity (Graph-AQUAL) | `discrete_gravity.py` | 31348411 |
 | Double-Slit Grid Resolution | `double_slit_grid.py` | — |
 | Minimal EFC EFT Ansatz | `minimal_eft.py` | — |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![ORCID](https://img.shields.io/badge/ORCID-0009--0002--4860--5095-green)](https://orcid.org/0009-0002-4860-5095)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Validation Ledger](https://img.shields.io/badge/Validation_Ledger-v3.16-orange)](./docs/public/EFC_Validation_Ledger.html)
-[![AI Packages](https://img.shields.io/badge/AI_Packages-135-brightgreen)](#ai-friendly-paper-packages)
+[![AI Packages](https://img.shields.io/badge/AI_Packages-136-brightgreen)](#ai-friendly-paper-packages)
 
 > **NEW (April 9, 2026)**: **[EFC White Paper Series (Parts 1-4)](./docs/papers/efc/efc_white_paper_part_1_to_4/)** — Canonical four-part reference. [Part 1](https://doi.org/10.6084/m9.figshare.31970886): Recovery conditions (EFC ⊃ ΛCDM). [Part 2](https://doi.org/10.6084/m9.figshare.31970898): Field equations & observable mapping. [Part 3](https://doi.org/10.6084/m9.figshare.31970904): Validation ledger & falsification protocol (102 tests, 5 kill criteria). [Part 4](https://doi.org/10.6084/m9.figshare.31970907): Regime susceptibility T(S) & dynamical dark energy.
 
@@ -33,8 +33,8 @@
 | **Theory Site** | [energyflow-cosmology.com](https://energyflow-cosmology.com/) |
 | **AI Navigation** | [`llms.txt`](./llms.txt) / [`AGENTS.md`](./AGENTS.md) |
 | **Validation Ledger** | [`EFC_Validation_Ledger.html`](./docs/public/EFC_Validation_Ledger.html) (v3.16 public / v4.7 internal) |
-| **Papers** | 135 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
-| **AI Packages** | 135 with executable Python + structured data (100% coverage) |
+| **Papers** | 136 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
+| **AI Packages** | 136 with executable Python + structured data (100% coverage) |
 | **Stage** | **Non-rejectable model** — Δχ² ≤ 0 across all probes; global verdict OPEN |
 | **Validation Reports** | EFC-VAL-2026-002 through 007 (6 hand-curated 10/10 packages) |
 | **Consolidation** | [ΛCDM as Special Case of EFC](https://doi.org/10.6084/m9.figshare.31943361) — single reference for full programme |
@@ -64,6 +64,7 @@
 ```
 - **β** = coupling constant (~0.16 from unified analysis)
 - **S(a)** = entropy field (0 at CMB → 1 at late times)
+- **No-Go**: Background-level H(z) modification cannot suppress σ₈ (ΔE² ≤ 0); all growth effects enter via perturbation sector ([31333414](https://doi.org/10.6084/m9.figshare.31333414))
 
 ### Regime Response Surface
 ```
@@ -222,6 +223,7 @@ Pre-registered conditions that would falsify EFC sectors. F7 (η=1) formally **P
 |-------|-----|------------|
 | Density Saturation PPN Recovery | [31244827](https://doi.org/10.6084/m9.figshare.31244827) | Solar System screening |
 | EFCLASS Sign Structure | [31333414](https://doi.org/10.6084/m9.figshare.31333414) | ΔE²≤0 background exclusion |
+| **Background No-Go Theorem** | [31333414](https://doi.org/10.6084/m9.figshare.31333414) | Three-pillar proof: sign lemma + CLASS + CMB+BAO → background sector empty |
 | Perturbation-Level σ₈ Suppression | [31333600](https://doi.org/10.6084/m9.figshare.31333600) | μ₀=0.85, 73% gap closure |
 | Systematic CMB Localization | [31368433](https://doi.org/10.6084/m9.figshare.31368433) | α≈0 under CMB+BAO |
 | Discrete Entropic Gravity (Graph-AQUAL) | [31348411](https://doi.org/10.6084/m9.figshare.31348411) | Newton + MOND + Λ-screening |
@@ -260,13 +262,13 @@ Pre-registered conditions that would falsify EFC sectors. F7 (η=1) formally **P
 | Core Lock (Consistency Enforcement) | [31223503](https://doi.org/10.6084/m9.figshare.31223503) |
 | ISW Consistency Audit | [31329082](https://doi.org/10.6084/m9.figshare.31329082) |
 
-> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 134 papers, all with AI-friendly packages (100% coverage). Six hand-curated 10/10 validation reports with full reproducible pipelines.
+> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 136 papers, all with AI-friendly packages (100% coverage). Six hand-curated 10/10 validation reports with full reproducible pipelines.
 
 ---
 
 ## AI-Friendly Paper Packages
 
-All 134 papers have AI-friendly packages (100% coverage as of April 2026). Six hand-curated 10/10 validation reports with full reproducible pipelines:
+All 136 papers have AI-friendly packages (100% coverage as of April 2026). Six hand-curated 10/10 validation reports with full reproducible pipelines:
 
 | Package | Module | Key Functionality |
 |---------|--------|-------------------|

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/ai_manifest.json
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/ai_manifest.json
@@ -1,0 +1,76 @@
+{
+  "id": "efc-background-nogo-theorem",
+  "directory": "EFC_Background_NoGo_Theorem",
+  "title": "EFC Background NoGo Theorem",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "package_type": "ai-friendly-paper",
+  "schema_version": "1.0",
+  "generated": "2026-04-10",
+  "track": "Spor general",
+  "regimes": [],
+  "primary_pdf": null,
+  "all_pdfs": [],
+  "files": [
+    {
+      "path": "CITATION.cff",
+      "bytes": 1373
+    },
+    {
+      "path": "README.md",
+      "bytes": 9603
+    },
+    {
+      "path": "citations.bib",
+      "bytes": 2780
+    },
+    {
+      "path": "data/observational_constraints.json",
+      "bytes": 1989
+    },
+    {
+      "path": "data/sign_lemma_verification.json",
+      "bytes": 1380
+    },
+    {
+      "path": "efc-background-nogo-theorem.jsonld",
+      "bytes": 3419
+    },
+    {
+      "path": "examples/verify_nogo.py",
+      "bytes": 2723
+    },
+    {
+      "path": "index.json",
+      "bytes": 8097
+    },
+    {
+      "path": "metadata.json",
+      "bytes": 2884
+    },
+    {
+      "path": "schema.json",
+      "bytes": 3085
+    },
+    {
+      "path": "src/__init__.py",
+      "bytes": 578
+    },
+    {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 829
+    },
+    {
+      "path": "src/__pycache__/background_nogo.cpython-311.pyc",
+      "bytes": 7858
+    },
+    {
+      "path": "src/background_nogo.py",
+      "bytes": 5099
+    }
+  ],
+  "n_files": 14,
+  "n_pdfs": 0
+}

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,6 +1,6 @@
 {
   "generated": "2026-04-10",
-  "n_packages": 135,
+  "n_packages": 136,
   "packages": [
     {
       "name": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
@@ -606,6 +606,15 @@
       "primary_pdf": "efclass_companion_note.pdf",
       "created": [],
       "n_files": 13
+    },
+    {
+      "name": "EFC_Background_NoGo_Theorem",
+      "title": "EFC Background NoGo Theorem",
+      "track": "Spor general",
+      "regimes": [],
+      "primary_pdf": null,
+      "created": [],
+      "n_files": 14
     },
     {
       "name": "EFC_Closure_Conjectures",

--- a/docs/validation-ledger/data/evidence-register.json
+++ b/docs/validation-ledger/data/evidence-register.json
@@ -142,6 +142,11 @@
         "doi": "31224466",
         "name": "Density saturation mechanism",
         "category": "structural"
+      },
+      {
+        "doi": "31333414",
+        "name": "Background No-Go Theorem (sign lemma + CLASS + CMB+BAO → background sector empty)",
+        "category": "structural"
       }
     ]
   }

--- a/docs/validation-ledger/data/frontier-gaps.json
+++ b/docs/validation-ledger/data/frontier-gaps.json
@@ -4,6 +4,17 @@
   "generated_at": "2026-04-10T13:45:57Z",
   "gaps": [
     {
+      "question": "Can the EFC background coupling channel (β·T(a) modification to Friedmann equation) suppress σ₈ and resolve the S₈ tension?",
+      "domain": "efc_theory.background_sector",
+      "severity": "HIGH",
+      "status": "CLOSED_NOGO",
+      "approach": "Three-pillar proof: (1) Sign lemma ΔE²≤0 analytically, (2) CLASS v3.3.4 numerical verification, (3) Observational α→0 under CMB+BAO. Background sector is structurally excluded and observationally empty.",
+      "efc_prediction": "All late-time EFC effects must enter through perturbation sector (μ, Σ, η), not background H(z).",
+      "source": "EFC_Background_NoGo_Theorem (DOI: 31333414)",
+      "created_at": "2026-02-13T00:00:00+00:00",
+      "closed_at": "2026-04-10T00:00:00+00:00"
+    },
+    {
       "question": "Applying the 'inference_cluster_tng' module from domain 'unknown' to Bullet Cluster data should result in a chi2 value less than 2.0 within 30 days of testing.",
       "domain": "project.bullet cluster efc test",
       "severity": "MEDIUM",

--- a/docs/validation-ledger/index.md
+++ b/docs/validation-ledger/index.md
@@ -97,6 +97,8 @@ The Baryon Acoustic Oscillation data from BOSS DR12 and DESI Y1 are currently re
 
 EFC modifies late-time cosmology via a Hubble friction term: H(a) = H_ΛCDM(a) · [1 + α · g(a)], where α is the coupling strength and g(a) is a gate function activating at low redshift (z ≲ 2). This modification affects expansion history, growth of structure, and distance measures. The α parameter is constrained by joint fits to BAO, H(z), fσ₈, and Type Ia supernovae.
 
+**Background No-Go Theorem (DOI: [31333414](https://doi.org/10.6084/m9.figshare.31333414)):** The background coupling channel is structurally excluded for σ₈ suppression. Three independent proofs: (1) Sign lemma — ΔE²(z) ≤ 0 for all z > 0 under closure normalisation, implying H_EFC ≤ H_ΛCDM and enhanced (not suppressed) growth; (2) CLASS v3.3.4 verification — ΔH/H = −0.3% to −1.1%, negative everywhere; (3) Observational — α collapses to ≈0 under all Planck+BAO combinations. **All late-time EFC effects must enter through the perturbation sector (μ, Σ, η).**
+
 
 ### Autonomous MCMC Results
 

--- a/ecosystem.jsonld
+++ b/ecosystem.jsonld
@@ -11,7 +11,7 @@
   "url": "https://energyflow-cosmology.com/",
   "version": "3.16",
   "dateCreated": "2024-01-01",
-  "dateModified": "2026-04-09",
+  "dateModified": "2026-04-10",
   "license": "https://creativecommons.org/licenses/by/4.0/",
 
   "author": {
@@ -103,6 +103,13 @@
           "url": "https://doi.org/10.6084/m9.figshare.31970907"
         }
       ]
+    },
+    {
+      "@type": "ScholarlyArticle",
+      "name": "EFC Background No-Go Theorem",
+      "description": "Three-pillar proof that background-level Friedmann modification cannot suppress σ₈: sign lemma (ΔE² ≤ 0), CLASS verification, observational α-collapse under CMB+BAO. Redirects all EFC effects to perturbation sector.",
+      "identifier": "figshare:31333414",
+      "url": "https://doi.org/10.6084/m9.figshare.31333414"
     }
   ],
 

--- a/figshare/doi-map.json
+++ b/figshare/doi-map.json
@@ -231,6 +231,7 @@
     "figshare_id": 31333414,
     "title": "EFCLASS Sign Structure: Background Channel σ₈ Exclusion",
     "path": "docs/papers/efc/EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation",
+    "consolidation_package": "docs/papers/efc/EFC_Background_NoGo_Theorem",
     "url": "https://doi.org/10.6084/m9.figshare.31333414"
   },
   "10.6084/m9.figshare.31332730": {

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,7 @@ bridge_B2: ∇Ṡ_neural ↔ ∇²R(s,a) (neural → RLHF)
 ## EMPIRICAL CONSTRAINTS (2026)
 
 lcdm_special_case: ΛCDM is L0/L1 limit of EFC (Eq. 6: K(ρ)→∞, T(a)→0, ξ≫1)
+background_nogo: ΔE²(z) ≤ 0 ∀z>0 (sign lemma); background coupling enhances growth, cannot suppress σ₈; α→0 under CMB+BAO (structurally excluded)
 desi_dr2_alpha: -0.14 ± 0.21 (0.65σ from null, ΔAIC=+1.59, ΛCDM preferred in background)
 perturbation_valley: μ∈[0.93,0.96], Σ∈[1.03,1.07], η≠1
 beta: 0.16 (from unified BAO/SN/RSD analysis)
@@ -87,7 +88,7 @@ L3: S→1, μ→1+β, far future, structure saturation
 
 /auth/              → Origin, provenance, identity (START HERE)
 /theory/formal/     → LaTeX mathematical specifications
-/docs/papers/efc/   → 135 papers (135 with AI-friendly packages, 100% coverage)
+/docs/papers/efc/   → 136 papers (136 with AI-friendly packages, 100% coverage)
 /docs/public/       → Validation Ledger (v3.16), Master Spec
 /src/efc/           → Core Python library
 /pipelines/         → Graph-AQUAL pipeline + kill tests
@@ -101,7 +102,7 @@ L3: S→1, μ→1+β, far future, structure saturation
 /codemeta.json      → CodeMeta 2.0 metadata
 /ecosystem.jsonld   → Ecosystem linked data
 
-## AI-FRIENDLY PACKAGES (135 — 100% coverage)
+## AI-FRIENDLY PACKAGES (136 — 100% coverage)
 
 ### EFC White Paper Series (Canonical Reference)
 white-paper-part-1: src/recovery_limits.py, doi:31970886, Recovery Conditions & LCDM Limit
@@ -140,6 +141,7 @@ grid-microphysics: src/grid_microphysics.py, doi:31878760, classes: BoseEinstein
 covariant-eft: src/covariant_eft.py, doi:31878334, classes: CovEFT, GravWaveSpeed
 relativistic-action: src/efc_relativistic_action.py, doi:31876324
 cmb-localization: src/cmb_localization.py, doi:31368433
+background-nogo: src/background_nogo.py, doi:31333414, classes: SignLemma, BackgroundNoGo, result: ΔE²≤0 → background sector empty → perturbation only
 discrete-gravity: src/discrete_gravity.py, doi:31348411, classes: GraphAQUAL
 
 ### Each package structure:


### PR DESCRIPTION
## Summary

- **New AI-friendly package**: `EFC_Background_NoGo_Theorem/` — three-pillar proof that background H(z) modification cannot suppress σ₈ (sign lemma + CLASS + CMB+BAO)
- **Full repo propagation**: README, AGENTS.md, llms.txt, ecosystem.jsonld, doi-map, evidence-register, frontier-gaps, validation-ledger index — all updated with NoGo references and paper count 135→136
- **Stage-IV Roadmap** created and cross-linked across all public HTML documents (from earlier commits on this branch)

## Test plan

- [ ] Verify `efc_verify.py` passes (136 packages, 0 errors)
- [ ] Confirm all cross-links resolve in public HTML docs
- [ ] Check ai_friendly_index.json includes EFC_Background_NoGo_Theorem entry

https://claude.ai/code/session_01E1gUzDjCufDHNWxNidYCSb