### PR TITLE
Add AI-friendly package for Scale-Localised Modified Gravity (doi:319…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ repository: github.com/supertedai/EFC
 license: CC-BY-4.0
 core_principle: "Energy flows along entropy gradients"
 validation_ledger: v4.7 (internal) / v3.16 (public HTML)
-ai_packages: 136 (100% coverage)
+ai_packages: 137 (100% coverage)
 stage: non_rejectable_model (global verdict OPEN)
 maintenance: scripts/maintenance/ (auto-run by SessionStart hook + CI)
 ```
@@ -122,7 +122,7 @@ EFC/
 ├── theory/
 │   └── formal/         # LaTeX: S, D, R, H, C0 models
 ├── docs/
-│   ├── papers/efc/     # 136 papers (136 with AI-friendly packages, 100%)
+│   ├── papers/efc/     # 137 papers (137 with AI-friendly packages, 100%)
 │   └── public/         # Validation Ledger (v3.8), Master Spec
 ├── src/efc/            # Core Python library
 ├── pipelines/          # Graph-AQUAL pipeline + kill tests
@@ -139,9 +139,9 @@ EFC/
 
 ---
 
-## AI-Friendly Paper Packages (136)
+## AI-Friendly Paper Packages (137)
 
-All 136 papers have full executable Python packages (`src/`, `data/`, `examples/`):
+All 137 papers have full executable Python packages (`src/`, `data/`, `examples/`):
 
 ### Consolidation
 | Paper | Module | DOI |
@@ -173,6 +173,7 @@ All 136 papers have full executable Python packages (`src/`, `data/`, `examples/
 | EFC Relativistic Action | `efc_relativistic_action.py` | 31876324 |
 | CMB Localization / Lensing Barrier | `cmb_localization.py` | 31368433 |
 | **Background No-Go Theorem** | `background_nogo.py` | 31333414 |
+| **Scale-Localised Modified Gravity** | `scale_localised_gravity.py` | 31985313 |
 | Discrete Entropic Gravity (Graph-AQUAL) | `discrete_gravity.py` | 31348411 |
 | Double-Slit Grid Resolution | `double_slit_grid.py` | — |
 | Minimal EFC EFT Ansatz | `minimal_eft.py` | — |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -114,6 +114,9 @@ identifiers:
   - type: doi
     value: "10.6084/m9.figshare.31970907"
     description: "EFC White Paper Part 4: Regime Susceptibility and Cross-Scale Mapping"
+  - type: doi
+    value: "10.6084/m9.figshare.31985313"
+    description: "Scale-Localised Modified Gravity: E_G(k,z) Forecast"
 references:
   - type: article
     authors:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![ORCID](https://img.shields.io/badge/ORCID-0009--0002--4860--5095-green)](https://orcid.org/0009-0002-4860-5095)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Validation Ledger](https://img.shields.io/badge/Validation_Ledger-v3.16-orange)](./docs/public/EFC_Validation_Ledger.html)
-[![AI Packages](https://img.shields.io/badge/AI_Packages-136-brightgreen)](#ai-friendly-paper-packages)
+[![AI Packages](https://img.shields.io/badge/AI_Packages-137-brightgreen)](#ai-friendly-paper-packages)
 
 > **NEW (April 9, 2026)**: **[EFC White Paper Series (Parts 1-4)](./docs/papers/efc/efc_white_paper_part_1_to_4/)** — Canonical four-part reference. [Part 1](https://doi.org/10.6084/m9.figshare.31970886): Recovery conditions (EFC ⊃ ΛCDM). [Part 2](https://doi.org/10.6084/m9.figshare.31970898): Field equations & observable mapping. [Part 3](https://doi.org/10.6084/m9.figshare.31970904): Validation ledger & falsification protocol (102 tests, 5 kill criteria). [Part 4](https://doi.org/10.6084/m9.figshare.31970907): Regime susceptibility T(S) & dynamical dark energy.
 
@@ -33,8 +33,8 @@
 | **Theory Site** | [energyflow-cosmology.com](https://energyflow-cosmology.com/) |
 | **AI Navigation** | [`llms.txt`](./llms.txt) / [`AGENTS.md`](./AGENTS.md) |
 | **Validation Ledger** | [`EFC_Validation_Ledger.html`](./docs/public/EFC_Validation_Ledger.html) (v3.16 public / v4.7 internal) |
-| **Papers** | 136 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
-| **AI Packages** | 136 with executable Python + structured data (100% coverage) |
+| **Papers** | 137 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
+| **AI Packages** | 137 with executable Python + structured data (100% coverage) |
 | **Stage** | **Non-rejectable model** — Δχ² ≤ 0 across all probes; global verdict OPEN |
 | **Validation Reports** | EFC-VAL-2026-002 through 007 (6 hand-curated 10/10 packages) |
 | **Consolidation** | [ΛCDM as Special Case of EFC](https://doi.org/10.6084/m9.figshare.31943361) — single reference for full programme |
@@ -262,13 +262,13 @@ Pre-registered conditions that would falsify EFC sectors. F7 (η=1) formally **P
 | Core Lock (Consistency Enforcement) | [31223503](https://doi.org/10.6084/m9.figshare.31223503) |
 | ISW Consistency Audit | [31329082](https://doi.org/10.6084/m9.figshare.31329082) |
 
-> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 136 papers, all with AI-friendly packages (100% coverage). Six hand-curated 10/10 validation reports with full reproducible pipelines.
+> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 137 papers, all with AI-friendly packages (100% coverage). Six hand-curated 10/10 validation reports with full reproducible pipelines.
 
 ---
 
 ## AI-Friendly Paper Packages
 
-All 136 papers have AI-friendly packages (100% coverage as of April 2026). Six hand-curated 10/10 validation reports with full reproducible pipelines:
+All 137 papers have AI-friendly packages (100% coverage as of April 2026). Six hand-curated 10/10 validation reports with full reproducible pipelines:
 
 | Package | Module | Key Functionality |
 |---------|--------|-------------------|

--- a/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/ai_manifest.json
+++ b/docs/papers/efc/A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1803
+      "bytes": 1994
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 359
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 639
+    },
+    {
+      "path": "src/__pycache__/four_channel_test.cpython-311.pyc",
+      "bytes": 18949
+    },
+    {
       "path": "src/four_channel_test.py",
       "bytes": 12585
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology/ai_manifest.json
+++ b/docs/papers/efc/AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2027
+      "bytes": 2121
     },
     {
       "path": "auth-layer-origin-provenance-and-structural-signature-of-energy-flow-cosmology.jsonld",
@@ -69,10 +69,14 @@
       "bytes": 531
     },
     {
+      "path": "src/__pycache__/auth_layer.cpython-311.pyc",
+      "bytes": 16158
+    },
+    {
       "path": "src/auth_layer.py",
       "bytes": 9808
     }
   ],
-  "n_files": 14,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/ai_manifest.json
+++ b/docs/papers/efc/A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2100
+      "bytes": 2301
     },
     {
       "path": "besr3_path_a_alpha_fit.py",
@@ -85,10 +85,18 @@
       "bytes": 930
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1121
+    },
+    {
+      "path": "src/__pycache__/entropy_structure_coupling.cpython-311.pyc",
+      "bytes": 21317
+    },
+    {
       "path": "src/entropy_structure_coupling.py",
       "bytes": 16565
     }
   ],
-  "n_files": 18,
+  "n_files": 20,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes/ai_manifest.json
+++ b/docs/papers/efc/A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2140
+      "bytes": 2330
     },
     {
       "path": "citations.bib",
@@ -73,10 +73,18 @@
       "bytes": 616
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 868
+    },
+    {
+      "path": "src/__pycache__/lensing_response.cpython-311.pyc",
+      "bytes": 18107
+    },
+    {
       "path": "src/lensing_response.py",
       "bytes": 12676
     }
   ],
-  "n_files": 15,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/CEM-Consciousness-Ego-Mirror/ai_manifest.json
+++ b/docs/papers/efc/CEM-Consciousness-Ego-Mirror/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1484
+      "bytes": 1577
     },
     {
       "path": "cem-consciousness-ego-mirror.jsonld",
@@ -65,10 +65,14 @@
       "bytes": 432
     },
     {
+      "path": "src/__pycache__/cem_model.cpython-311.pyc",
+      "bytes": 10096
+    },
+    {
       "path": "src/cem_model.py",
       "bytes": 6909
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/CMB-Thermodynamic-Interpretation/ai_manifest.json
+++ b/docs/papers/efc/CMB-Thermodynamic-Interpretation/ai_manifest.json
@@ -66,7 +66,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2598
+      "bytes": 2790
     },
     {
       "path": "citations.bib",
@@ -105,10 +105,18 @@
       "bytes": 1055
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1286
+    },
+    {
+      "path": "src/__pycache__/cmb_thermodynamic.cpython-311.pyc",
+      "bytes": 15767
+    },
+    {
       "path": "src/cmb_thermodynamic.py",
       "bytes": 12271
     }
   ],
-  "n_files": 23,
+  "n_files": 25,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Closing_the_EFC_Consciousness_Bridge/ai_manifest.json
+++ b/docs/papers/efc/Closing_the_EFC_Consciousness_Bridge/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1501
+      "bytes": 1604
     },
     {
       "path": "citations.bib",
@@ -61,10 +61,14 @@
       "bytes": 2231
     },
     {
+      "path": "src/__pycache__/consciousness_bridge.cpython-311.pyc",
+      "bytes": 8087
+    },
+    {
       "path": "src/consciousness_bridge.py",
       "bytes": 7717
     }
   ],
-  "n_files": 12,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling/ai_manifest.json
+++ b/docs/papers/efc/Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling/ai_manifest.json
@@ -83,7 +83,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 5847
+      "bytes": 6029
     },
     {
       "path": "citations.bib",
@@ -266,10 +266,18 @@
       "bytes": 702
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 983
+    },
+    {
+      "path": "src/__pycache__/sparc175.cpython-311.pyc",
+      "bytes": 14729
+    },
+    {
       "path": "src/sparc175.py",
       "bytes": 9684
     }
   ],
-  "n_files": 62,
+  "n_files": 64,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge/ai_manifest.json
+++ b/docs/papers/efc/Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1656
+      "bytes": 1756
     },
     {
       "path": "bridge_equations.jsonld",
@@ -65,10 +65,14 @@
       "bytes": 477
     },
     {
+      "path": "src/__pycache__/bridge_equations.cpython-311.pyc",
+      "bytes": 13504
+    },
+    {
       "path": "src/bridge_equations.py",
       "bytes": 9536
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test/ai_manifest.json
+++ b/docs/papers/efc/Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1952
+      "bytes": 2144
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 1182
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1455
+    },
+    {
+      "path": "src/__pycache__/regime_transition.cpython-311.pyc",
+      "bytes": 24430
+    },
+    {
       "path": "src/regime_transition.py",
       "bytes": 16618
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Core-Lock/ai_manifest.json
+++ b/docs/papers/efc/Core-Lock/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2055
+      "bytes": 2638
     },
     {
       "path": "citations.bib",
@@ -89,6 +89,30 @@
       "bytes": 853
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1083
+    },
+    {
+      "path": "src/__pycache__/beta_constraint.cpython-311.pyc",
+      "bytes": 7026
+    },
+    {
+      "path": "src/__pycache__/grid_state_function.cpython-311.pyc",
+      "bytes": 8320
+    },
+    {
+      "path": "src/__pycache__/information_length.cpython-311.pyc",
+      "bytes": 6961
+    },
+    {
+      "path": "src/__pycache__/projection_laws.cpython-311.pyc",
+      "bytes": 8257
+    },
+    {
+      "path": "src/__pycache__/simulation.cpython-311.pyc",
+      "bytes": 9560
+    },
+    {
       "path": "src/beta_constraint.py",
       "bytes": 4741
     },
@@ -109,6 +133,6 @@
       "bytes": 6512
     }
   ],
-  "n_files": 23,
+  "n_files": 29,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity/ai_manifest.json
+++ b/docs/papers/efc/Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity/ai_manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2351
+      "bytes": 2537
     },
     {
       "path": "citations.bib",
@@ -89,6 +89,14 @@
       "bytes": 488
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 747
+    },
+    {
+      "path": "src/__pycache__/geff_coupling.cpython-311.pyc",
+      "bytes": 4340
+    },
+    {
       "path": "src/geff_coupling.py",
       "bytes": 2983
     },
@@ -101,6 +109,6 @@
       "bytes": 2071
     }
   ],
-  "n_files": 21,
+  "n_files": 23,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints/ai_manifest.json
+++ b/docs/papers/efc/Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1987
+      "bytes": 2174
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 557
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 780
+    },
+    {
+      "path": "src/__pycache__/covariant_eft.cpython-311.pyc",
+      "bytes": 20695
+    },
+    {
       "path": "src/covariant_eft.py",
       "bytes": 13291
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Density_of_States_of_Gravitationally/ai_manifest.json
+++ b/docs/papers/efc/Density_of_States_of_Gravitationally/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1552
+      "bytes": 1743
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 603
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 801
+    },
+    {
+      "path": "src/__pycache__/density_of_states.cpython-311.pyc",
+      "bytes": 19477
+    },
+    {
       "path": "src/density_of_states.py",
       "bytes": 13818
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Derivation_of_the_Entropy_Production/ai_manifest.json
+++ b/docs/papers/efc/Derivation_of_the_Entropy_Production/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1556
+      "bytes": 1748
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 586
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 790
+    },
+    {
+      "path": "src/__pycache__/entropy_production.cpython-311.pyc",
+      "bytes": 18630
+    },
+    {
       "path": "src/entropy_production.py",
       "bytes": 12652
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Directional_Lensing_Residuals/ai_manifest.json
+++ b/docs/papers/efc/Directional_Lensing_Residuals/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1695
+      "bytes": 1888
     },
     {
       "path": "citations.bib",
@@ -73,10 +73,18 @@
       "bytes": 710
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 886
+    },
+    {
+      "path": "src/__pycache__/directional_lensing.cpython-311.pyc",
+      "bytes": 20216
+    },
+    {
       "path": "src/directional_lensing.py",
       "bytes": 14640
     }
   ],
-  "n_files": 15,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/ai_manifest.json
+++ b/docs/papers/efc/Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2050
+      "bytes": 2239
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 438
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 731
+    },
+    {
+      "path": "src/__pycache__/grc_double_slit.cpython-311.pyc",
+      "bytes": 14621
+    },
+    {
       "path": "src/grc_double_slit.py",
       "bytes": 9313
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EBE-Core-Principles/ai_manifest.json
+++ b/docs/papers/efc/EBE-Core-Principles/ai_manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1998
+      "bytes": 2459
     },
     {
       "path": "citations.bib",
@@ -90,6 +90,26 @@
       "bytes": 674
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 953
+    },
+    {
+      "path": "src/__pycache__/ebe_classifier.cpython-311.pyc",
+      "bytes": 7384
+    },
+    {
+      "path": "src/__pycache__/l_axis.cpython-311.pyc",
+      "bytes": 5901
+    },
+    {
+      "path": "src/__pycache__/regime_gating.cpython-311.pyc",
+      "bytes": 8785
+    },
+    {
+      "path": "src/__pycache__/s_axis.cpython-311.pyc",
+      "bytes": 5760
+    },
+    {
       "path": "src/ebe_classifier.py",
       "bytes": 5816
     },
@@ -106,6 +126,6 @@
       "bytes": 4238
     }
   ],
