### PR TITLE
chore: refresh symbiose snapshot + unprocessed papers state

### DIFF
--- a/.claude/symbiose_snapshot.json
+++ b/.claude/symbiose_snapshot.json
@@ -1,6 +1,6 @@
 {
   "source": "ledger_fallback",
-  "generated_at": "2026-04-14T13:20:30.206755Z",
+  "generated_at": "2026-04-14T14:50:28.600620Z",
   "tests": {
     "total": 106,
     "active": 89,

--- a/.claude/unprocessed_papers.json
+++ b/.claude/unprocessed_papers.json
@@ -150,16 +150,6 @@
     "track": "unknown"
   },
   {
-    "directory": "EFC-Flow-Entropy-and-Spacetime-Distortion-in-Cosmological-Clusters",
-    "doi": "28112096",
-    "title": "EFC \u2014 Flow, Entropy, and Spacetime Distortion in Cosmological Clusters",
-    "missing_from": [
-      "Ledger"
-    ],
-    "has_key_results": true,
-    "track": "unknown"
-  },
-  {
     "directory": "EFC-Grid-Higgs-Framework",
     "doi": "28559510",
     "title": "EFC \u2014 Grid-Higgs Framework",
@@ -455,7 +445,6 @@
     "doi": "32011407",
     "title": "Effective Horndeski Reduction of the EFC Perturbation Sector",
     "missing_from": [
-      "Ledger",
       "Changelog"
     ],
     "has_key_results": true,
@@ -466,7 +455,6 @@
     "doi": "32010399",
     "title": "Pre-Registered Predictions for the Entropy Flow Cosmology (EFC) Model",
     "missing_from": [
-      "Ledger",
       "Changelog"
     ],
     "has_key_results": true,


### PR DESCRIPTION
Auto-generated by efc-maintain hook:
- symbiose_snapshot.json: bump generated_at timestamp
- unprocessed_papers.json: drop resolved Ledger entries (Flow-Entropy-Spacetime-Distortion, Horndeski-Reduction, Pre-Registered-Predictions)

https://claude.ai/code/session_01GL7cbnmEy4KsyKsNz4JvaK