### PR TITLE
fix: resolve DOI conflict in EFC_Background_NoGo_Theorem (C8)

### DIFF
--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/CITATION.cff
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/CITATION.cff
@@ -8,7 +8,7 @@ authors:
     affiliation: "Symbiose Research, Sandnes, Norway"
 date-released: "2026-04-10"
 version: "1.0"
-doi: "10.6084/m9.figshare.31333414"
+doi: "10.6084/m9.figshare.31985163"
 license: "CC-BY-4.0"
 repository-code: "https://github.com/supertedai/EFC"
 keywords:

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/README.md
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/README.md
@@ -2,7 +2,7 @@
 
 ## AI-Friendly Package
 
-- **DOI:** [10.6084/m9.figshare.31333414](https://doi.org/10.6084/m9.figshare.31333414) (EFCLASS Sign Structure)
+- **DOI:** [10.6084/m9.figshare.31985163](https://doi.org/10.6084/m9.figshare.31985163) (consolidation package; source: [31333414](https://doi.org/10.6084/m9.figshare.31333414))
 - **Version:** 1.0
 - **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
 - **Affiliation:** Symbiose Research, Sandnes, Norway

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/ai_manifest.json
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/ai_manifest.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "README.md",
-      "bytes": 9603
+      "bytes": 9668
     },
     {
       "path": "ai_manifest.json",
@@ -58,7 +58,7 @@
     },
     {
       "path": "index.json",
-      "bytes": 8898
+      "bytes": 8910
     },
     {
       "path": "metadata.json",

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/efc-background-nogo-theorem.jsonld
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/efc-background-nogo-theorem.jsonld
@@ -5,7 +5,7 @@
     "doi": "https://doi.org/"
   },
   "@type": "ScholarlyArticle",
-  "@id": "doi:10.6084/m9.figshare.31333414",
+  "@id": "doi:10.6084/m9.figshare.31985163",
   "name": "EFC Background No-Go Theorem: Why Background-Level Modification Cannot Suppress Structure Growth",
   "headline": "Analytical proof, numerical verification, and observational confirmation that the EFC background coupling cannot suppress σ₈",
   "author": {
@@ -88,7 +88,7 @@
     }
   ],
   "epistemicStatus": "Layer B — Analytical theorem with numerical verification and observational confirmation; structural boundary (closed result)",
-  "identifier": "https://doi.org/10.6084/m9.figshare.31333414",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31333414",
-  "doi": "10.6084/m9.figshare.31333414"
+  "identifier": "https://doi.org/10.6084/m9.figshare.31985163",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31985163",
+  "doi": "10.6084/m9.figshare.31985163"
 }

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/index.json
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/index.json
@@ -6,7 +6,10 @@
   "version": "1.0",
   "date": "2026-04-10",
   "doi": "10.6084/m9.figshare.31985163",
-  "source_dois": ["10.6084/m9.figshare.31333414", "10.6084/m9.figshare.31368433"],
+  "source_dois": [
+    "10.6084/m9.figshare.31333414",
+    "10.6084/m9.figshare.31368433"
+  ],
   "keywords": [
     "Energy-Flow Cosmology",
     "no-go theorem",
@@ -270,5 +273,5 @@
     "schema": "schema.json",
     "citations": "citations.bib"
   },
-  "figshare_url": "https://doi.org/10.6084/m9.figshare.31333414"
+  "figshare_url": "https://doi.org/10.6084/m9.figshare.31985163"
 }

--- a/docs/papers/efc/EFC_Background_NoGo_Theorem/metadata.json
+++ b/docs/papers/efc/EFC_Background_NoGo_Theorem/metadata.json
@@ -9,7 +9,7 @@
     "affiliation": "Symbiose Research, Sandnes, Norway"
   },
   "license": "CC-BY-4.0",
-  "doi": "10.6084/m9.figshare.31333414",
+  "doi": "10.6084/m9.figshare.31985163",
   "abstract": "Consolidation package establishing the background sector no-go theorem for Energy-Flow Cosmology. Three independent lines of evidence — an analytical sign lemma (ΔE² ≤ 0 for all z > 0), numerical CLASS v3.3.4 verification, and observational CMB+BAO joint constraints (α → 0) — demonstrate that the EFC background coupling channel cannot suppress σ₈ and is observationally empty. This structural boundary redirects all late-time EFC effects to the perturbation sector (μ, Σ, η), producing sharper and independently testable predictions.",
   "keywords": [
     "Energy-Flow Cosmology",
@@ -62,7 +62,7 @@
     ]
   },
   "paper": {
-    "doi": "10.6084/m9.figshare.31333414",
-    "figshare_url": "https://doi.org/10.6084/m9.figshare.31333414"
+    "doi": "10.6084/m9.figshare.31985163",
+    "figshare_url": "https://doi.org/10.6084/m9.figshare.31985163"
   }
 }

--- a/maintain.log
+++ b/maintain.log
@@ -1,27 +1,19 @@
 [efc-gen] 139 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
-[efc-sync] conflicts present — manual reconciliation required
 ========================================================================
 EFC DOI sync — 139 paper dirs scanned
 ========================================================================
   papers with registered DOI : 134
   papers without DOI         : 5
-  papers with conflicts      : 1
+  papers with conflicts      : 0
 
-CONFLICTS (must be reconciled manually):
-  EFC_Background_NoGo_Theorem
-      10.6084/m9.figshare.31333414
-      10.6084/m9.figshare.31985163
-        index.json: 10.6084/m9.figshare.31985163
-        metadata.json: 10.6084/m9.figshare.31333414
-        CITATION.cff: 10.6084/m9.figshare.31333414
-        *.jsonld: 10.6084/m9.figshare.31333414
+PROPAGATED DOIs into 1 papers:
+  EFC_Background_NoGo_Theorem -> index.json
 ========================================================================
 [efc-gen] 139 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
-[efc-verify] 139 paper dirs · 1 errors · 0 warnings
-  [ERROR] C8 EFC_Background_NoGo_Theorem: DOI conflict: canonical=10.6084/m9.figshare.31333414 vs 10.6084/m9.figshare.31985163
+[efc-verify] 139 paper dirs · 0 errors · 0 warnings
 [efc-maintain] --- EFC maintenance pass ---
 [efc-maintain] running efc_gen_ai_friendly.py …
 [efc-maintain] running efc_sync_dois.py --apply…
 [efc-maintain] running efc_gen_ai_friendly.py …
 [efc-maintain] running efc_verify.py …
-[efc-maintain] --- done (issues) ---
+[efc-maintain] --- done (clean) ---


### PR DESCRIPTION
## Summary

- Resolve pre-existing DOI conflict in `EFC_Background_NoGo_Theorem` that caused `efc-verify` C8 failure
- Canonical DOI set to `10.6084/m9.figshare.31985163` (consolidation package) across metadata.json, CITATION.cff, jsonld, README.md
- Source component DOI `31333414` preserved in references/source_dois sections
- After fix: `efc-verify` reports **0 errors, 0 warnings**; `efc_sync_dois --check` reports **0 conflicts**

## Test plan

- [x] `efc-verify`: 0 errors, 0 warnings
- [x] `efc_sync_dois --check`: 0 conflicts
- [x] Source DOI preserved in CITATION.cff references and index.json source_dois

https://claude.ai/code/session_01SvUcWkvpzamxVQfZmDTyeQ