### PR TITLE
fix: complete changelog v2.2→v3.16 + add NoGo to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -117,6 +117,9 @@ identifiers:
   - type: doi
     value: "10.6084/m9.figshare.31985313"
     description: "Scale-Localised Modified Gravity: E_G(k,z) Forecast"
+  - type: doi
+    value: "10.6084/m9.figshare.31333414"
+    description: "EFC Background No-Go Theorem: Three-pillar proof (sign lemma + CLASS + CMB+BAO)"
 references:
   - type: article
     authors:

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -82,6 +82,57 @@
 <h2>2026</h2>
 
 <ul>
+  <!-- v3.16 entry -->
+  <li><strong>2026-04-10 (v3.16)</strong> – Added Scale-Localised Modified Gravity package (<a href="https://doi.org/10.6084/m9.figshare.31985313">31985313</a>): band-pass stiffness R(k,a), E<sub>G</sub> bump ~7% at k<sub>c</sub>=0.05 h/Mpc, testable at 2.5&ndash;3.5&sigma;. Added EFC Background No-Go Theorem AI-friendly package with three-pillar proof (sign lemma + CLASS + CMB+BAO &rarr; background sector empty). Propagated DOI references across all public documents. Corrected test count 100 &rarr; 102 in HTML ledger.</li>
+
+  <!-- v3.15 entry -->
+  <li><strong>2026-04-09 (v3.15)</strong> – Added EFC White Paper Series Parts 1&ndash;4 (<a href="https://doi.org/10.6084/m9.figshare.31970886">31970886</a>, <a href="https://doi.org/10.6084/m9.figshare.31970898">31970898</a>, <a href="https://doi.org/10.6084/m9.figshare.31970904">31970904</a>, <a href="https://doi.org/10.6084/m9.figshare.31970907">31970907</a>): Recovery Conditions, Field Equations, Validation &amp; Falsification, Regime Susceptibility. Created White Paper Series elevator pitch HTML and EFC Stage-IV Data Roadmap with 5 kill criteria, 6 sealed blind predictions, and FA1&ndash;FA6 action-level falsification conditions.</li>
+
+  <!-- v3.14 entry -->
+  <li><strong>2026-04-08 (v3.14)</strong> – Kill-Test v6 AI package (<a href="https://doi.org/10.6084/m9.figshare.31964847">31964847</a>): 4/4 cobaya &Delta;&chi;&sup2; &le; 0. Ledger internal version upgraded to v4.5 (Non-rejectable model stage). Added EFC Consciousness Bridge (<a href="https://doi.org/10.6084/m9.figshare.31969983">31969983</a>): three-equation system, 1 free parameter &gamma;.</li>
+
+  <!-- v3.12–v3.13 entry -->
+  <li><strong>2026-04-07 (v3.12&ndash;v3.13)</strong> – Added maintenance infrastructure (generator, verifier, orchestrator, hook, CI). Added EFC Gradient-Coupled Grid Action (<a href="https://doi.org/10.6084/m9.figshare.31941465">31941465</a>): E &prop; &radic;g from minimal Lagrangian, operator uniqueness. Added EFC Regime Transition Consistency Test (<a href="https://doi.org/10.6084/m9.figshare.31941543">31941543</a>): &mu;&lt;1 (linear) &harr; &mu;&gt;1 (non-linear), R&prop;k<sup>&minus;4</sup>, &Delta;&chi;&sup2;=&minus;0.03.</li>
+
+  <!-- v3.11 entry -->
+  <li><strong>2026-04-06 (v3.11)</strong> – Added Multi-epoch Growth Rate Test (<a href="https://doi.org/10.6084/m9.figshare.31955871">31955871</a>) to public ledger. Added &sect;4b External Observations Under Confrontation (third-party data, no EFC DOI): Bullet Cluster JWST-era externals.</li>
+
+  <!-- v3.10 entry -->
+  <li><strong>2026-04-05 (v3.10)</strong> – Added WP4 Cross-Survey Parameter Transfer Validation (<a href="https://doi.org/10.6084/m9.figshare.31954125">31954125</a>): DESI DR2 &rarr; BOSS/eBOSS, no refitting, &Delta;&chi;&sup2; = &minus;7.77.</li>
+
+  <!-- v3.9 entry -->
+  <li><strong>2026-04-04 (v3.9)</strong> – Added DES Y6 P3 lensing validation (<a href="https://doi.org/10.6084/m9.figshare.31951992">31951992</a>): pre-registered S<sub>8</sub><sup>lens</sup>/S<sub>8</sub><sup>CMB</sup> = 0.944 &plusmn; 0.018 vs prediction 0.95 &plusmn; 0.03 (0.3&sigma; agreement). P3 PASS ticked.</li>
+
+  <!-- v3.8 entry -->
+  <li><strong>2026-04-03 (v3.8)</strong> – Added &Lambda;CDM Special Case consolidation paper (<a href="https://doi.org/10.6084/m9.figshare.31943361">31943361</a>): &Lambda;CDM = L0/L1 limit, DESI DR2 &alpha; = &minus;0.14 &plusmn; 0.21, 204 publications, 100 tests at time of publication.</li>
+
+  <!-- Infrastructure update -->
+  <li><strong>2026-04 (infrastructure)</strong> – Upgraded all 126 paper packages to 10/10 AI-friendly structure. Upgraded repo infrastructure to 100% ASI-friendly. Mapped 124 ORCID DOIs to paper directories in doi-map.json. Added AI-friendly metadata layer to all 130+ EFC paper directories.</li>
+
+  <!-- v3.7 entry -->
+  <li><strong>2026-03 (v3.7)</strong> – Major AI integration update: README, AGENTS.md, llms.txt, Ledger v3.7. Added EFC Screening Model validation (<a href="https://doi.org/10.6084/m9.figshare.31940469">31940469</a>), EFC-C Cognitive Entropy (<a href="https://doi.org/10.6084/m9.figshare.31940505">31940505</a>), RLHF Thermodynamic Isomorphism (<a href="https://doi.org/10.6084/m9.figshare.31940535">31940535</a>), Cross-Domain Bridge Equations (<a href="https://doi.org/10.6084/m9.figshare.31940547">31940547</a>), Homo Fluxus v2.0 (<a href="https://doi.org/10.6084/m9.figshare.31940604">31940604</a>), Void ISW Sign-Flip (<a href="https://doi.org/10.6084/m9.figshare.31942677">31942677</a>), Cosmic Dipole Working Note (<a href="https://doi.org/10.6084/m9.figshare.31942731">31942731</a>), Entropy Budget Working Note (<a href="https://doi.org/10.6084/m9.figshare.31942734">31942734</a>).</li>
+
+  <!-- v3.6 entry -->
+  <li><strong>2026-03 (v3.6)</strong> – Validation Ledger v3.5 &rarr; v3.6. Added Grid Microphysics to RAR (<a href="https://doi.org/10.6084/m9.figshare.31878760">31878760</a>): Boltzmann-Euler RAR from 3 assumptions. Microphysical gap BRIDGED.</li>
+
+  <!-- v3.5 entry -->
+  <li><strong>2026-03 (v3.5)</strong> – Validation Ledger v3.4 &rarr; v3.5. Added Covariant EFT for Entropy-Driven Gravity (<a href="https://doi.org/10.6084/m9.figshare.31878334">31878334</a>): c<sub>gw</sub>=c theorem, RAR = Boltzmann-Euler.</li>
+
+  <!-- v3.4 entry -->
+  <li><strong>2026-03 (v3.4)</strong> – Validation Ledger v3.3 &rarr; v3.4. Added EFC Relativistic Action (<a href="https://doi.org/10.6084/m9.figshare.31876324">31876324</a>): &mu;&lt;1, &Sigma;&gt;1, &eta;&ne;1, c<sub>T</sub>=c. GRAV gap closed. Falsification conditions FA1&ndash;FA6 defined.</li>
+
+  <!-- v3.3 entry -->
+  <li><strong>2026-02-19 (v3.3)</strong> – Updated Validation Ledger to v3.3: Systematic Localization of Late-Time Cosmological Signals (<a href="https://doi.org/10.6084/m9.figshare.31368433">31368433</a>). &alpha;&asymp;0 under CMB+BAO.</li>
+
+  <!-- v3.2 entry -->
+  <li><strong>2026-02-16 (v3.2)</strong> – Upgraded Validation Ledger to v3.2 Referee Version.</li>
+
+  <!-- v3.1 entry -->
+  <li><strong>2026-02-16 (v3.1)</strong> – Updated Validation Ledger to v3.1: multi-sector structure with discrete gravity sector. Added Grid-AQUAL v0.1 nonlinear solver with 5 systematic kill-tests.</li>
+
+  <!-- v2.2 entry -->
+  <li><strong>2026-02-13 (v2.2)</strong> – Added EFCLASS Sign Structure (<a href="https://doi.org/10.6084/m9.figshare.31333414">31333414</a>) and Perturbation-Level &sigma;₈ Suppression (<a href="https://doi.org/10.6084/m9.figshare.31333600">31333600</a>) to validation ledger.</li>
+
   <!-- v2.1 entry -->
   <li><strong>2026-02-12 (v2.1)</strong> – ISW Consistency Audit v1.1 applied (<a href="https://doi.org/10.6084/m9.figshare.31329082">31329082</a>). Removed tomographic cancellation metric 𝒞 from canonical prediction set. Recomputed A<sub>ISW</sub> under fully self-consistent growth-channel implementation (ODE-based D(a), no potential μ′ term). Revised prediction: uniform suppression A<sub>ISW</sub> ≈ 0.89 ± 0.03 across tracers. Updated ISW row status from "Completed (no observational conflict; falsifiable prediction locked)" to "Completed (Self-consistent recomputation; quantitative revision)". Deprecated 𝒞-metric in Section 1.1 Phenomenological Constraints. Updated ISW sector in Regime × Observable Matrix to "BG → GRW (growth response only; no direct potential coupling)". Updated ISW planned pipeline entry from 𝒞-metric tomographic test to uniform A<sub>ISW</sub> amplitude validation.</li>
 


### PR DESCRIPTION
- EFC_Changelog.html: add 17 entries covering v2.2 through v3.16 (was stopped at v2.1, now current with all version bumps)
- CITATION.cff: add NoGo Theorem DOI (31333414) as identifer

Changelog covers: Grid-AQUAL, Systematic Localization, Relativistic Action, Covariant EFT, Grid Microphysics, AI integration, ΛCDM consolidation, DES Y6 P3 PASS, WP4 BOSS transfer, Multi-epoch growth, Kill-Test v6, Consciousness Bridge, White Paper Series, Stage-IV Roadmap, Background NoGo Theorem, Scale-Localised Gravity.