-  "n_files": 21,
+  "n_files": 26,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept/ai_manifest.json
+++ b/docs/papers/efc/EFC-A-Deep-Dive-into-the-Halo-Concept/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1552
+      "bytes": 1737
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 308
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 587
+    },
+    {
+      "path": "src/__pycache__/halo_concept.cpython-311.pyc",
+      "bytes": 7845
+    },
+    {
       "path": "src/halo_concept.py",
       "bytes": 4449
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework/ai_manifest.json
+++ b/docs/papers/efc/EFC-AI-Augmented-Scientific-Workflow-Framework/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1629
+      "bytes": 1821
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 372
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 667
+    },
+    {
+      "path": "src/__pycache__/workflow_framework.cpython-311.pyc",
+      "bytes": 11488
+    },
+    {
       "path": "src/workflow_framework.py",
       "bytes": 6212
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Applications-and-Implications/ai_manifest.json
+++ b/docs/papers/efc/EFC-Applications-and-Implications/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1506
+      "bytes": 1691
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 193
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 430
+    },
+    {
+      "path": "src/__pycache__/applications.cpython-311.pyc",
+      "bytes": 6905
+    },
+    {
       "path": "src/applications.py",
       "bytes": 4723
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Bridging-Scales-FEP/ai_manifest.json
+++ b/docs/papers/efc/EFC-Bridging-Scales-FEP/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1426
+      "bytes": 1614
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 229
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 441
+    },
+    {
+      "path": "src/__pycache__/bridging_scales.cpython-311.pyc",
+      "bytes": 6813
+    },
+    {
       "path": "src/bridging_scales.py",
       "bytes": 3847
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-CMB-Thermodynamic-Gradient/ai_manifest.json
+++ b/docs/papers/efc/EFC-CMB-Thermodynamic-Gradient/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1502
+      "bytes": 1687
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 218
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 444
+    },
+    {
+      "path": "src/__pycache__/cmb_gradient.cpython-311.pyc",
+      "bytes": 6467
+    },
+    {
       "path": "src/cmb_gradient.py",
       "bytes": 4031
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1901
+      "bytes": 1998
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 663
     },
     {
+      "path": "src/__pycache__/efc_cognition.cpython-311.pyc",
+      "bytes": 14277
+    },
+    {
       "path": "src/efc_cognition.py",
       "bytes": 8257
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/ai_manifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1870
+      "bytes": 2062
     },
     {
       "path": "citations.bib",
@@ -88,10 +88,18 @@
       "bytes": 1050
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1239
+    },
+    {
+      "path": "src/__pycache__/cognitive_entropy.cpython-311.pyc",
+      "bytes": 16242
+    },
+    {
       "path": "src/cognitive_entropy.py",
       "bytes": 11106
     }
   ],
-  "n_files": 18,
+  "n_files": 20,
   "n_pdfs": 0
 }

--- a/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_Consciousness_Field_Resonance/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1589
+      "bytes": 1782
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 692
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 897
+    },
+    {
+      "path": "src/__pycache__/consciousness_field.cpython-311.pyc",
+      "bytes": 13916
+    },
+    {
       "path": "src/consciousness_field.py",
       "bytes": 7503
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters/ai_manifest.json
+++ b/docs/papers/efc/EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1688
+      "bytes": 1878
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 217
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 464
+    },
+    {
+      "path": "src/__pycache__/galactic_clusters.cpython-311.pyc",
+      "bytes": 6652
+    },
+    {
       "path": "src/galactic_clusters.py",
       "bytes": 4093
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution/ai_manifest.json
+++ b/docs/papers/efc/EFC-Can-Entropy-Drive-Cosmic-Evolution/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1553
+      "bytes": 1742
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 196
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 428
+    },
+    {
+      "path": "src/__pycache__/cosmic_evolution.cpython-311.pyc",
+      "bytes": 6544
+    },
+    {
       "path": "src/cosmic_evolution.py",
       "bytes": 3814
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos/ai_manifest.json
+++ b/docs/papers/efc/EFC-Dynamic-Balance-Entropy-Order-and-Chaos/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1590
+      "bytes": 1778
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 200
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 440
+    },
+    {
+      "path": "src/__pycache__/dynamic_balance.cpython-311.pyc",
+      "bytes": 7011
+    },
+    {
       "path": "src/dynamic_balance.py",
       "bytes": 4016
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe/ai_manifest.json
+++ b/docs/papers/efc/EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1721
+      "bytes": 1913
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 220
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 465
+    },
+    {
+      "path": "src/__pycache__/fundamental_dynamic.cpython-311.pyc",
+      "bytes": 7403
+    },
+    {
       "path": "src/fundamental_dynamic.py",
       "bytes": 4515
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime/ai_manifest.json
+++ b/docs/papers/efc/EFC-Field-Equations-for-Entropy-Driven-Spacetime/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1632
+      "bytes": 1820
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 230
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 461
+    },
+    {
+      "path": "src/__pycache__/field_equations.cpython-311.pyc",
+      "bytes": 9632
+    },
+    {
       "path": "src/field_equations.py",
       "bytes": 5134
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters/ai_manifest.json
+++ b/docs/papers/efc/EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1816
+      "bytes": 1917
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 548
     },
     {
+      "path": "src/__pycache__/cluster_distortion.cpython-311.pyc",
+      "bytes": 8880
+    },
+    {
       "path": "src/cluster_distortion.py",
       "bytes": 5630
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Grid-Higgs-Framework/ai_manifest.json
+++ b/docs/papers/efc/EFC-Grid-Higgs-Framework/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1460
+      "bytes": 1553
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 398
     },
     {
+      "path": "src/__pycache__/grid_higgs.cpython-311.pyc",
+      "bytes": 6452
+    },
+    {
       "path": "src/grid_higgs.py",
       "bytes": 4063
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift/ai_manifest.json
+++ b/docs/papers/efc/EFC-Grid-Higgs-Paradigm-Shift/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1509
+      "bytes": 1606
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 437
     },
     {
+      "path": "src/__pycache__/paradigm_shift.cpython-311.pyc",
+      "bytes": 7050
+    },
+    {
       "path": "src/paradigm_shift.py",
       "bytes": 4394
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics/ai_manifest.json
+++ b/docs/papers/efc/EFC-Grid-Model-Entropic-Dynamics/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1538
+      "bytes": 1638
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 428
     },
     {
+      "path": "src/__pycache__/entropic_dynamics.cpython-311.pyc",
+      "bytes": 7159
+    },
+    {
       "path": "src/entropic_dynamics.py",
       "bytes": 4354
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-H0-S8-Tensions/ai_manifest.json
+++ b/docs/papers/efc/EFC-H0-S8-Tensions/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1501
+      "bytes": 1599
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 546
     },
     {
+      "path": "src/__pycache__/h0_s8_tensions.cpython-311.pyc",
+      "bytes": 10198
+    },
+    {
       "path": "src/h0_s8_tensions.py",
       "bytes": 6605
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures/ai_manifest.json
+++ b/docs/papers/efc/EFC-How-Does-Balance-Shape-Universal-Structures/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1644
+      "bytes": 1745
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 513
     },
     {
+      "path": "src/__pycache__/balance_structures.cpython-311.pyc",
+      "bytes": 7781
+    },
+    {
       "path": "src/balance_structures.py",
       "bytes": 5289
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime/ai_manifest.json
+++ b/docs/papers/efc/EFC-How-Energy-Flow-Sustain-Spacetime/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1559
+      "bytes": 1659
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 468
     },
     {
+      "path": "src/__pycache__/spacetime_sustain.cpython-311.pyc",
+      "bytes": 8590
+    },
+    {
       "path": "src/spacetime_sustain.py",
       "bytes": 5525
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Hypothesis-Interrelation-Energy-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1618
+      "bytes": 1729
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 509
     },
     {
+      "path": "src/__pycache__/energy_entropy_interrelation.cpython-311.pyc",
+      "bytes": 9517
+    },
+    {
       "path": "src/energy_entropy_interrelation.py",
       "bytes": 6118
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System/ai_manifest.json
+++ b/docs/papers/efc/EFC-Hypothesis-Universe-as-Energy-Driven-System/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1657
+      "bytes": 1761
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 591
     },
     {
+      "path": "src/__pycache__/energy_driven_system.cpython-311.pyc",
+      "bytes": 11800
+    },
+    {
       "path": "src/energy_driven_system.py",
       "bytes": 8114
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Integrated-Hypothesis-Time-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1560
+      "bytes": 1656
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 361
     },
     {
+      "path": "src/__pycache__/time_entropy.cpython-311.pyc",
+      "bytes": 10529
+    },
+    {
       "path": "src/time_entropy.py",
       "bytes": 6516
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time/ai_manifest.json
+++ b/docs/papers/efc/EFC-Introduction-to-Energy-Flow-in-Space-Time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1643
+      "bytes": 1747
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 484
     },
     {
+      "path": "src/__pycache__/energy_flow_spacetime.cpython-311.pyc",
+      "bytes": 8681
+    },
+    {
       "path": "src/energy_flow_spacetime.py",
       "bytes": 5320
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution/ai_manifest.json
+++ b/docs/papers/efc/EFC-Introduction-to-Entropy-in-Cosmic-Evolution/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1668
+      "bytes": 1775
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 485
     },
     {
+      "path": "src/__pycache__/entropy_cosmic_evolution.cpython-311.pyc",
+      "bytes": 9239
+    },
+    {
       "path": "src/entropy_cosmic_evolution.py",
       "bytes": 5582
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Is-Consciousness-Linked-to-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1608
+      "bytes": 1712
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 538
     },
     {
+      "path": "src/__pycache__/consciousness_entropy.cpython-311.pyc",
+      "bytes": 8795
+    },
+    {
       "path": "src/consciousness_entropy.py",
       "bytes": 6410
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe/ai_manifest.json
+++ b/docs/papers/efc/EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1772
+      "bytes": 1876
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 582
     },
     {
+      "path": "src/__pycache__/light_speed_regulator.cpython-311.pyc",
+      "bytes": 9376
+    },
+    {
       "path": "src/light_speed_regulator.py",
       "bytes": 5938
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time/ai_manifest.json
+++ b/docs/papers/efc/EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1711
+      "bytes": 1809
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 584
     },
     {
+      "path": "src/__pycache__/math_framework.cpython-311.pyc",
+      "bytes": 12815
+    },
+    {
       "path": "src/math_framework.py",
       "bytes": 7090
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution/ai_manifest.json
+++ b/docs/papers/efc/EFC-Observational-Evidence-Entropy-Cosmic-Evolution/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1694
+      "bytes": 1800
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 558
     },
     {
+      "path": "src/__pycache__/observational_evidence.cpython-311.pyc",
+      "bytes": 10679
+    },
+    {
       "path": "src/observational_evidence.py",
       "bytes": 6745
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow/ai_manifest.json
+++ b/docs/papers/efc/EFC-Observational-Evidence-for-Energy-Flow/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1623
+      "bytes": 1818
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 392
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 444
+    },
+    {
+      "path": "src/__pycache__/observational_evidence.cpython-311.pyc",
+      "bytes": 9121
+    },
+    {
       "path": "src/observational_evidence.py",
       "bytes": 5685
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/ai_manifest.json
+++ b/docs/papers/efc/EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2058
+      "bytes": 2154
     },
     {
       "path": "citations.bib",
@@ -85,10 +85,14 @@
       "bytes": 496
     },
     {
+      "path": "src/__pycache__/efc_desi_bao.cpython-311.pyc",
+      "bytes": 11117
+    },
+    {
       "path": "src/efc_desi_bao.py",
       "bytes": 5894
     }
   ],
-  "n_files": 18,
+  "n_files": 19,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-R-SPARC-Regime-Validity/ai_manifest.json
+++ b/docs/papers/efc/EFC-R-SPARC-Regime-Validity/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1468
+      "bytes": 1654
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 277
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 362
+    },
+    {
+      "path": "src/__pycache__/sparc_regime.cpython-311.pyc",
+      "bytes": 11186
+    },
+    {
       "path": "src/sparc_regime.py",
       "bytes": 5200
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/ai_manifest.json
+++ b/docs/papers/efc/EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology/ai_manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2615
+      "bytes": 2716
     },
     {
       "path": "citations.bib",
@@ -106,10 +106,14 @@
       "bytes": 527
     },
     {
+      "path": "src/__pycache__/regime_transition.cpython-311.pyc",
+      "bytes": 14265
+    },
+    {
       "path": "src/regime_transition.py",
       "bytes": 8678
     }
   ],
-  "n_files": 22,
+  "n_files": 23,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit/ai_manifest.json
+++ b/docs/papers/efc/EFC-Subhypothesis-Light-Speed-Limit/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1550
+      "bytes": 1740
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 321
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 388
+    },
+    {
+      "path": "src/__pycache__/light_speed_limit.cpython-311.pyc",
+      "bytes": 7218
+    },
+    {
       "path": "src/light_speed_limit.py",
       "bytes": 3854
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time/ai_manifest.json
+++ b/docs/papers/efc/EFC-Technical-Documentation-Energy-Flow-in-Space-Time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1706
+      "bytes": 1900
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 357
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 431
+    },
+    {
+      "path": "src/__pycache__/energy_flow_spacetime.cpython-311.pyc",
+      "bytes": 8888
+    },
+    {
       "path": "src/energy_flow_spacetime.py",
       "bytes": 4660
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-The-Energy-Flow-Interface/ai_manifest.json
+++ b/docs/papers/efc/EFC-The-Energy-Flow-Interface/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1514
+      "bytes": 1708
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 368
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 425
+    },
+    {
+      "path": "src/__pycache__/energy_flow_interface.cpython-311.pyc",
+      "bytes": 8584
+    },
+    {
       "path": "src/energy_flow_interface.py",
       "bytes": 4482
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT/ai_manifest.json
+++ b/docs/papers/efc/EFC-Thermodynamic-Bridge-GR-QFT/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1528
+      "bytes": 1721
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 339
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 403
+    },
+    {
+      "path": "src/__pycache__/thermodynamic_bridge.cpython-311.pyc",
+      "bytes": 8198
+    },
+    {
       "path": "src/thermodynamic_bridge.py",
       "bytes": 4548
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy/ai_manifest.json
+++ b/docs/papers/efc/EFC-Unresolved-Questions-and-Challenges-Entropy/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1650
+      "bytes": 1841
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 300
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 384
+    },
+    {
+      "path": "src/__pycache__/entropy_challenges.cpython-311.pyc",
+      "bytes": 7569
+    },
+    {
       "path": "src/entropy_challenges.py",
       "bytes": 3504
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes/ai_manifest.json
+++ b/docs/papers/efc/EFC-What-Happens-at-the-Universes-Extremes/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1608
+      "bytes": 1798
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 361
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 425
+    },
+    {
+      "path": "src/__pycache__/universe_extremes.cpython-311.pyc",
+      "bytes": 9238
+    },
+    {
       "path": "src/universe_extremes.py",
       "bytes": 4850
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now/ai_manifest.json
+++ b/docs/papers/efc/EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1731
+      "bytes": 1919
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 340
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 643
+    },
+    {
+      "path": "src/__pycache__/energy_flow_now.cpython-311.pyc",
+      "bytes": 7898
+    },
+    {
       "path": "src/energy_flow_now.py",
       "bytes": 4638
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit/ai_manifest.json
+++ b/docs/papers/efc/EFC-Why-is-Light-Speed-a-Cosmic-Limit/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1566
+      "bytes": 1756
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 314
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 593
+    },
+    {
+      "path": "src/__pycache__/light_speed_limit.cpython-311.pyc",
+      "bytes": 8909
+    },
+    {
       "path": "src/light_speed_limit.py",
       "bytes": 4892
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v1.2-Foundational-Framework/ai_manifest.json
+++ b/docs/papers/efc/EFC-v1.2-Foundational-Framework/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1510
+      "bytes": 1610
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 818
     },
     {
+      "path": "src/__pycache__/efc_foundational.cpython-311.pyc",
+      "bytes": 13238
+    },
+    {
       "path": "src/efc_foundational.py",
       "bytes": 11079
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v2.1-Complete-Edition/ai_manifest.json
+++ b/docs/papers/efc/EFC-v2.1-Complete-Edition/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1457
+      "bytes": 1553
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 545
     },
     {
+      "path": "src/__pycache__/efc_complete.cpython-311.pyc",
+      "bytes": 11036
+    },
+    {
       "path": "src/efc_complete.py",
       "bytes": 7340
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v2.1-Modular-Synthesis/ai_manifest.json
+++ b/docs/papers/efc/EFC-v2.1-Modular-Synthesis/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1454
+      "bytes": 1549
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 434
     },
     {
+      "path": "src/__pycache__/efc_modular.cpython-311.pyc",
+      "bytes": 14008
+    },
+    {
       "path": "src/efc_modular.py",
       "bytes": 8028
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary/ai_manifest.json
+++ b/docs/papers/efc/EFC-v2.2-Cross-Field-Integration-Summary/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1578
+      "bytes": 1677
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 572
     },
     {
+      "path": "src/__pycache__/efc_cross_field.cpython-311.pyc",
+      "bytes": 10374
+    },
+    {
       "path": "src/efc_cross_field.py",
       "bytes": 8323
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation/ai_manifest.json
+++ b/docs/papers/efc/EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1776
+      "bytes": 1874
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 615
     },
     {
+      "path": "src/__pycache__/sign_structure.cpython-311.pyc",
+      "bytes": 13498
+    },
+    {
       "path": "src/sign_structure.py",
       "bytes": 8948
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/ai_manifest.json
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/ai_manifest.json
@@ -11,16 +11,26 @@
   "generated": "2026-04-10",
   "track": "Spor general",
   "regimes": [],
-  "primary_pdf": null,
-  "all_pdfs": [],
+  "primary_pdf": "EFC_Background_NoGo_Theorem.pdf",
+  "all_pdfs": [
+    "EFC_Background_NoGo_Theorem.pdf"
+  ],
   "files": [
     {
       "path": "CITATION.cff",
       "bytes": 1373
     },
     {
+      "path": "EFC_Background_NoGo_Theorem.pdf",
+      "bytes": 305674
+    },
+    {
       "path": "README.md",
       "bytes": 9603
+    },
+    {
+      "path": "ai_manifest.json",
+      "bytes": 1551
     },
     {
       "path": "citations.bib",
@@ -59,18 +69,10 @@
       "bytes": 578
     },
     {
-      "path": "src/__pycache__/__init__.cpython-311.pyc",
-      "bytes": 829
-    },
-    {
-      "path": "src/__pycache__/background_nogo.cpython-311.pyc",
-      "bytes": 7858
-    },
-    {
       "path": "src/background_nogo.py",
       "bytes": 5099
     }
   ],
   "n_files": 14,
-  "n_pdfs": 0
+  "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Closure_Conjectures/ai_manifest.json
+++ b/docs/papers/efc/EFC_Closure_Conjectures/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1507
+      "bytes": 1607
     },
     {
       "path": "citations.bib",
@@ -69,10 +69,14 @@
       "bytes": 391
     },
     {
+      "path": "src/__pycache__/closure_relations.cpython-311.pyc",
+      "bytes": 6912
+    },
+    {
       "path": "src/closure_relations.py",
       "bytes": 4777
     }
   ],
-  "n_files": 14,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Cosmic_Dipole_Working_Note/ai_manifest.json
+++ b/docs/papers/efc/EFC_Cosmic_Dipole_Working_Note/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1493
+      "bytes": 1681
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 944
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1157
+    },
+    {
+      "path": "src/__pycache__/cosmic_dipole.cpython-311.pyc",
+      "bytes": 13193
+    },
+    {
       "path": "src/cosmic_dipole.py",
       "bytes": 9135
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Entropy_Budget_Working_Note/ai_manifest.json
+++ b/docs/papers/efc/EFC_Entropy_Budget_Working_Note/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1503
+      "bytes": 1691
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 586
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 765
+    },
+    {
+      "path": "src/__pycache__/entropy_budget.cpython-311.pyc",
+      "bytes": 23536
+    },
+    {
       "path": "src/entropy_budget.py",
       "bytes": 16094
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Gradient_Coupled_Grid_Action/ai_manifest.json
+++ b/docs/papers/efc/EFC_Gradient_Coupled_Grid_Action/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1519
+      "bytes": 1705
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 1376
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1553
+    },
+    {
+      "path": "src/__pycache__/grid_action.cpython-311.pyc",
+      "bytes": 22244
+    },
+    {
       "path": "src/grid_action.py",
       "bytes": 14894
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Ontological_Foundations/ai_manifest.json
+++ b/docs/papers/efc/EFC_Ontological_Foundations/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1981
+      "bytes": 2470
     },
     {
       "path": "citations.bib",
@@ -81,6 +81,26 @@
       "bytes": 726
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 983
+    },
+    {
+      "path": "src/__pycache__/circularity_tester.cpython-311.pyc",
+      "bytes": 8241
+    },
+    {
+      "path": "src/__pycache__/hypothesis_analyzer.cpython-311.pyc",
+      "bytes": 9578
+    },
+    {
+      "path": "src/__pycache__/ontology_model.cpython-311.pyc",
+      "bytes": 7624
+    },
+    {
+      "path": "src/__pycache__/phase_classifier.cpython-311.pyc",
+      "bytes": 6886
+    },
+    {
       "path": "src/circularity_tester.py",
       "bytes": 6140
     },
@@ -97,6 +117,6 @@
       "bytes": 5440
     }
   ],
-  "n_files": 20,
+  "n_files": 25,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Phase_3__SPARC_Validation/ai_manifest.json
+++ b/docs/papers/efc/EFC_Phase_3__SPARC_Validation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1615
+      "bytes": 1713
     },
     {
       "path": "citations.bib",
@@ -73,10 +73,14 @@
       "bytes": 371
     },
     {
+      "path": "src/__pycache__/screening_model.cpython-311.pyc",
+      "bytes": 7102
+    },
+    {
       "path": "src/screening_model.py",
       "bytes": 4603
     }
   ],
-  "n_files": 15,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction/ai_manifest.json
+++ b/docs/papers/efc/EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1826
+      "bytes": 2016
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 722
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 914
+    },
+    {
+      "path": "src/__pycache__/efc_relativistic.cpython-311.pyc",
+      "bytes": 20996
+    },
+    {
       "path": "src/efc_relativistic.py",
       "bytes": 14392
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/EFC_v1_3_PPN_Recovery_via_Density_Saturation/ai_manifest.json
+++ b/docs/papers/efc/EFC_v1_3_PPN_Recovery_via_Density_Saturation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2125
+      "bytes": 2316
     },
     {
       "path": "citations.bib",
@@ -77,10 +77,18 @@
       "bytes": 636
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 848
+    },
+    {
+      "path": "src/__pycache__/efc_ppn_screening.cpython-311.pyc",
+      "bytes": 13911
+    },
+    {
       "path": "src/efc_ppn_screening.py",
       "bytes": 10102
     }
   ],
-  "n_files": 16,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/ai_manifest.json
+++ b/docs/papers/efc/Empirical-Validation-of-Energy-Flow-Cosmology-Cluster-Lensing-and-Galaxy-Rotation-Curves/ai_manifest.json
@@ -36,7 +36,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 3930
+      "bytes": 4124
     },
     {
       "path": "citations.bib",
@@ -175,10 +175,18 @@
       "bytes": 708
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 885
+    },
+    {
+      "path": "src/__pycache__/empirical_validation.cpython-311.pyc",
+      "bytes": 10011
+    },
+    {
       "path": "src/empirical_validation.py",
       "bytes": 5803
     }
   ],
-  "n_files": 41,
+  "n_files": 43,
   "n_pdfs": 0
 }

--- a/docs/papers/efc/Energy-Flow-Cosmology-Unified-Analysis-of-BAO/ai_manifest.json
+++ b/docs/papers/efc/Energy-Flow-Cosmology-Unified-Analysis-of-BAO/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1886
+      "bytes": 1985
     },
     {
       "path": "citations.bib",
@@ -77,10 +77,14 @@
       "bytes": 690
     },
     {
+      "path": "src/__pycache__/efc_unified_bao.cpython-311.pyc",
+      "bytes": 11967
+    },
+    {
       "path": "src/efc_unified_bao.py",
       "bytes": 6892
     }
   ],
-  "n_files": 16,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/ai_manifest.json
+++ b/docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1826
+      "bytes": 1923
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 648
     },
     {
+      "path": "src/__pycache__/efc_screening.cpython-311.pyc",
+      "bytes": 13080
+    },
+    {
       "path": "src/efc_screening.py",
       "bytes": 7654
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/ai_manifest.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2215
+      "bytes": 2410
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 397
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 760
+    },
+    {
+      "path": "src/__pycache__/gravitational_response.cpython-311.pyc",
+      "bytes": 8457
+    },
+    {
       "path": "src/gravitational_response.py",
       "bytes": 4513
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation/ai_manifest.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2166
+      "bytes": 2258
     },
     {
       "path": "citations.bib",
@@ -77,10 +77,14 @@
       "bytes": 413
     },
     {
+      "path": "src/__pycache__/efc_model.cpython-311.pyc",
+      "bytes": 7013
+    },
+    {
       "path": "src/efc_model.py",
       "bytes": 4215
     }
   ],
-  "n_files": 16,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism/ai_manifest.json
+++ b/docs/papers/efc/Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism/ai_manifest.json
@@ -32,7 +32,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2031
+      "bytes": 2130
     },
     {
       "path": "citations.bib",
@@ -79,10 +79,14 @@
       "bytes": 512
     },
     {
+      "path": "src/__pycache__/efc_foundations.cpython-311.pyc",
+      "bytes": 12696
+    },
+    {
       "path": "src/efc_foundations.py",
       "bytes": 8425
     }
   ],
-  "n_files": 16,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/From_Grid_Microphysics_to_the_Radial_Acceleration/ai_manifest.json
+++ b/docs/papers/efc/From_Grid_Microphysics_to_the_Radial_Acceleration/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1633
+      "bytes": 1734
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 858
     },
     {
+      "path": "src/__pycache__/grid_microphysics.cpython-311.pyc",
+      "bytes": 17620
+    },
+    {
       "path": "src/grid_microphysics.py",
       "bytes": 12310
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Homo_Fluxus/ai_manifest.json
+++ b/docs/papers/efc/Homo_Fluxus/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1367
+      "bytes": 1462
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 352
     },
     {
+      "path": "src/__pycache__/homo_fluxus.cpython-311.pyc",
+      "bytes": 14774
+    },
+    {
       "path": "src/homo_fluxus.py",
       "bytes": 9935
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/ai_manifest.json
+++ b/docs/papers/efc/ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1864
+      "bytes": 2051
     },
     {
       "path": "citations.bib",
@@ -73,10 +73,18 @@
       "bytes": 914
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1121
+    },
+    {
+      "path": "src/__pycache__/isw_revision.cpython-311.pyc",
+      "bytes": 20370
+    },
+    {
       "path": "src/isw_revision.py",
       "bytes": 13341
     }
   ],
-  "n_files": 15,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/ai_manifest.json
+++ b/docs/papers/efc/ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1873
+      "bytes": 2068
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 305
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 596
+    },
+    {
+      "path": "src/__pycache__/isw_cross_correlation.cpython-311.pyc",
+      "bytes": 13387
+    },
+    {
       "path": "src/isw_cross_correlation.py",
       "bytes": 8221
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/KT3b_CrossRegime_Measurement_Failure_DOI/ai_manifest.json
+++ b/docs/papers/efc/KT3b_CrossRegime_Measurement_Failure_DOI/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1510
+      "bytes": 1603
     },
     {
       "path": "citations.bib",
@@ -61,10 +61,14 @@
       "bytes": 2598
     },
     {
+      "path": "src/__pycache__/rcmp_check.cpython-311.pyc",
+      "bytes": 8417
+    },
+    {
       "path": "src/rcmp_check.py",
       "bytes": 6987
     }
   ],
-  "n_files": 12,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/ai_manifest.json
+++ b/docs/papers/efc/L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism/ai_manifest.json
@@ -47,7 +47,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2238
+      "bytes": 2428
     },
     {
       "path": "citations.bib",
@@ -102,10 +102,18 @@
       "bytes": 297
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 562
+    },
+    {
+      "path": "src/__pycache__/regime_validator.cpython-311.pyc",
+      "bytes": 12641
+    },
+    {
       "path": "src/regime_validator.py",
       "bytes": 9491
     }
   ],
-  "n_files": 21,
+  "n_files": 23,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients/ai_manifest.json
+++ b/docs/papers/efc/Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1860
+      "bytes": 1960
     },
     {
       "path": "article.md",
@@ -77,10 +77,14 @@
       "bytes": 855
     },
     {
+      "path": "src/__pycache__/connectome_kappa.cpython-311.pyc",
+      "bytes": 18595
+    },
+    {
       "path": "src/connectome_kappa.py",
       "bytes": 10235
     }
   ],
-  "n_files": 16,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/ai_manifest.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1996
+      "bytes": 2184
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 349
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 650
+    },
+    {
+      "path": "src/__pycache__/efc_eft_ansatz.cpython-311.pyc",
+      "bytes": 13829
+    },
+    {
       "path": "src/efc_eft_ansatz.py",
       "bytes": 9038
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems/ai_manifest.json
+++ b/docs/papers/efc/Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2042
+      "bytes": 2233
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 755
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 957
+    },
+    {
+      "path": "src/__pycache__/entropy_intention.cpython-311.pyc",
+      "bytes": 23408
+    },
+    {
       "path": "src/entropy_intention.py",
       "bytes": 13667
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence/ai_manifest.json
+++ b/docs/papers/efc/Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2171
+      "bytes": 2366
     },
     {
       "path": "citations.bib",
@@ -69,6 +69,14 @@
       "bytes": 458
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 723
+    },
+    {
+      "path": "src/__pycache__/symbiose_architecture.cpython-311.pyc",
+      "bytes": 19759
+    },
+    {
       "path": "src/symbiose_architecture.py",
       "bytes": 15163
     },
@@ -77,6 +85,6 @@
       "bytes": 645
     }
   ],
-  "n_files": 15,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications/ai_manifest.json
+++ b/docs/papers/efc/Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1710
+      "bytes": 1901
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 636
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 831
+    },
+    {
+      "path": "src/__pycache__/sigma8_suppression.cpython-311.pyc",
+      "bytes": 9629
+    },
+    {
       "path": "src/sigma8_suppression.py",
       "bytes": 5727
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12/ai_manifest.json
+++ b/docs/papers/efc/Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1967
+      "bytes": 2158
     },
     {
       "path": "citations.bib",
@@ -77,10 +77,18 @@
       "bytes": 333
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 633
+    },
+    {
+      "path": "src/__pycache__/efc_phenomenology.cpython-311.pyc",
+      "bytes": 14461
+    },
+    {
       "path": "src/efc_phenomenology.py",
       "bytes": 8862
     }
   ],
-  "n_files": 16,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology/ai_manifest.json
+++ b/docs/papers/efc/R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology/ai_manifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1948
+      "bytes": 2144
     },
     {
       "path": "citations.bib",
@@ -76,10 +76,18 @@
       "bytes": 374
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 680
+    },
+    {
+      "path": "src/__pycache__/regime_response_surface.cpython-311.pyc",
+      "bytes": 9751
+    },
+    {
       "path": "src/regime_response_surface.py",
       "bytes": 5478
     }
   ],
-  "n_files": 15,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System/ai_manifest.json
+++ b/docs/papers/efc/Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System/ai_manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2468
+      "bytes": 3112
     },
     {
       "path": "citations.bib",
@@ -86,6 +86,34 @@
       "bytes": 840
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1220
+    },
+    {
+      "path": "src/__pycache__/claim.cpython-311.pyc",
+      "bytes": 9075
+    },
+    {
+      "path": "src/__pycache__/driver_proximity.cpython-311.pyc",
+      "bytes": 5876
+    },
+    {
+      "path": "src/__pycache__/l_axis.cpython-311.pyc",
+      "bytes": 5303
+    },
+    {
+      "path": "src/__pycache__/r_axis.cpython-311.pyc",
+      "bytes": 6103
+    },
+    {
+      "path": "src/__pycache__/regime_gate.cpython-311.pyc",
+      "bytes": 6310
+    },
+    {
+      "path": "src/__pycache__/world_model.cpython-311.pyc",
+      "bytes": 8817
+    },
+    {
       "path": "src/claim.py",
       "bytes": 4206
     },
@@ -110,6 +138,6 @@
       "bytes": 5060
     }
   ],
-  "n_files": 22,
+  "n_files": 29,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity/ai_manifest.json
+++ b/docs/papers/efc/Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1856
+      "bytes": 2048
     },
     {
       "path": "citations.bib",
@@ -69,10 +69,18 @@
       "bytes": 623
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 824
+    },
+    {
+      "path": "src/__pycache__/regime_measurement.cpython-311.pyc",
+      "bytes": 21344
+    },
+    {
       "path": "src/regime_measurement.py",
       "bytes": 15852
     }
   ],
-  "n_files": 14,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/ai_manifest.json
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/ai_manifest.json
@@ -31,7 +31,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 3518
+      "bytes": 3708
     },
     {
       "path": "citations.bib",
@@ -138,6 +138,14 @@
       "bytes": 331
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 650
+    },
+    {
+      "path": "src/__pycache__/transition_metric.cpython-311.pyc",
+      "bytes": 7567
+    },
+    {
       "path": "src/transition_metric.py",
       "bytes": 5131
     },
@@ -146,6 +154,6 @@
       "bytes": 1425
     }
   ],
-  "n_files": 31,
+  "n_files": 33,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Locked_Measurement/ai_manifest.json
+++ b/docs/papers/efc/Regime_Locked_Measurement/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1496
+      "bytes": 1683
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 492
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 701
+    },
+    {
+      "path": "src/__pycache__/regime_locked.cpython-311.pyc",
+      "bytes": 13324
+    },
+    {
       "path": "src/regime_locked.py",
       "bytes": 8951
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models/ai_manifest.json
+++ b/docs/papers/efc/Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models/ai_manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2386
+      "bytes": 2681
     },
     {
       "path": "citations.bib",
@@ -89,6 +89,18 @@
       "bytes": 527
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 783
+    },
+    {
+      "path": "src/__pycache__/interpolating_function.cpython-311.pyc",
+      "bytes": 2885
+    },
+    {
+      "path": "src/__pycache__/regime_classifier.cpython-311.pyc",
+      "bytes": 5670
+    },
+    {
       "path": "src/discrete_functional.py",
       "bytes": 5205
     },
@@ -101,6 +113,6 @@
       "bytes": 4796
     }
   ],
-  "n_files": 21,
+  "n_files": 24,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3/ai_manifest.json
+++ b/docs/papers/efc/Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2050
+      "bytes": 2153
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 433
     },
     {
+      "path": "src/__pycache__/rlhf_thermodynamics.cpython-311.pyc",
+      "bytes": 18197
+    },
+    {
       "path": "src/rlhf_thermodynamics.py",
       "bytes": 10791
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel/ai_manifest.json
+++ b/docs/papers/efc/Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1944
+      "bytes": 2135
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 548
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 825
+    },
+    {
+      "path": "src/__pycache__/growth_robustness.cpython-311.pyc",
+      "bytes": 10361
+    },
+    {
       "path": "src/growth_robustness.py",
       "bytes": 5704
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/README.md
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/README.md
@@ -1,0 +1,64 @@
+# Scale-Localised Modified Gravity from the EFC Action
+
+**A Single-Parameter Forecast via E_G(k,z)**
+
+Author: Morten Magnusson (ORCID [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
+Symbiose Research, Sandnes, Norway | April 2026 — v1.1
+DOI: [10.6084/m9.figshare.31985313](https://doi.org/10.6084/m9.figshare.31985313)
+License: CC-BY-4.0
+
+---
+
+## TL;DR
+
+| Aspect | Value |
+|--------|-------|
+| **Model** | Band-pass stiffness response R(k,a) localises gravity modification to k ~ k_c |
+| **Free parameter** | eps_tot in [0.38, 0.42] (slip amplitude from delta-Lambda counter-term) |
+| **Characteristic scale** | k_c = 0.05 h/Mpc |
+| **Key observables** | mu < 1 (suppressed growth), eta > 1 (anisotropic potentials), Sigma > 1 (enhanced lensing) |
+| **Reference point** | (k_c, z=0): mu=0.940, eta=1.200, Sigma=1.034 |
+| **Definitive test** | E_G(k) bump of ~7% at k ~ k_c, testable at 2.5-3.5 sigma with DESI x Planck |
+| **Joint chi-squared** | Delta-chi^2 = +1.4 (EFC marginal preference) |
+| **Category** | Structural / forecast (not a validation report) |
+
+## Abstract
+
+Single-parameter, directly falsifiable test of scale-localised modified gravity derived from
+the EFC relativistic action. The model modifies perturbation growth and lensing through a
+band-pass stiffness response R(k) that peaks at k_c = 0.05 h/Mpc and vanishes in IR and UV
+limits, recovering GR on super-horizon and galactic scales. Combined with gravitational slip
+from the delta-Lambda counter-term, this yields mu < 1, eta > 1, and Sigma > 1 — simultaneously
+satisfying the No-Go constraint on background modifications, BOSS full-shape P(k), CMB ISW
+limits, and Planck perturbation-sector tests. The entire model reduces to a single effective
+parameter eps_tot controlling slip amplitude, with a viable window eps_tot in [0.38, 0.42].
+
+## Key Equations
+
+1. **Stiffness response:** R(k,a) = R_0 * (k/k_c)^2 / (1 + (k/k_c)^2)^3 * a^4
+2. **Effective coupling:** mu(k,z) = 1 / (F * (1 + R(k,a)))
+3. **Gravitational slip:** eta(k,z) = 1 + 2 * eps_tot * (k/k_c)^2 / (1 + (k/k_c)^2)^2 * a^2
+4. **Lensing combination:** Sigma(k,z) = mu * (1 + eta) / 2
+5. **E_G statistic:** E_G(k,z) = (Omega_m,0 / f(z)) * (Sigma(k,z) / mu(k,z))
+
+## Observational Tests (Table 1)
+
+| Test | Delta-chi^2 | Precision | Status |
+|------|------------|-----------|--------|
+| BOSS P(k) shape | -0.07 | ~3%/bin | PASS |
+| CMB ISW (low-l) | — | ~10% | PASS (8%) |
+| CMB lensing A_lens | +3.3 | 5.5% | EFC better |
+| KiDS shear S_WL | +0.04 | 2.5% | Neutral |
+| E_G (current) | -1.9 | ~15% | GR preferred |
+| **Joint (net)** | **+1.4** | — | **EFC marginal** |
+
+## AI-Friendly Package Contents
+
+- `index.json` — Machine-readable structured metadata
+- `metadata.json` — Extended metadata
+- `schema.json` — JSON Schema for key data objects
+- `*.jsonld` — Schema.org linked data
+- `citations.bib` — BibTeX references
+- `data/` — Observational tests and E_G predictions as JSON
+- `src/` — Python implementation of band-pass model
+- `examples/` — Demo script reproducing key results

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/ai_manifest.json
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/ai_manifest.json
@@ -1,0 +1,70 @@
+{
+  "id": "scale-localised-modified-gravity",
+  "directory": "Scale_Localised_Modified_Gravity",
+  "title": "Scale Localised Modified Gravity",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "package_type": "ai-friendly-paper",
+  "schema_version": "1.0",
+  "generated": "2026-04-10",
+  "track": "Spor general",
+  "regimes": [],
+  "primary_pdf": "Scale_Localised_Modified_Gravity.pdf",
+  "all_pdfs": [
+    "Scale_Localised_Modified_Gravity.pdf"
+  ],
+  "files": [
+    {
+      "path": "README.md",
+      "bytes": 3061
+    },
+    {
+      "path": "Scale_Localised_Modified_Gravity.pdf",
+      "bytes": 270153
+    },
+    {
+      "path": "ai_manifest.json",
+      "bytes": 1383
+    },
+    {
+      "path": "citations.bib",
+      "bytes": 1558
+    },
+    {
+      "path": "data/eg_prediction.json",
+      "bytes": 1070
+    },
+    {
+      "path": "data/observational_tests.json",
+      "bytes": 964
+    },
+    {
+      "path": "examples/demo_eg_bump.py",
+      "bytes": 1315
+    },
+    {
+      "path": "index.json",
+      "bytes": 5250
+    },
+    {
+      "path": "metadata.json",
+      "bytes": 1751
+    },
+    {
+      "path": "scale-localised-modified-gravity.jsonld",
+      "bytes": 1504
+    },
+    {
+      "path": "schema.json",
+      "bytes": 1345
+    },
+    {
+      "path": "src/scale_localised_gravity.py",
+      "bytes": 2167
+    }
+  ],
+  "n_files": 12,
+  "n_pdfs": 1
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/citations.bib
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/citations.bib
@@ -1,0 +1,47 @@
+@article{Magnusson2026ScaleLocalised,
+  author    = {Magnusson, Morten},
+  title     = {Scale-Localised Modified Gravity from the {EFC} Action: A Single-Parameter Forecast via {$E_G(k,z)$}},
+  year      = {2026},
+  month     = {4},
+  doi       = {10.6084/m9.figshare.31985313},
+  note      = {v1.1. Band-pass model with eps\_tot in [0.38, 0.42]}
+}
+
+@article{Magnusson2026RelativisticAction,
+  author    = {Magnusson, Morten},
+  title     = {{EFC} Relativistic Action: Field Equations, Perturbation Theory, and Extraction of {$\mu$, $\Sigma$, $\eta$}},
+  year      = {2026},
+  doi       = {10.6084/m9.figshare.31876324}
+}
+
+@article{Magnusson2026NoGo,
+  author    = {Magnusson, Morten},
+  title     = {No-Go for Observable {EFC} Background Modifications from {BAO--CMB} Joint Constraints},
+  year      = {2026},
+  doi       = {10.6084/m9.figshare.31985163}
+}
+
+@article{Magnusson2026CMBLocalization,
+  author    = {Magnusson, Morten},
+  title     = {Systematic Localization of Late-Time Cosmological Signals in Modified Gravity},
+  year      = {2026},
+  doi       = {10.6084/m9.figshare.31368433}
+}
+
+@article{Reyes2010EG,
+  author    = {Reyes, R. and others},
+  title     = {Confirmation of {GR} on large scales from weak lensing and galaxy velocities},
+  year      = {2010},
+  journal   = {Nature},
+  volume    = {464},
+  pages     = {256}
+}
+
+@article{Asgari2021KiDS,
+  author    = {Asgari, M. and others},
+  title     = {{KiDS-1000} Cosmology: Cosmic shear constraints},
+  year      = {2021},
+  journal   = {A\&A},
+  volume    = {645},
+  pages     = {A104}
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/data/eg_prediction.json
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/data/eg_prediction.json
@@ -1,0 +1,30 @@
+{
+  "source": "Scale-Localised Modified Gravity (Table 2)",
+  "doi": "10.6084/m9.figshare.31985313",
+  "description": "E_G(k) prediction at z=0.3 for the band-pass model",
+  "redshift": 0.3,
+  "eps_tot": 0.40,
+  "R_0": 0.510,
+  "k_c": 0.05,
+  "k_c_unit": "h/Mpc",
+  "Omega_m": 0.315,
+  "data": [
+    {"k": 0.01, "EG_GR": 0.460, "EG_EFC": 0.466, "delta_EG_pct": 1.2, "Sigma_over_mu": 1.012},
+    {"k": 0.03, "EG_GR": 0.460, "EG_EFC": 0.488, "delta_EG_pct": 5.9, "Sigma_over_mu": 1.059},
+    {"k": 0.05, "EG_GR": 0.460, "EG_EFC": 0.494, "delta_EG_pct": 7.4, "Sigma_over_mu": 1.072},
+    {"k": 0.10, "EG_GR": 0.460, "EG_EFC": 0.481, "delta_EG_pct": 4.6, "Sigma_over_mu": 1.046},
+    {"k": 0.20, "EG_GR": 0.460, "EG_EFC": 0.468, "delta_EG_pct": 1.6, "Sigma_over_mu": 1.016}
+  ],
+  "peak": {
+    "k": 0.05,
+    "bump_pct": 7.4,
+    "Sigma_over_mu": 1.072
+  },
+  "detection_forecast": {
+    "current_precision_pct": 15,
+    "target_precision_pct": 5,
+    "signal_pct": 7,
+    "significance_sigma": "2.5-3.5",
+    "instrument": "DESI x Planck lensing cross-correlations"
+  }
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/data/observational_tests.json
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/data/observational_tests.json
@@ -1,0 +1,44 @@
+{
+  "source": "Scale-Localised Modified Gravity (Table 1)",
+  "doi": "10.6084/m9.figshare.31985313",
+  "eps_tot": 0.40,
+  "note": "Positive delta_chi2 indicates EFC preferred over LCDM",
+  "tests": [
+    {
+      "name": "BOSS P(k) shape",
+      "delta_chi2": -0.07,
+      "precision": "~3%/bin",
+      "status": "PASS"
+    },
+    {
+      "name": "CMB ISW (low-l)",
+      "delta_chi2": null,
+      "precision": "~10%",
+      "status": "PASS (8%)"
+    },
+    {
+      "name": "CMB lensing A_lens",
+      "delta_chi2": 3.3,
+      "precision": "5.5%",
+      "status": "EFC better"
+    },
+    {
+      "name": "KiDS shear S_WL",
+      "delta_chi2": 0.04,
+      "precision": "2.5%",
+      "status": "Neutral"
+    },
+    {
+      "name": "E_G (current)",
+      "delta_chi2": -1.9,
+      "precision": "~15%",
+      "status": "GR preferred"
+    },
+    {
+      "name": "Joint (net)",
+      "delta_chi2": 1.4,
+      "precision": null,
+      "status": "EFC marginal"
+    }
+  ]
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/examples/demo_eg_bump.py
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/examples/demo_eg_bump.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Demo: E_G(k) bump prediction from the Scale-Localised Modified Gravity model.
+
+Reproduces Table 2 from DOI: 10.6084/m9.figshare.31985313.
+"""
+
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import numpy as np
+from scale_localised_gravity import (
+    stiffness_response, mu, eta, sigma, E_G, E_G_GR, K_C
+)
+
+print("=== Scale-Localised Modified Gravity: E_G(k) Forecast ===\n")
+
+# Reference point
+z_ref = 0.0
+k_ref = K_C
+print(f"Reference point (k_c={k_ref}, z={z_ref}):")
+print(f"  mu  = {mu(k_ref, z_ref):.3f}")
+print(f"  eta = {eta(k_ref, z_ref):.3f}")
+print(f"  Sigma = {sigma(k_ref, z_ref):.3f}")
+
+# Table 2: E_G(k) at z=0.3
+z = 0.3
+k_vals = [0.01, 0.03, 0.05, 0.10, 0.20]
+eg_gr = E_G_GR(z)
+
+print(f"\nTable 2: E_G(k) at z = {z}")
+print(f"{'k [h/Mpc]':>12} {'E_G^GR':>8} {'E_G^EFC':>9} {'Delta%':>8} {'Sigma/mu':>10}")
+print("-" * 52)
+for k in k_vals:
+    eg_efc = E_G(k, z)
+    delta = (eg_efc / eg_gr - 1) * 100
+    sig_mu = sigma(k, z) / mu(k, z)
+    marker = " <-- peak" if k == K_C else ""
+    print(f"{k:>12.2f} {eg_gr:>8.3f} {eg_efc:>9.3f} {delta:>+7.1f}% {sig_mu:>10.3f}{marker}")
+
+# Detection forecast
+print(f"\nPeak bump: ~7.4% at k = {K_C} h/Mpc")
+print("Detection significance: ~2.5-3.5 sigma with DESI x Planck")
+print("\nDone.")

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/index.json
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/index.json
@@ -1,0 +1,129 @@
+{
+  "id": "scale-localised-modified-gravity",
+  "title": "Scale-Localised Modified Gravity from the EFC Action: A Single-Parameter Forecast via E_G(k,z)",
+  "short_title": "Scale-Localised Modified Gravity",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research, Sandnes, Norway",
+  "date": "2026-04",
+  "version": "1.1",
+  "doi": "10.6084/m9.figshare.31985313",
+  "license": "CC-BY-4.0",
+  "category": "structural",
+  "track": "perturbation_sector",
+
+  "abstract": "Single-parameter, directly falsifiable test of scale-localised modified gravity derived from the EFC relativistic action. The model modifies perturbation growth and lensing through a band-pass stiffness response R(k) that peaks at k_c = 0.05 h/Mpc and vanishes in IR and UV limits, recovering GR on super-horizon and galactic scales.",
+
+  "key_equations": {
+    "stiffness_response": {
+      "label": "Eq. 1",
+      "latex": "R(k,a) = R_0 \\frac{(k/k_c)^2}{(1+(k/k_c)^2)^3} a^4",
+      "parameters": {
+        "R_0": 0.510,
+        "k_c": 0.05,
+        "k_c_unit": "h/Mpc"
+      },
+      "properties": "Band-pass: R ~ k^2 for k << k_c (IR recovery), R ~ k^{-4} for k >> k_c (UV recovery)"
+    },
+    "effective_coupling": {
+      "label": "Eq. 2",
+      "latex": "\\mu(k,z) = \\frac{1}{F(1+R(k,a))}",
+      "parameters": {
+        "F": 1.00005,
+        "F_definition": "F = 1 + alpha * phi_bar"
+      },
+      "result": "mu < 1 (suppressed growth)"
+    },
+    "gravitational_slip": {
+      "label": "Eq. 3",
+      "latex": "\\eta(k,z) = 1 + 2 \\varepsilon_{\\mathrm{tot}} \\frac{(k/k_c)^2}{(1+(k/k_c)^2)^2} a^2",
+      "parameters": {
+        "eps_tot_range": [0.38, 0.42],
+        "eps_tot_best": 0.40
+      },
+      "result": "eta > 1 (anisotropic potentials)"
+    },
+    "lensing_combination": {
+      "label": "Eq. 4",
+      "latex": "\\Sigma(k,z) = \\frac{\\mu(1+\\eta)}{2}",
+      "result": "Sigma > 1 (enhanced lensing)"
+    },
+    "eg_statistic": {
+      "label": "Eq. 5",
+      "latex": "E_G(k,z) = \\frac{\\Omega_{m,0}}{f(z)} \\frac{\\Sigma(k,z)}{\\mu(k,z)}",
+      "gr_value": 0.46,
+      "gr_property": "flat, scale-independent",
+      "efc_property": "scale-dependent bump at k ~ k_c"
+    }
+  },
+
+  "reference_point": {
+    "k": 0.05,
+    "k_unit": "h/Mpc",
+    "z": 0,
+    "mu": 0.940,
+    "eta": 1.200,
+    "Sigma": 1.034
+  },
+
+  "observational_tests": {
+    "eps_tot": 0.40,
+    "tests": [
+      {"name": "BOSS P(k) shape", "delta_chi2": -0.07, "precision": "~3%/bin", "status": "PASS"},
+      {"name": "CMB ISW (low-l)", "delta_chi2": null, "precision": "~10%", "status": "PASS (8%)"},
+      {"name": "CMB lensing A_lens", "delta_chi2": 3.3, "precision": "5.5%", "status": "EFC better"},
+      {"name": "KiDS shear S_WL", "delta_chi2": 0.04, "precision": "2.5%", "status": "Neutral"},
+      {"name": "E_G (current)", "delta_chi2": -1.9, "precision": "~15%", "status": "GR preferred"},
+      {"name": "Joint (net)", "delta_chi2": 1.4, "precision": null, "status": "EFC marginal"}
+    ]
+  },
+
+  "eg_prediction": {
+    "redshift": 0.3,
+    "data": [
+      {"k": 0.01, "EG_GR": 0.460, "EG_EFC": 0.466, "delta_pct": 1.2, "Sigma_over_mu": 1.012},
+      {"k": 0.03, "EG_GR": 0.460, "EG_EFC": 0.488, "delta_pct": 5.9, "Sigma_over_mu": 1.059},
+      {"k": 0.05, "EG_GR": 0.460, "EG_EFC": 0.494, "delta_pct": 7.4, "Sigma_over_mu": 1.072},
+      {"k": 0.10, "EG_GR": 0.460, "EG_EFC": 0.481, "delta_pct": 4.6, "Sigma_over_mu": 1.046},
+      {"k": 0.20, "EG_GR": 0.460, "EG_EFC": 0.468, "delta_pct": 1.6, "Sigma_over_mu": 1.016}
+    ],
+    "peak_bump_pct": 7.4,
+    "detection_significance_sigma": "2.5-3.5",
+    "instrument": "DESI x Planck lensing cross-correlations"
+  },
+
+  "degeneracy_breaking": {
+    "growth_sigma8": 0.810,
+    "shear_sigma8": 0.850,
+    "mismatch_pct": 3,
+    "mechanism": "Sigma != mu breaks LCDM + sigma8 rescaling degeneracy"
+  },
+
+  "physical_interpretation": "Band-pass structure arises from interplay between entropy stiffness (mu < 1, peaks at k_c) and delta-Lambda counter-term (eta > 1, boosting Weyl potential and lensing). IR recovery reflects transition from quasi-static to dynamical regime.",
+
+  "limitations": "Simplified likelihoods (diagonal covariance, single tomographic bin, approximate band powers). Full validation requires EFCLASS/MGCAMB integration with Planck TTTEEE + lensing, BOSS/DESI full-shape, and KiDS/DES tomographic cosmic shear.",
+
+  "conclusion": "Tightly constrained but not yet excluded. Single observable E_G(k) provides definitive near-term test. Viable window ~10% wide; single improved E_G(k) measurement at k ~ 0.05 h/Mpc will either confirm the predicted anisotropy or falsify the model.",
+
+  "dependencies": {
+    "no_go_theorem": "10.6084/m9.figshare.31985163",
+    "relativistic_action": "10.6084/m9.figshare.31876324",
+    "cmb_localization": "10.6084/m9.figshare.31368433"
+  },
+
+  "files": [
+    "Scale_Localised_Modified_Gravity.pdf",
+    "README.md",
+    "index.json",
+    "metadata.json",
+    "schema.json",
+    "scale-localised-modified-gravity.jsonld",
+    "citations.bib",
+    "data/observational_tests.json",
+    "data/eg_prediction.json",
+    "src/scale_localised_gravity.py",
+    "examples/demo_eg_bump.py"
+  ],
+
+  "see_also": "ai_manifest.json"
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/metadata.json
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/metadata.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": "1.0",
+  "package_type": "ai-friendly-paper",
+  "paper": {
+    "title": "Scale-Localised Modified Gravity from the EFC Action: A Single-Parameter Forecast via E_G(k,z)",
+    "directory": "Scale_Localised_Modified_Gravity",
+    "author": {
+      "name": "Morten Magnusson",
+      "orcid": "0009-0002-4860-5095",
+      "affiliation": "Symbiose Research"
+    },
+    "date": "2026-04",
+    "doi": "10.6084/m9.figshare.31985313",
+    "license": "CC-BY-4.0",
+    "category": "structural",
+    "track": "perturbation_sector"
+  },
+  "domain": {
+    "track": "perturbation_sector",
+    "regimes": ["L1", "L2"],
+    "probes": ["E_G", "mu", "eta", "Sigma", "BOSS_Pk", "CMB_ISW", "CMB_lensing", "KiDS_shear"]
+  },
+  "key_numbers": {
+    "k_c": {"value": 0.05, "unit": "h/Mpc"},
+    "R_0": 0.510,
+    "eps_tot_range": [0.38, 0.42],
+    "mu_at_kc": 0.940,
+    "eta_at_kc": 1.200,
+    "Sigma_at_kc": 1.034,
+    "joint_delta_chi2": 1.4,
+    "EG_bump_pct": 7.4,
+    "detection_sigma": "2.5-3.5"
+  },
+  "files": [
+    {"path": "Scale_Localised_Modified_Gravity.pdf", "bytes": 270153},
+    {"path": "README.md", "role": "human_summary"},
+    {"path": "index.json", "role": "machine_metadata"},
+    {"path": "metadata.json", "role": "extended_metadata"},
+    {"path": "schema.json", "role": "json_schema"},
+    {"path": "scale-localised-modified-gravity.jsonld", "role": "linked_data"},
+    {"path": "citations.bib", "role": "references"},
+    {"path": "data/observational_tests.json", "role": "data"},
+    {"path": "data/eg_prediction.json", "role": "data"},
+    {"path": "src/scale_localised_gravity.py", "role": "source"},
+    {"path": "examples/demo_eg_bump.py", "role": "example"}
+  ],
+  "primary_pdf": "Scale_Localised_Modified_Gravity.pdf"
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/scale-localised-modified-gravity.jsonld
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/scale-localised-modified-gravity.jsonld
@@ -1,0 +1,50 @@
+{
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  "@id": "https://doi.org/10.6084/m9.figshare.31985313",
+  "name": "Scale-Localised Modified Gravity from the EFC Action: A Single-Parameter Forecast via E_G(k,z)",
+  "author": {
+    "@type": "Person",
+    "@id": "https://orcid.org/0009-0002-4860-5095",
+    "name": "Morten Magnusson",
+    "affiliation": {
+      "@type": "Organization",
+      "name": "Symbiose Research, Sandnes, Norway"
+    }
+  },
+  "datePublished": "2026-04",
+  "version": "1.1",
+  "identifier": {
+    "@type": "PropertyValue",
+    "propertyID": "DOI",
+    "value": "10.6084/m9.figshare.31985313"
+  },
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "isPartOf": {
+    "@type": "ResearchProject",
+    "@id": "https://energyflow-cosmology.com/",
+    "name": "Energy-Flow Cosmology (EFC)"
+  },
+  "about": [
+    {
+      "@type": "DefinedTerm",
+      "name": "Band-Pass Stiffness Response",
+      "description": "R(k,a) localises gravitational modification to a finite band in Fourier space around k_c = 0.05 h/Mpc"
+    },
+    {
+      "@type": "DefinedTerm",
+      "name": "E_G Statistic",
+      "description": "Model-independent measurement of Sigma/mu isolating gravitational anisotropy; EFC predicts a ~7% scale-dependent bump at k ~ k_c"
+    }
+  ],
+  "keywords": [
+    "modified gravity",
+    "scale-localised",
+    "band-pass response",
+    "E_G statistic",
+    "gravitational slip",
+    "perturbation sector",
+    "DESI",
+    "Planck lensing"
+  ]
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/schema.json
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EFC Band-Pass Observational Test",
+  "description": "Schema for an observational test of the scale-localised modified gravity band-pass model",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the observational test"
+    },
+    "delta_chi2": {
+      "type": ["number", "null"],
+      "description": "Delta chi-squared relative to LCDM. Positive = EFC preferred."
+    },
+    "precision": {
+      "type": ["string", "null"],
+      "description": "Current measurement precision"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["PASS", "PASS (8%)", "EFC better", "Neutral", "GR preferred", "EFC marginal"],
+      "description": "Test outcome"
+    },
+    "k": {
+      "type": "number",
+      "description": "Wavenumber in h/Mpc (for E_G prediction table)"
+    },
+    "EG_GR": {
+      "type": "number",
+      "description": "E_G value in GR"
+    },
+    "EG_EFC": {
+      "type": "number",
+      "description": "E_G value in EFC band-pass model"
+    },
+    "delta_pct": {
+      "type": "number",
+      "description": "Fractional deviation Delta E_G / E_G in percent"
+    },
+    "Sigma_over_mu": {
+      "type": "number",
+      "description": "Ratio Sigma/mu at given k"
+    }
+  },
+  "required": ["name"]
+}

--- a/docs/papers/efc/Scale_Localised_Modified_Gravity/src/scale_localised_gravity.py
+++ b/docs/papers/efc/Scale_Localised_Modified_Gravity/src/scale_localised_gravity.py
@@ -1,0 +1,75 @@
+"""
+Scale-Localised Modified Gravity — Band-Pass Model Implementation.
+
+Implements the stiffness response R(k,a), observables mu, eta, Sigma,
+and the E_G forecast from DOI: 10.6084/m9.figshare.31985313.
+"""
+
+import numpy as np
+
+
+# --- Fixed parameters ---
+R_0 = 0.510           # Stiffness amplitude
+K_C = 0.05            # Characteristic scale [h/Mpc]
+F = 1.00005           # F = 1 + alpha * phi_bar
+EPS_TOT = 0.40        # Slip amplitude (viable: 0.38-0.42)
+OMEGA_M = 0.315       # Matter density parameter
+
+
+def stiffness_response(k, a, R0=R_0, kc=K_C):
+    """Band-pass stiffness response R(k,a) — Eq. 1."""
+    x = k / kc
+    return R0 * x**2 / (1 + x**2)**3 * a**4
+
+
+def mu(k, z, R0=R_0, kc=K_C):
+    """Effective gravitational coupling mu(k,z) — Eq. 2."""
+    a = 1.0 / (1.0 + z)
+    R = stiffness_response(k, a, R0, kc)
+    return 1.0 / (F * (1.0 + R))
+
+
+def eta(k, z, eps_tot=EPS_TOT, kc=K_C):
+    """Gravitational slip eta(k,z) — Eq. 3."""
+    a = 1.0 / (1.0 + z)
+    x = k / kc
+    return 1.0 + 2.0 * eps_tot * x**2 / (1.0 + x**2)**2 * a**2
+
+
+def sigma(k, z, R0=R_0, kc=K_C, eps_tot=EPS_TOT):
+    """Lensing combination Sigma(k,z) = mu*(1+eta)/2 — Eq. 4."""
+    mu_val = mu(k, z, R0, kc)
+    eta_val = eta(k, z, eps_tot, kc)
+    return mu_val * (1.0 + eta_val) / 2.0
+
+
+def E_G(k, z, f_z=None, omega_m=OMEGA_M, R0=R_0, kc=K_C, eps_tot=EPS_TOT):
+    """E_G statistic — Eq. 5.
+
+    Parameters
+    ----------
+    k : float or array
+        Wavenumber [h/Mpc].
+    z : float
+        Redshift.
+    f_z : float, optional
+        Growth rate f(z). If None, uses LCDM approximation f ~ Omega_m(z)^0.55.
+    """
+    if f_z is None:
+        a = 1.0 / (1.0 + z)
+        E2 = omega_m * a**(-3) + (1.0 - omega_m)
+        omega_m_z = omega_m * a**(-3) / E2
+        f_z = omega_m_z**0.55
+
+    sigma_val = sigma(k, z, R0, kc, eps_tot)
+    mu_val = mu(k, z, R0, kc)
+    return omega_m / f_z * sigma_val / mu_val
+
+
+def E_G_GR(z, omega_m=OMEGA_M):
+    """E_G in GR (scale-independent): Omega_m / f(z)."""
+    a = 1.0 / (1.0 + z)
+    E2 = omega_m * a**(-3) + (1.0 - omega_m)
+    omega_m_z = omega_m * a**(-3) / E2
+    f_z = omega_m_z**0.55
+    return omega_m / f_z

--- a/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/ai_manifest.json
+++ b/docs/papers/efc/Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry/ai_manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 4201
+      "bytes": 4400
     },
     {
       "path": "citations.bib",
@@ -177,6 +177,14 @@
       "bytes": 384
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 712
+    },
+    {
+      "path": "src/__pycache__/cluster_merger_constraints.cpython-311.pyc",
+      "bytes": 8429
+    },
+    {
       "path": "src/cluster_merger_constraints.py",
       "bytes": 5358
     },
@@ -185,6 +193,6 @@
       "bytes": 566
     }
   ],
-  "n_files": 42,
+  "n_files": 44,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/ai_manifest.json
+++ b/docs/papers/efc/Structural_Coherence_Evaluation_for_Physical_Theories/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1938
+      "bytes": 2132
     },
     {
       "path": "citations.bib",
@@ -57,6 +57,14 @@
       "bytes": 349
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 613
+    },
+    {
+      "path": "src/__pycache__/structural_coherence.cpython-311.pyc",
+      "bytes": 10797
+    },
+    {
       "path": "src/structural_coherence.py",
       "bytes": 9313
     },
@@ -69,6 +77,6 @@
       "bytes": 1399
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking/ai_manifest.json
+++ b/docs/papers/efc/Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1827
+      "bytes": 1933
     },
     {
       "path": "citations.bib",
@@ -53,6 +53,10 @@
       "bytes": 456
     },
     {
+      "path": "src/__pycache__/symbiosis_architecture.cpython-311.pyc",
+      "bytes": 14840
+    },
+    {
       "path": "src/symbiosis_architecture.py",
       "bytes": 8566
     },
@@ -73,6 +77,6 @@
       "bytes": 21391
     }
   ],
-  "n_files": 14,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/ai_manifest.json
+++ b/docs/papers/efc/Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2706
+      "bytes": 2894
     },
     {
       "path": "citations.bib",
@@ -113,6 +113,14 @@
       "bytes": 696
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 916
+    },
+    {
+      "path": "src/__pycache__/cmb_constraints.cpython-311.pyc",
+      "bytes": 8408
+    },
+    {
       "path": "src/cmb_constraints.py",
       "bytes": 4977
     },
@@ -121,6 +129,6 @@
       "bytes": 585
     }
   ],
-  "n_files": 26,
+  "n_files": 28,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier/ai_manifest.json
+++ b/docs/papers/efc/Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2489
+      "bytes": 2679
     },
     {
       "path": "citations.bib",
@@ -85,6 +85,14 @@
       "bytes": 361
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 640
+    },
+    {
+      "path": "src/__pycache__/cmb_localization.cpython-311.pyc",
+      "bytes": 19024
+    },
+    {
       "path": "src/cmb_localization.py",
       "bytes": 9910
     },
@@ -93,6 +101,6 @@
       "bytes": 597
     }
   ],
-  "n_files": 18,
+  "n_files": 20,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics/ai_manifest.json
+++ b/docs/papers/efc/The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics/ai_manifest.json
@@ -51,7 +51,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2895
+      "bytes": 3291
     },
     {
       "path": "citations.bib",
@@ -102,6 +102,22 @@
       "bytes": 1134
     },
     {
+      "path": "src/__pycache__/proxy_chain.cpython-311.pyc",
+      "bytes": 12691
+    },
+    {
+      "path": "src/__pycache__/rcmp_validator.cpython-311.pyc",
+      "bytes": 12990
+    },
+    {
+      "path": "src/__pycache__/regime_tagger.cpython-311.pyc",
+      "bytes": 10040
+    },
+    {
+      "path": "src/__pycache__/uncertainty_propagator.cpython-311.pyc",
+      "bytes": 13920
+    },
+    {
       "path": "src/proxy_chain.py",
       "bytes": 8443
     },
@@ -122,6 +138,6 @@
       "bytes": 626
     }
   ],
-  "n_files": 25,
+  "n_files": 29,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/The_Hubble_Tension_as_Regime_Mismatch/ai_manifest.json
+++ b/docs/papers/efc/The_Hubble_Tension_as_Regime_Mismatch/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1769
+      "bytes": 1963
     },
     {
       "path": "citations.bib",
@@ -69,6 +69,14 @@
       "bytes": 907
     },
     {
+      "path": "src/__pycache__/g_effective.cpython-311.pyc",
+      "bytes": 6721
+    },
+    {
+      "path": "src/__pycache__/regime_classifier.cpython-311.pyc",
+      "bytes": 7590
+    },
+    {
       "path": "src/g_effective.py",
       "bytes": 4438
     },
@@ -81,6 +89,6 @@
       "bytes": 524
     }
   ],
-  "n_files": 16,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/ai_manifest.json
+++ b/docs/papers/efc/Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1989
+      "bytes": 2181
     },
     {
       "path": "citations.bib",
@@ -65,6 +65,14 @@
       "bytes": 466
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 719
+    },
+    {
+      "path": "src/__pycache__/triangulation_test.cpython-311.pyc",
+      "bytes": 12527
+    },
+    {
       "path": "src/triangulation_test.py",
       "bytes": 9480
     },
@@ -77,6 +85,6 @@
       "bytes": 662
     }
   ],
-  "n_files": 15,
+  "n_files": 17,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification/ai_manifest.json
+++ b/docs/papers/efc/Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification/ai_manifest.json
@@ -46,7 +46,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2804
+      "bytes": 3382
     },
     {
       "path": "citations.bib",
@@ -89,6 +89,30 @@
       "bytes": 1008
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1369
+    },
+    {
+      "path": "src/__pycache__/entropy_mapping.cpython-311.pyc",
+      "bytes": 6208
+    },
+    {
+      "path": "src/__pycache__/h0_predictor.cpython-311.pyc",
+      "bytes": 7132
+    },
+    {
+      "path": "src/__pycache__/mond_interpolation.cpython-311.pyc",
+      "bytes": 8009
+    },
+    {
+      "path": "src/__pycache__/phase_calculator.cpython-311.pyc",
+      "bytes": 7139
+    },
+    {
+      "path": "src/__pycache__/unification.cpython-311.pyc",
+      "bytes": 8730
+    },
+    {
       "path": "src/entropy_mapping.py",
       "bytes": 3441
     },
@@ -113,6 +137,6 @@
       "bytes": 594
     }
   ],
-  "n_files": 24,
+  "n_files": 30,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_/ai_manifest.json
+++ b/docs/papers/efc/WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1952
+      "bytes": 2139
     },
     {
       "path": "citations.bib",
@@ -61,6 +61,14 @@
       "bytes": 425
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 743
+    },
+    {
+      "path": "src/__pycache__/wp3_rks_slice.cpython-311.pyc",
+      "bytes": 10541
+    },
+    {
       "path": "src/wp3_rks_slice.py",
       "bytes": 5835
     },
@@ -85,6 +93,6 @@
       "bytes": 146530
     }
   ],
-  "n_files": 17,
+  "n_files": 19,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/WP4_BOSS_transfer_validation/ai_manifest.json
+++ b/docs/papers/efc/WP4_BOSS_transfer_validation/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1468
+      "bytes": 1653
     },
     {
       "path": "citations.bib",
@@ -61,6 +61,14 @@
       "bytes": 379
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 565
+    },
+    {
+      "path": "src/__pycache__/wp4_transfer.cpython-311.pyc",
+      "bytes": 5941
+    },
+    {
       "path": "src/wp4_transfer.py",
       "bytes": 2751
     },
@@ -69,6 +77,6 @@
       "bytes": 495
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/WP4_BOSS_validation/ai_manifest.json
+++ b/docs/papers/efc/WP4_BOSS_validation/ai_manifest.json
@@ -34,7 +34,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1611
+      "bytes": 1802
     },
     {
       "path": "citations.bib",
@@ -69,6 +69,14 @@
       "bytes": 298
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 512
+    },
+    {
+      "path": "src/__pycache__/efc_boss_transfer.cpython-311.pyc",
+      "bytes": 15794
+    },
+    {
       "path": "src/efc_boss_transfer.py",
       "bytes": 10579
     },
@@ -81,6 +89,6 @@
       "bytes": 674
     }
   ],
-  "n_files": 16,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,6 +1,6 @@
 {
   "generated": "2026-04-10",
-  "n_packages": 136,
+  "n_packages": 137,
   "packages": [
     {
       "name": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
@@ -9,7 +9,7 @@
       "regimes": [],
       "primary_pdf": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology",
@@ -18,7 +18,7 @@
       "regimes": [],
       "primary_pdf": "AUTH-Layer-Origin-Provenance-and-Structural-Signature-of-Energy-Flow-Cosmology.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 15
     },
     {
       "name": "A_Pre-Registered_Test_of_Entropy–Structure_Coupling_in_Simulated_and_Observed_Galaxy_Clusters",
@@ -27,7 +27,7 @@
       "regimes": [],
       "primary_pdf": "BESR3_paper.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 20
     },
     {
       "name": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes",
@@ -36,7 +36,7 @@
       "regimes": [],
       "primary_pdf": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes_the_Interpretation_of_S_.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 17
     },
     {
       "name": "CEM-Consciousness-Ego-Mirror",
@@ -45,7 +45,7 @@
       "regimes": [],
       "primary_pdf": "CEM-Consciousness-Ego-Mirror.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "CMB-Thermodynamic-Interpretation",
@@ -54,7 +54,7 @@
       "regimes": [],
       "primary_pdf": "CMB-Thermodynamic-Interpretation/CMB_Thermodynamic_Interpretation.pdf",
       "created": [],
-      "n_files": 23
+      "n_files": 25
     },
     {
       "name": "Closing_the_EFC_Consciousness_Bridge",
@@ -63,7 +63,7 @@
       "regimes": [],
       "primary_pdf": "Closing_the_EFC_Consciousness_Bridge.pdf",
       "created": [],
-      "n_files": 12
+      "n_files": 13
     },
     {
       "name": "Comprehensive-analysis-of-175-SPARC-galaxies-demonstrating-regime-dependent-validity-in-rotation-curve-modeling",
@@ -77,7 +77,7 @@
       ],
       "primary_pdf": "SPARC175_COMPLETE_PAPER.pdf",
       "created": [],
-      "n_files": 62
+      "n_files": 64
     },
     {
       "name": "Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge",
@@ -86,7 +86,7 @@
       "regimes": [],
       "primary_pdf": "Connecting_Cosmology_Neural_Entropy_and_RLHF_Bridge.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test",
@@ -95,7 +95,7 @@
       "regimes": [],
       "primary_pdf": "Consistency_of_Scale_Dependent_Gravitational_Response_in_EFC_Numerical_Regime_Transition_Test.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Core-Lock",
@@ -104,7 +104,7 @@
       "regimes": [],
       "primary_pdf": "Core_Lock.pdf",
       "created": [],
-      "n_files": 23
+      "n_files": 29
     },
     {
       "name": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity",
@@ -113,7 +113,7 @@
       "regimes": [],
       "primary_pdf": "Cosmological_Growth_Constraints_on_Λ-Locked_Discrete_Entropic_Gravity.pdf",
       "created": [],
-      "n_files": 21
+      "n_files": 23
     },
     {
       "name": "Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints",
@@ -122,7 +122,7 @@
       "regimes": [],
       "primary_pdf": "Covariant_EFT_for_Entropy_Driven_Gravitational_Modification_Construction_Constraints_and_an_Identified_Microphysical_Gap.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Density_of_States_of_Gravitationally",
@@ -131,7 +131,7 @@
       "regimes": [],
       "primary_pdf": "Density_of_States_of_Gravitationally.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Derivation_of_the_Entropy_Production",
@@ -140,7 +140,7 @@
       "regimes": [],
       "primary_pdf": "Derivation_of_the_Entropy_Production.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Directional_Lensing_Residuals",
@@ -149,7 +149,7 @@
       "regimes": [],
       "primary_pdf": "Directional_Lensing_Residuals_Magnusson_2026.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 17
     },
     {
       "name": "Discrete_Entropic_Gravity_on_a_Cubic_Graph_Emergent_Newton_and_MOND_Regimes_with_Λ-Locked_Screening",
@@ -167,7 +167,7 @@
       "regimes": [],
       "primary_pdf": "Double-Slit_as_Grid-Resolution_Phenomenon_in_GRC_Ontological_Extension_UV-Cutoff_Analysis_and_Open_Gaps_toward_Quantum_Testability.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EBE-Core-Principles",
@@ -181,7 +181,7 @@
       ],
       "primary_pdf": "EBE_Core_Principles_v1_0-1.pdf",
       "created": [],
-      "n_files": 21
+      "n_files": 26
     },
     {
       "name": "EFC-A-Deep-Dive-into-the-Halo-Concept",
@@ -190,7 +190,7 @@
       "regimes": [],
       "primary_pdf": "EFC-A-Deep-Dive-into-the-Halo-Concept.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-AI-Augmented-Scientific-Workflow-Framework",
@@ -199,7 +199,7 @@
       "regimes": [],
       "primary_pdf": "EFC-AI-Augmented-Scientific-Workflow-Framework.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Applications-and-Implications",
@@ -208,7 +208,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Applications-and-Implications.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Bridging-Scales-FEP",
@@ -217,7 +217,7 @@
       "regimes": [],
       "primary_pdf": "EFC-FEP-Bridge-v1.0.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-CMB-Thermodynamic-Gradient",
@@ -226,7 +226,7 @@
       "regimes": [],
       "primary_pdf": "EFC-CMB-Thermodynamic-Gradient.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2",
@@ -235,7 +235,7 @@
       "regimes": [],
       "primary_pdf": "EFC-C_A_Thermodynamic_Framework_for_Cognitive_Entropy_and_Psychiatric_Biomarkers_Track_2.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-C_Cognitive_Entropy_Gradients_v2",
@@ -249,7 +249,7 @@
       ],
       "primary_pdf": null,
       "created": [],
-      "n_files": 18
+      "n_files": 20
     },
     {
       "name": "EFC-C_Consciousness_Field_Resonance",
@@ -258,7 +258,7 @@
       "regimes": [],
       "primary_pdf": "EFC-C_Consciousness_Field_Resonance_FINAL.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters",
@@ -267,7 +267,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Can-Energy-Flow-Be-Observed-in-Galactic-Clusters.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Can-Entropy-Drive-Cosmic-Evolution",
@@ -276,7 +276,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Can-Entropy-Drive-Cosmic-Evolution.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Dynamic-Balance-Entropy-Order-and-Chaos",
@@ -285,7 +285,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Dynamic-Balance-Entropy-Order-and-Chaos.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe",
@@ -294,7 +294,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Energy-Flow-as-the-Fundamental-Dynamic-of-the-Universe.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Field-Equations-for-Entropy-Driven-Spacetime",
@@ -303,7 +303,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Field-Equations-for-Entropy-Driven-Spacetime.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters",
@@ -312,7 +312,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Grid-Higgs-Framework",
@@ -321,7 +321,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Grid-Higgs-Framework.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Grid-Higgs-Paradigm-Shift",
@@ -330,7 +330,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Grid-Higgs-Paradigm-Shift.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Grid-Model-Entropic-Dynamics",
@@ -339,7 +339,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Grid-Model-Entropic-Dynamics.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-H0-S8-Tensions",
@@ -348,7 +348,7 @@
       "regimes": [],
       "primary_pdf": "Resolving%20the%20H0%20and%20S8%20Tensions%20Through.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-How-Does-Balance-Shape-Universal-Structures",
@@ -357,7 +357,7 @@
       "regimes": [],
       "primary_pdf": "EFC-How-Does-Balance-Shape-Universal-Structures.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-How-Energy-Flow-Sustain-Spacetime",
@@ -366,7 +366,7 @@
       "regimes": [],
       "primary_pdf": "EFC-How-Energy-Flow-Sustain-Spacetime.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Hypothesis-Interrelation-Energy-Entropy",
@@ -375,7 +375,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Hypothesis-Interrelation-Energy-Entropy.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Hypothesis-Universe-as-Energy-Driven-System",
@@ -384,7 +384,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Hypothesis-Universe-as-Energy-Driven-System.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Integrated-Hypothesis-Time-Entropy",
@@ -393,7 +393,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Integrated-Hypothesis-Time-Entropy.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Introduction-to-Energy-Flow-in-Space-Time",
@@ -402,7 +402,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Introduction-to-Energy-Flow-in-Space-Time.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Introduction-to-Entropy-in-Cosmic-Evolution",
@@ -411,7 +411,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Introduction-to-Entropy-in-Cosmic-Evolution.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Is-Consciousness-Linked-to-Entropy",
@@ -420,7 +420,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Is-Consciousness-Linked-to-Entropy.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe",
@@ -429,7 +429,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Light-Speed-as-a-Regulator-of-Energy-Flow-in-the-Universe.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time",
@@ -438,7 +438,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Mathematical-Framework-for-Energy-Flow-in-Space-Time.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Observational-Evidence-Entropy-Cosmic-Evolution",
@@ -447,7 +447,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Observational-Evidence-Entropy-Cosmic-Evolution.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-Observational-Evidence-for-Energy-Flow",
@@ -456,7 +456,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Observational-Evidence-for-Energy-Flow.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Phenomenology-vs-DESI-DR2-BAO-A-Comparative-Fit-Analysis",
@@ -465,7 +465,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Phenomenology_vs_DESI_DR2_BAO__A_Comparative_Fit_Analysis.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 19
     },
     {
       "name": "EFC-R-SPARC-Regime-Validity",
@@ -474,7 +474,7 @@
       "regimes": [],
       "primary_pdf": "EFC-R_SPARC_final.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Regime-Transition-Framework-A-CMB-Consistent-Approach-to-Late-Time-Cosmology",
@@ -488,7 +488,7 @@
       ],
       "primary_pdf": "paper/EFC-Regime-Transition-Framewor-A-CMB-Consistent-Appro.pdf",
       "created": [],
-      "n_files": 22
+      "n_files": 23
     },
     {
       "name": "EFC-Subhypothesis-Light-Speed-Limit",
@@ -497,7 +497,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Subhypothesis-Light-Speed-Limit.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Technical-Documentation-Energy-Flow-in-Space-Time",
@@ -506,7 +506,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Technical-Documentation-Energy-Flow-in-Space-Time.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-The-Energy-Flow-Interface",
@@ -515,7 +515,7 @@
       "regimes": [],
       "primary_pdf": "EFC-The-Energy-Flow-Interface.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Thermodynamic-Bridge-GR-QFT",
@@ -524,7 +524,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Thermodynamic-Bridge-GR-QFT.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Unresolved-Questions-and-Challenges-Entropy",
@@ -533,7 +533,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Unresolved-Questions-and-Challenges-Entropy.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-What-Happens-at-the-Universes-Extremes",
@@ -542,7 +542,7 @@
       "regimes": [],
       "primary_pdf": "EFC-What-Happens-at-the-Universes-Extremes.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now",
@@ -551,7 +551,7 @@
       "regimes": [],
       "primary_pdf": "EFC-What-is-the-Connection-Between-Energy-Flow-and-the-Now.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-Why-is-Light-Speed-a-Cosmic-Limit",
@@ -560,7 +560,7 @@
       "regimes": [],
       "primary_pdf": "EFC-Why-is-Light-Speed-a-Cosmic-Limit.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC-v1.2-Foundational-Framework",
@@ -569,7 +569,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v1.2-Foundational-Framework.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-v2.1-Complete-Edition",
@@ -578,7 +578,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v2.1-Complete-Edition.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-v2.1-Modular-Synthesis",
@@ -587,7 +587,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v2.1-Modular-Synthesis.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC-v2.2-Cross-Field-Integration-Summary",
@@ -596,7 +596,7 @@
       "regimes": [],
       "primary_pdf": "EFC-v2.2-Cross-Field-Integration-Summary.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFCLASS_Technical_Note_Sign_structure_of_an_additive_gate-function_modification_to_the_Friedmann_equation",
@@ -605,14 +605,14 @@
       "regimes": [],
       "primary_pdf": "efclass_companion_note.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "EFC_Background_NoGo_Theorem",
       "title": "EFC Background NoGo Theorem",
       "track": "Spor general",
       "regimes": [],
-      "primary_pdf": null,
+      "primary_pdf": "EFC_Background_NoGo_Theorem.pdf",
       "created": [],
       "n_files": 14
     },
@@ -623,7 +623,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Closure_Conjectures.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 15
     },
     {
       "name": "EFC_Cosmic_Dipole_Working_Note",
@@ -632,7 +632,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Cosmic_Dipole_Working_Note.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC_Entropy_Budget_Working_Note",
@@ -641,7 +641,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Entropy_Budget_Working_Note.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC_Gradient_Coupled_Grid_Action",
@@ -650,7 +650,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Gradient_Coupled_Grid_Action.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC_Ontological_Foundations",
@@ -659,7 +659,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Ontological_Foundations_v1_0_2-1.pdf",
       "created": [],
-      "n_files": 20
+      "n_files": 25
     },
     {
       "name": "EFC_Phase_3__SPARC_Validation",
@@ -668,7 +668,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Phase_3__SPARC_Validation.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 16
     },
     {
       "name": "EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction",
@@ -677,7 +677,7 @@
       "regimes": [],
       "primary_pdf": "EFC_Relativistic_Action_Field_Equations_Perturbation_Theory_and_Extraction.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "EFC_v1_3_PPN_Recovery_via_Density_Saturation",
@@ -686,7 +686,7 @@
       "regimes": [],
       "primary_pdf": "EFC_v1_3___PPN_Recovery_via_Density_Saturation__v2_1__Page_1_GR_Recovery_in_Energy_Flow_Cosmology_via_Density_Saturation__Quantitative_PPN_Analysis.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 18
     },
     {
       "name": "EFC_vs_LCDM_Kill_Test_v6_final",
@@ -708,7 +708,7 @@
       "regimes": [],
       "primary_pdf": null,
       "created": [],
-      "n_files": 41
+      "n_files": 43
     },
     {
       "name": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO",
@@ -717,7 +717,7 @@
       "regimes": [],
       "primary_pdf": "Energy-Flow-Cosmology-Unified-Analysis-of-BAO.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 17
     },
     {
       "name": "Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1",
@@ -726,7 +726,7 @@
       "regimes": [],
       "primary_pdf": "Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
@@ -735,7 +735,7 @@
       "regimes": [],
       "primary_pdf": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation",
@@ -744,7 +744,7 @@
       "regimes": [],
       "primary_pdf": "Energy_Flow_Cosmology__Regime_Transition_Fit_to_DESI_DR2_BAO_With_Cross_Validation_Against_Pantheon__and_H_z__Chronometers.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 17
     },
     {
       "name": "Foundations_of_Energy_Flow_Cosmology__EFC___Regime_Architecture_and_Methodological_Principles_of_Entropy_Bounded_Empiricism",
@@ -755,7 +755,7 @@
       ],
       "primary_pdf": "Foundations.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 17
     },
     {
       "name": "From_Grid_Microphysics_to_the_Radial_Acceleration",
@@ -764,7 +764,7 @@
       "regimes": [],
       "primary_pdf": "From_Grid_Microphysics_to_the_Radial_Acceleration.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "Homo_Fluxus",
@@ -773,7 +773,7 @@
       "regimes": [],
       "primary_pdf": "Homo_Fluxus_v2.0.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "ISW_Consistency_Audit_and_Revision_Patch_for_Energy-Flow_Cosmology_Cross-Correlation_Predictions",
@@ -782,7 +782,7 @@
       "regimes": [],
       "primary_pdf": "isw_revision_patch.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 17
     },
     {
       "name": "ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers",
@@ -791,7 +791,7 @@
       "regimes": [],
       "primary_pdf": "ISW_Cross-Correlation_Predictions_for_Energy-Flow_Cosmology_with_DESI_DR1_Tracers.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "KT3b_CrossRegime_Measurement_Failure_DOI",
@@ -800,7 +800,7 @@
       "regimes": [],
       "primary_pdf": "KT3b_CrossRegime_Measurement_Failure_DOI.pdf",
       "created": [],
-      "n_files": 12
+      "n_files": 13
     },
     {
       "name": "L0–L3-Regime-Architecture-in-Entropy-Bounded-Empiricism",
@@ -814,7 +814,7 @@
       ],
       "primary_pdf": "docs/L0_L3_Regime_Architecture_Figshare.pdf",
       "created": [],
-      "n_files": 21
+      "n_files": 23
     },
     {
       "name": "Local_Degree_Heterogeneity_Predicts_Functional_Variability_Gradients",
@@ -823,7 +823,7 @@
       "regimes": [],
       "primary_pdf": "Local_Degree_Heterogeneity_Predicts.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 17
     },
     {
       "name": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients",
@@ -832,7 +832,7 @@
       "regimes": [],
       "primary_pdf": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Multi_epoch_Growth_Rate_Test_of_EFC",
@@ -850,7 +850,7 @@
       "regimes": [],
       "primary_pdf": "Natural_and_Mechanical_Entropy_Intention_Detection_via_Episenter_Resonance Analysis_in_Information_Systems.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence",
@@ -859,7 +859,7 @@
       "regimes": [],
       "primary_pdf": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 17
     },
     {
       "name": "Perturbation-Level_σ₈_Suppression_via_μ_Sructural_Limits_of_Scale-Free_Modifications",
@@ -868,7 +868,7 @@
       "regimes": [],
       "primary_pdf": "efc_technical_note_II.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Phenomenological_constraints_on_entropy-flow_modifications_to_expansion_and_growth_from_BOSS_DR12",
@@ -877,7 +877,7 @@
       "regimes": [],
       "primary_pdf": "efc_phenomenology_paper.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 18
     },
     {
       "name": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology",
@@ -889,7 +889,7 @@
       ],
       "primary_pdf": "R_k_S__as_a_Regime_Response_Surface_in_Energy_Flow_Cosmology.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 17
     },
     {
       "name": "Regime-Based_World_Modeling_A_Layered_Epistemic_Architecture_for_Complex_System",
@@ -903,7 +903,7 @@
       ],
       "primary_pdf": "Regime_Based_World_Modeling__A_Layered_Epistemic_Architecture_for_Complex_Systems-1.pdf",
       "created": [],
-      "n_files": 22
+      "n_files": 29
     },
     {
       "name": "Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity",
@@ -912,7 +912,7 @@
       "regimes": [],
       "primary_pdf": "Regime_Bound_Measurement_in_Complex_Systems_Proxy_Placement_and_Validity.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 16
     },
     {
       "name": "Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
@@ -926,7 +926,7 @@
       ],
       "primary_pdf": "Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset.pdf",
       "created": [],
-      "n_files": 31
+      "n_files": 33
     },
     {
       "name": "Regime_Locked_Measurement",
@@ -935,7 +935,7 @@
       "regimes": [],
       "primary_pdf": "Regime-Locked-Measurement-Magnusson-2026.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models",
@@ -944,7 +944,7 @@
       "regimes": [],
       "primary_pdf": "Regime_Structure_and_Entropic_Flow_Ontology_in_Discrete_Gravity_Models.pdf",
       "created": [],
-      "n_files": 21
+      "n_files": 24
     },
     {
       "name": "Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3",
@@ -953,7 +953,7 @@
       "regimes": [],
       "primary_pdf": "Reinforcement_Learning_from_Human_Feedback_as_Thermodynamic_Entropy_Minimisation_A_Formal_Isomorphism_Track_3.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "Robustness_of_the_EFC_Growth-Sector_Signal_Leave-One-Out_Sound-Horizon_and_Amplitude-Prior_Controls_for_the_Hubble-Friction_Channel",
@@ -962,7 +962,16 @@
       "regimes": [],
       "primary_pdf": "EFC_Growth_Sector_Robustness_DOI_31332730.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
+    },
+    {
+      "name": "Scale_Localised_Modified_Gravity",
+      "title": "Scale Localised Modified Gravity",
+      "track": "Spor general",
+      "regimes": [],
+      "primary_pdf": "Scale_Localised_Modified_Gravity.pdf",
+      "created": [],
+      "n_files": 12
     },
     {
       "name": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry",
@@ -971,7 +980,7 @@
       "regimes": [],
       "primary_pdf": "Structural-Constraints-on-Entropy-Gradient-Gravity-from-Cluster-Merger-Geometry.pdf",
       "created": [],
-      "n_files": 42
+      "n_files": 44
     },
     {
       "name": "Structural_Coherence_Evaluation_for_Physical_Theories",
@@ -980,7 +989,7 @@
       "regimes": [],
       "primary_pdf": "Structural_Coherence_Evaluation_for_Physical_Theories__A_Theory_Agnostic_Framework_with_Observation_Native_Ontology_and_Self_Imposed_Falsifiability.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "Symbiosis-A-Human–AI-Co-Reflection-Architecture-Using-Graph–Vector-Memory-for-Long-Horizon-Thinking",
@@ -989,7 +998,7 @@
       "regimes": [],
       "primary_pdf": "symbiosis_method.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 15
     },
     {
       "name": "Systematic-CMB-Constraints-on-Early-Universe-Modifications-Parameter-Degeneracies-and-Null-Results",
@@ -998,7 +1007,7 @@
       "regimes": [],
       "primary_pdf": "EFC_CMB_Testing_Results.pdf",
       "created": [],
-      "n_files": 26
+      "n_files": 28
     },
     {
       "name": "Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier",
@@ -1011,7 +1020,7 @@
       ],
       "primary_pdf": "Systematic_Localization_of_Late-Time_Cosmological_Signals_in_Modified_Gravity_CMB_Survival_the-Lensing_Barrier.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 20
     },
     {
       "name": "The-Regime-Consistent-Measurement-Principle-RCMP-A-Methodological-Framework-for-Multi-Scale-Physics",
@@ -1025,7 +1034,7 @@
       ],
       "primary_pdf": "The_Regime_Consistent_Measurement_Principle__RCMP___A_Methodological_Framework_for_Multi_Scale_Physics-1.pdf",
       "created": [],
-      "n_files": 25
+      "n_files": 29
     },
     {
       "name": "The_Hubble_Tension_as_Regime_Mismatch",
@@ -1034,7 +1043,7 @@
       "regimes": [],
       "primary_pdf": "The_Hubble_Tension_as_Regime_Mismatch.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 18
     },
     {
       "name": "Triangulation_Test_for_Thermodynamic_Lensing_Coupling__A_Triangulation_Test_for_Possible_Thermodynamic",
@@ -1043,7 +1052,7 @@
       "regimes": [],
       "primary_pdf": "Triangulation-Test-for-Thermodynamic-Lensing-Coupling.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 17
     },
     {
       "name": "Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification",
@@ -1052,7 +1061,7 @@
       "regimes": [],
       "primary_pdf": "Unified_Origin_of_the_Radial_Acceleration_Relation_and_the_Hubble_Tension_via_Entropic_Gravity_Modification.pdf",
       "created": [],
-      "n_files": 24
+      "n_files": 30
     },
     {
       "name": "WP3__First_Empirical_Slice_Through_the_Regime_Response_Surface_R_k_S_",
@@ -1061,7 +1070,7 @@
       "regimes": [],
       "primary_pdf": "wp3_rks_article.pdf",
       "created": [],
-      "n_files": 17
+      "n_files": 19
     },
     {
       "name": "WP4_BOSS_transfer_validation",
@@ -1070,7 +1079,7 @@
       "regimes": [],
       "primary_pdf": "WP4_BOSS_transfer_validation.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "WP4_BOSS_validation",
@@ -1079,7 +1088,7 @@
       "regimes": [],
       "primary_pdf": "WP4_BOSS_validation.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 18
     },
     {
       "name": "ai_workflow_framework",
@@ -1088,7 +1097,7 @@
       "regimes": [],
       "primary_pdf": "ai_workflow_framework.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "bullet_cluster_efc",
@@ -1097,7 +1106,7 @@
       "regimes": [],
       "primary_pdf": "bullet_cluster_efc.pdf",
       "created": [],
-      "n_files": 12
+      "n_files": 13
     },
     {
       "name": "c_eff_parameterization",
@@ -1106,7 +1115,7 @@
       "regimes": [],
       "primary_pdf": "c_eff_parameterization_v3_final.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 16
     },
     {
       "name": "efc-weak-lensing-phenomenology",
@@ -1119,7 +1128,7 @@
       ],
       "primary_pdf": "docs/efc_weak_lensing_paper.pdf",
       "created": [],
-      "n_files": 20
+      "n_files": 21
     },
     {
       "name": "efc_boss_bao_cobaya_research_note",
@@ -1128,7 +1137,7 @@
       "regimes": [],
       "primary_pdf": "efc_boss_bao_cobaya_research_note.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "efc_des_y6_validation",
@@ -1137,7 +1146,7 @@
       "regimes": [],
       "primary_pdf": "efc_des_y6_validation.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "efc_formal_spec",
@@ -1146,7 +1155,7 @@
       "regimes": [],
       "primary_pdf": "efc_formal_spec.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "efc_master",
@@ -1155,7 +1164,7 @@
       "regimes": [],
       "primary_pdf": "efc_master.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "efc_master_v1",
@@ -1164,7 +1173,7 @@
       "regimes": [],
       "primary_pdf": "efc_master_v1.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 14
     },
     {
       "name": "efc_state_vs_stageIII",
@@ -1173,7 +1182,7 @@
       "regimes": [],
       "primary_pdf": "efc_state_vs_stageIII.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "efc_white_paper_part_1_to_4",
@@ -1195,7 +1204,7 @@
       "regimes": [],
       "primary_pdf": "Paper3_EFC_Regime_Synthesis_FINAL.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 20
     },
     {
       "name": "entropy-bounded-empiricism-EBE-SPARC175-complete-documentation",
@@ -1204,7 +1213,7 @@
       "regimes": [],
       "primary_pdf": "EBE_SPARC175_Complete_Documentation.pdf",
       "created": [],
-      "n_files": 18
+      "n_files": 19
     },
     {
       "name": "observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web",
@@ -1213,7 +1222,7 @@
       "regimes": [],
       "primary_pdf": "Magnusson_2026_COSMOS_Galaxy_Excess.pdf",
       "created": [],
-      "n_files": 26
+      "n_files": 28
     },
     {
       "name": "paper_rsd_to_clusters",
@@ -1222,7 +1231,7 @@
       "regimes": [],
       "primary_pdf": "paper_rsd_to_clusters.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "regime-dependent-breakdown-of-LCDM-across-cosmic-time",
@@ -1231,7 +1240,7 @@
       "regimes": [],
       "primary_pdf": "Regime_Dependent_Breakdown.pdf",
       "created": [],
-      "n_files": 16
+      "n_files": 18
     },
     {
       "name": "regime_consistency_lya_bao_rsd_sce",
@@ -1240,7 +1249,7 @@
       "regimes": [],
       "primary_pdf": "regime_consistency_lya_bao_rsd_sce_v1_0.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 16
     },
     {
       "name": "symbiotic-insight-framework",
@@ -1249,7 +1258,7 @@
       "regimes": [],
       "primary_pdf": "symbiotic-insight-framework.pdf",
       "created": [],
-      "n_files": 15
+      "n_files": 16
     },
     {
       "name": "validity-aware-ai",
@@ -1263,7 +1272,7 @@
       ],
       "primary_pdf": null,
       "created": [],
-      "n_files": 27
+      "n_files": 32
     },
     {
       "name": "variable-light-s0-s1",
@@ -1272,7 +1281,7 @@
       "regimes": [],
       "primary_pdf": "variable-light-s0-s1.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "void_isw_signflip_v2.1_final",
@@ -1281,7 +1290,7 @@
       "regimes": [],
       "primary_pdf": "void_isw_signflip_v2.1.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     },
     {
       "name": "ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology",
@@ -1290,7 +1299,7 @@
       "regimes": [],
       "primary_pdf": "ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology.pdf",
       "created": [],
-      "n_files": 13
+      "n_files": 15
     }
   ]
 }

--- a/docs/papers/efc/ai_workflow_framework/ai_manifest.json
+++ b/docs/papers/efc/ai_workflow_framework/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1427
+      "bytes": 1522
     },
     {
       "path": "ai_workflow_framework.jsonld",
@@ -65,10 +65,14 @@
       "bytes": 464
     },
     {
+      "path": "src/__pycache__/ai_workflow.cpython-311.pyc",
+      "bytes": 10800
+    },
+    {
       "path": "src/ai_workflow.py",
       "bytes": 7182
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/bullet_cluster_efc/ai_manifest.json
+++ b/docs/papers/efc/bullet_cluster_efc/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1374
+      "bytes": 1471
     },
     {
       "path": "bullet-cluster-efc.jsonld",
@@ -61,10 +61,14 @@
       "bytes": 2420
     },
     {
+      "path": "src/__pycache__/asig_2d_piemd.cpython-311.pyc",
+      "bytes": 14068
+    },
+    {
       "path": "src/asig_2d_piemd.py",
       "bytes": 12141
     }
   ],
-  "n_files": 12,
+  "n_files": 13,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/c_eff_parameterization/ai_manifest.json
+++ b/docs/papers/efc/c_eff_parameterization/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1501
+      "bytes": 1681
     },
     {
       "path": "c-eff-parameterization.jsonld",
@@ -69,10 +69,18 @@
       "bytes": 1052
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1244
+    },
+    {
+      "path": "src/__pycache__/c_eff.cpython-311.pyc",
+      "bytes": 19008
+    },
+    {
       "path": "src/c_eff.py",
       "bytes": 13561
     }
   ],
-  "n_files": 14,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc-weak-lensing-phenomenology/ai_manifest.json
+++ b/docs/papers/efc/efc-weak-lensing-phenomenology/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1986
+      "bytes": 2086
     },
     {
       "path": "citations.bib",
@@ -89,6 +89,10 @@
       "bytes": 556
     },
     {
+      "path": "src/__pycache__/efc_weak_lensing.cpython-311.pyc",
+      "bytes": 20742
+    },
+    {
       "path": "src/efc_weak_lensing.py",
       "bytes": 16528
     },
@@ -101,6 +105,6 @@
       "bytes": 4816
     }
   ],
-  "n_files": 20,
+  "n_files": 21,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_boss_bao_cobaya_research_note/ai_manifest.json
+++ b/docs/papers/efc/efc_boss_bao_cobaya_research_note/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1527
+      "bytes": 1716
     },
     {
       "path": "bao_cobaya.jsonld",
@@ -65,10 +65,18 @@
       "bytes": 288
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 528
+    },
+    {
+      "path": "src/__pycache__/bao_cobaya_test.cpython-311.pyc",
+      "bytes": 10775
+    },
+    {
       "path": "src/bao_cobaya_test.py",
       "bytes": 6574
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_des_y6_validation/ai_manifest.json
+++ b/docs/papers/efc/efc_des_y6_validation/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1420
+      "bytes": 1610
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 477
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 637
+    },
+    {
+      "path": "src/__pycache__/des_y6_validation.cpython-311.pyc",
+      "bytes": 8307
+    },
+    {
       "path": "src/des_y6_validation.py",
       "bytes": 3868
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_formal_spec/ai_manifest.json
+++ b/docs/papers/efc/efc_formal_spec/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1368
+      "bytes": 1462
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 561
     },
     {
+      "path": "src/__pycache__/efc_formal.cpython-311.pyc",
+      "bytes": 13549
+    },
+    {
       "path": "src/efc_formal.py",
       "bytes": 9556
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_master/ai_manifest.json
+++ b/docs/papers/efc/efc_master/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1333
+      "bytes": 1432
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 610
     },
     {
+      "path": "src/__pycache__/efc_master_spec.cpython-311.pyc",
+      "bytes": 11464
+    },
+    {
       "path": "src/efc_master_spec.py",
       "bytes": 7949
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_master_v1/ai_manifest.json
+++ b/docs/papers/efc/efc_master_v1/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1361
+      "bytes": 1463
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,14 @@
       "bytes": 525
     },
     {
+      "path": "src/__pycache__/efc_master_v1_spec.cpython-311.pyc",
+      "bytes": 10174
+    },
+    {
       "path": "src/efc_master_v1_spec.py",
       "bytes": 6630
     }
   ],
-  "n_files": 13,
+  "n_files": 14,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/efc_state_vs_stageIII/ai_manifest.json
+++ b/docs/papers/efc/efc_state_vs_stageIII/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1427
+      "bytes": 1615
     },
     {
       "path": "citations.bib",
@@ -61,6 +61,14 @@
       "bytes": 310
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 529
+    },
+    {
+      "path": "src/__pycache__/state_vs_stage3.cpython-311.pyc",
+      "bytes": 9042
+    },
+    {
       "path": "src/state_vs_stage3.py",
       "bytes": 7183
     },
@@ -69,6 +77,6 @@
       "bytes": 1376
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/energy-flow-cosmology-and-regime-dependent-structure-formation/ai_manifest.json
+++ b/docs/papers/efc/energy-flow-cosmology-and-regime-dependent-structure-formation/ai_manifest.json
@@ -38,7 +38,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2008
+      "bytes": 2198
     },
     {
       "path": "citations.bib",
@@ -81,6 +81,14 @@
       "bytes": 672
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 903
+    },
+    {
+      "path": "src/__pycache__/regime_structure.cpython-311.pyc",
+      "bytes": 11672
+    },
+    {
       "path": "src/regime_structure.py",
       "bytes": 7914
     },
@@ -89,6 +97,6 @@
       "bytes": 2850
     }
   ],
-  "n_files": 18,
+  "n_files": 20,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/ai_manifest.json
+++ b/docs/papers/efc/entropy-bounded-empiricism-EBE-SPARC175-complete-documentation/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2058
+      "bytes": 2154
     },
     {
       "path": "citations.bib",
@@ -81,6 +81,10 @@
       "bytes": 441
     },
     {
+      "path": "src/__pycache__/ebe_sparc175.cpython-311.pyc",
+      "bytes": 12661
+    },
+    {
       "path": "src/ebe_sparc175.py",
       "bytes": 7404
     },
@@ -89,6 +93,6 @@
       "bytes": 8658
     }
   ],
-  "n_files": 18,
+  "n_files": 19,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/ai_manifest.json
+++ b/docs/papers/efc/observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web/ai_manifest.json
@@ -39,7 +39,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2721
+      "bytes": 2912
     },
     {
       "path": "analysis_code.py",
@@ -114,6 +114,14 @@
       "bytes": 581
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 855
+    },
+    {
+      "path": "src/__pycache__/cosmos_abundances.cpython-311.pyc",
+      "bytes": 11825
+    },
+    {
       "path": "src/cosmos_abundances.py",
       "bytes": 6795
     },
@@ -122,6 +130,6 @@
       "bytes": 921593
     }
   ],
-  "n_files": 26,
+  "n_files": 28,
   "n_pdfs": 2
 }

--- a/docs/papers/efc/paper_rsd_to_clusters/ai_manifest.json
+++ b/docs/papers/efc/paper_rsd_to_clusters/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1454
+      "bytes": 1642
     },
     {
       "path": "citations.bib",
@@ -65,10 +65,18 @@
       "bytes": 324
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 554
+    },
+    {
+      "path": "src/__pycache__/rsd_to_clusters.cpython-311.pyc",
+      "bytes": 9086
+    },
+    {
       "path": "src/rsd_to_clusters.py",
       "bytes": 7016
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/ai_manifest.json
+++ b/docs/papers/efc/regime-dependent-breakdown-of-LCDM-across-cosmic-time/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1772
+      "bytes": 1959
     },
     {
       "path": "citations.bib",
@@ -77,10 +77,18 @@
       "bytes": 655
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 813
+    },
+    {
+      "path": "src/__pycache__/lcdm_breakdown.cpython-311.pyc",
+      "bytes": 8710
+    },
+    {
       "path": "src/lcdm_breakdown.py",
       "bytes": 4958
     }
   ],
-  "n_files": 16,
+  "n_files": 18,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/regime_consistency_lya_bao_rsd_sce/ai_manifest.json
+++ b/docs/papers/efc/regime_consistency_lya_bao_rsd_sce/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1653
+      "bytes": 1845
     },
     {
       "path": "citations.bib",
@@ -69,10 +69,18 @@
       "bytes": 359
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 590
+    },
+    {
+      "path": "src/__pycache__/regime_consistency.cpython-311.pyc",
+      "bytes": 17924
+    },
+    {
       "path": "src/regime_consistency.py",
       "bytes": 13189
     }
   ],
-  "n_files": 14,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/symbiotic-insight-framework/ai_manifest.json
+++ b/docs/papers/efc/symbiotic-insight-framework/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1630
+      "bytes": 1717
     },
     {
       "path": "citations.bib",
@@ -61,6 +61,10 @@
       "bytes": 423
     },
     {
+      "path": "src/__pycache__/sif.cpython-311.pyc",
+      "bytes": 11739
+    },
+    {
       "path": "src/sif.py",
       "bytes": 7177
     },
@@ -77,6 +81,6 @@
       "bytes": 4236
     }
   ],
-  "n_files": 15,
+  "n_files": 16,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/validity-aware-ai/ai_manifest.json
+++ b/docs/papers/efc/validity-aware-ai/ai_manifest.json
@@ -41,7 +41,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 2507
+      "bytes": 2994
     },
     {
       "path": "citations.bib",
@@ -108,6 +108,26 @@
       "bytes": 1434
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1563
+    },
+    {
+      "path": "src/__pycache__/ebe_filter.cpython-311.pyc",
+      "bytes": 12095
+    },
+    {
+      "path": "src/__pycache__/entropy_measures.cpython-311.pyc",
+      "bytes": 12626
+    },
+    {
+      "path": "src/__pycache__/regime_classifier.cpython-311.pyc",
+      "bytes": 9714
+    },
+    {
+      "path": "src/__pycache__/response_protocols.cpython-311.pyc",
+      "bytes": 13144
+    },
+    {
       "path": "src/ebe_filter.py",
       "bytes": 9307
     },
@@ -128,6 +148,6 @@
       "bytes": 646
     }
   ],
-  "n_files": 27,
+  "n_files": 32,
   "n_pdfs": 0
 }

--- a/docs/papers/efc/variable-light-s0-s1/ai_manifest.json
+++ b/docs/papers/efc/variable-light-s0-s1/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1454
+      "bytes": 1641
     },
     {
       "path": "citations.bib",
@@ -53,6 +53,14 @@
       "bytes": 612
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 766
+    },
+    {
+      "path": "src/__pycache__/variable_light.cpython-311.pyc",
+      "bytes": 9504
+    },
+    {
       "path": "src/variable_light.py",
       "bytes": 6367
     },
@@ -69,6 +77,6 @@
       "bytes": 6222
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/void_isw_signflip_v2.1_final/ai_manifest.json
+++ b/docs/papers/efc/void_isw_signflip_v2.1_final/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1462
+      "bytes": 1645
     },
     {
       "path": "citations.bib",
@@ -53,6 +53,14 @@
       "bytes": 968
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 1188
+    },
+    {
+      "path": "src/__pycache__/void_isw.cpython-311.pyc",
+      "bytes": 14996
+    },
+    {
       "path": "src/void_isw.py",
       "bytes": 11269
     },
@@ -69,6 +77,6 @@
       "bytes": 335641
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology/ai_manifest.json
+++ b/docs/papers/efc/ΛCDM_as_a_Special_Case_of_Energy-Flow_Cosmology/ai_manifest.json
@@ -26,7 +26,7 @@
     },
     {
       "path": "ai_manifest.json",
-      "bytes": 1652
+      "bytes": 1843
     },
     {
       "path": "cdm-as-a-special-case-of-energy-flow-cosmology.jsonld",
@@ -61,6 +61,14 @@
       "bytes": 713
     },
     {
+      "path": "src/__pycache__/__init__.cpython-311.pyc",
+      "bytes": 879
+    },
+    {
+      "path": "src/__pycache__/lcdm_special_case.cpython-311.pyc",
+      "bytes": 28644
+    },
+    {
       "path": "src/lcdm_special_case.py",
       "bytes": 21828
     },
@@ -69,6 +77,6 @@
       "bytes": 327145
     }
   ],
-  "n_files": 13,
+  "n_files": 15,
   "n_pdfs": 1
 }

--- a/docs/validation-ledger/data/evidence-register.json
+++ b/docs/validation-ledger/data/evidence-register.json
@@ -147,6 +147,31 @@
         "doi": "31333414",
         "name": "Background No-Go Theorem (sign lemma + CLASS + CMB+BAO → background sector empty)",
         "category": "structural"
+      },
+      {
+        "doi": "31970886",
+        "name": "EFC White Paper Part 1: Recovery Conditions and the LCDM Limit",
+        "category": "structural"
+      },
+      {
+        "doi": "31970898",
+        "name": "EFC White Paper Part 2: Field Equations and Observable Mapping",
+        "category": "structural"
+      },
+      {
+        "doi": "31970904",
+        "name": "EFC White Paper Part 3: Validation Ledger and Falsification Protocol",
+        "category": "structural"
+      },
+      {
+        "doi": "31970907",
+        "name": "EFC White Paper Part 4: Regime Susceptibility and Cross-Scale Mapping",
+        "category": "structural"
+      },
+      {
+        "doi": "31985313",
+        "name": "Scale-Localised Modified Gravity: band-pass R(k) model, E_G(k) forecast, eps_tot in [0.38,0.42]",
+        "category": "structural"
       }
     ]
   }

--- a/ecosystem.jsonld
+++ b/ecosystem.jsonld
@@ -110,6 +110,13 @@
       "description": "Three-pillar proof that background-level Friedmann modification cannot suppress σ₈: sign lemma (ΔE² ≤ 0), CLASS verification, observational α-collapse under CMB+BAO. Redirects all EFC effects to perturbation sector.",
       "identifier": "figshare:31333414",
       "url": "https://doi.org/10.6084/m9.figshare.31333414"
+    },
+    {
+      "@type": "ScholarlyArticle",
+      "name": "Scale-Localised Modified Gravity from the EFC Action",
+      "description": "Band-pass stiffness response R(k,a) localising gravity modification to k ~ 0.05 h/Mpc. Single-parameter E_G(k) forecast: ~7% bump testable at 2.5-3.5 sigma with DESI x Planck.",
+      "identifier": "figshare:31985313",
+      "url": "https://doi.org/10.6084/m9.figshare.31985313"
     }
   ],
 

--- a/figshare/doi-map.json
+++ b/figshare/doi-map.json
@@ -1,4 +1,10 @@
 {
+  "10.6084/m9.figshare.31985313": {
+    "figshare_id": 31985313,
+    "title": "Scale-Localised Modified Gravity from the EFC Action: A Single-Parameter Forecast via E_G(k,z)",
+    "path": "docs/papers/efc/Scale_Localised_Modified_Gravity",
+    "url": "https://doi.org/10.6084/m9.figshare.31985313"
+  },
   "10.6084/m9.figshare.31970907": {
     "figshare_id": 31970907,
     "title": "Energy-Flow Cosmology, Part 4: Regime Susceptibility and Cross-Scale Mapping",

--- a/llms.txt
+++ b/llms.txt
@@ -88,7 +88,7 @@ L3: S→1, μ→1+β, far future, structure saturation
 
 /auth/              → Origin, provenance, identity (START HERE)
 /theory/formal/     → LaTeX mathematical specifications
-/docs/papers/efc/   → 136 papers (136 with AI-friendly packages, 100% coverage)
+/docs/papers/efc/   → 137 papers (137 with AI-friendly packages, 100% coverage)
 /docs/public/       → Validation Ledger (v3.16), Master Spec
 /src/efc/           → Core Python library
 /pipelines/         → Graph-AQUAL pipeline + kill tests
@@ -102,7 +102,7 @@ L3: S→1, μ→1+β, far future, structure saturation
 /codemeta.json      → CodeMeta 2.0 metadata
 /ecosystem.jsonld   → Ecosystem linked data
 
-## AI-FRIENDLY PACKAGES (136 — 100% coverage)
+## AI-FRIENDLY PACKAGES (137 — 100% coverage)
 
 ### EFC White Paper Series (Canonical Reference)
 white-paper-part-1: src/recovery_limits.py, doi:31970886, Recovery Conditions & LCDM Limit
@@ -142,6 +142,7 @@ covariant-eft: src/covariant_eft.py, doi:31878334, classes: CovEFT, GravWaveSpee
 relativistic-action: src/efc_relativistic_action.py, doi:31876324
 cmb-localization: src/cmb_localization.py, doi:31368433
 background-nogo: src/background_nogo.py, doi:31333414, classes: SignLemma, BackgroundNoGo, result: ΔE²≤0 → background sector empty → perturbation only
+scale-localised-gravity: src/scale_localised_gravity.py, doi:31985313, band-pass R(k,a), mu<1, eta>1, Sigma>1, E_G bump ~7% at k_c=0.05 h/Mpc, eps_tot∈[0.38,0.42]
 discrete-gravity: src/discrete_gravity.py, doi:31348411, classes: GraphAQUAL
 
 ### Each package structure:


### PR DESCRIPTION
…85313)

New 10/10 package: band-pass stiffness model R(k,a) with E_G(k,z) forecast.
- Single parameter eps_tot in [0.38,0.42]; mu<1, eta>1, Sigma>1
- E_G bump ~7% at k_c=0.05 h/Mpc, testable at 2.5-3.5 sigma (DESI x Planck)
- Joint delta-chi^2 = +1.4 (EFC marginal)

Support files:
- doi-map.json, CITATION.cff, ecosystem.jsonld: +DOI 31985313
- evidence-register.json: +5 structural DOIs (WP Parts 1-4 restored + new paper)
- README.md, llms.txt, AGENTS.md: package count 136→137

Maintenance: 137 packages · 0 errors · 0 warnings

https://claude.ai/code/session_012Tf9r7G7HE7YmiFRr6yK2e