### PR TITLE
gap-analysis: fix stale Bottom Line + add coherence guard

### DIFF
--- a/docs/public/EFC_Gap_Analysis.html
+++ b/docs/public/EFC_Gap_Analysis.html
@@ -112,7 +112,7 @@ April 2026 &middot; CC-BY-4.0
 
 <div style="background-color:#f8f9fa; border-left:4px solid #007bff; padding:15px; margin:20px 0;">
 <p style="margin:0; font-size:15px;">
-<strong>Purpose:</strong> Living assessment of what EFC needs vs what exists. Identifies gaps in pipeline readiness, theory, data timelines, and competitive landscape. Updated monthly or on significant external events. <strong>Last update: 2026-04-12.</strong>
+<strong>Purpose:</strong> Living assessment of what EFC needs vs what exists. Identifies gaps in pipeline readiness, theory, data timelines, and competitive landscape. Updated monthly or on significant external events. <strong>Last update: 2026-04-14.</strong>
 </p>
 </div>
 
@@ -269,9 +269,9 @@ April 2026 &middot; CC-BY-4.0
 
 <table>
 <tbody>
-<tr><td style="font-weight:bold; width:30%; background:#f8f9fa;">Biggest gap right now</td><td><strong>Bellini-Sawicki &alpha;-function mapping</strong> &mdash; needed for Euclid EFT pipeline before Oct 2026</td></tr>
-<tr><td style="font-weight:bold; background:#f8f9fa;">Most urgent monitor</td><td><strong>DESI DR2 full-shape RSD</strong> &mdash; only pending direct test of sealed f&sigma;<sub>8</sub> prediction</td></tr>
-<tr><td style="font-weight:bold; background:#f8f9fa;">Most urgent pre-registration</td><td><strong>Rubin DP2 cosmic shear</strong> + <strong>SO &times; Euclid E<sub>G</sub></strong> &mdash; both by Jul&ndash;Sep 2026</td></tr>
+<tr><td style="font-weight:bold; width:30%; background:#f8f9fa;">Biggest gap right now</td><td><strong>Rubin DP2 + SO &times; Euclid E<sub>G</sub> pre-registrations</strong> &mdash; both HIGH priority and NOT STARTED, deadlines Jul&ndash;Sep 2026. (Bellini&ndash;Sawicki &alpha;-mapping CLOSED in <a href="https://doi.org/10.6084/m9.figshare.32011407">32011407</a>.)</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Most urgent monitor</td><td><strong>DESI DR2 full-shape RSD</strong> &mdash; only pending direct test of sealed f&sigma;<sub>8</sub>(z=0.7) = 0.430 prediction</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Most urgent pre-registration</td><td><strong>Rubin DP2 cosmic shear</strong> (Jul 2026) + <strong>SO &times; Euclid E<sub>G</sub></strong> (Sep 2026) &mdash; both required to lock KC4 (&eta; &asymp; 1.10) before data arrives</td></tr>
 <tr><td style="font-weight:bold; background:#f8f9fa;">Key differentiator vs competitors</td><td>&eta; &asymp; 1.10 &mdash; no competitor model predicts this specific combination</td></tr>
 <tr><td style="font-weight:bold; background:#f8f9fa;">Automated monitoring</td><td><code>efc_weekly_scan.py</code> runs every Monday 07:00 UTC via GitHub Actions</td></tr>
 </tbody>

--- a/scripts/maintenance/efc_cross_validate.py
+++ b/scripts/maintenance/efc_cross_validate.py
@@ -20,6 +20,7 @@ Exit codes:
   2 = warnings only (publish OK but review recommended)
 """
 from __future__ import annotations
+import html as _html
 import json
 import os
 import re
@@ -319,6 +320,83 @@ def validate_consistency(repo, stats, result):
         result.ok(f"{repo['with_sealed']} papers have sealed predictions ({repo['sealed_total']} total)")
 
 
+def validate_gap_bottom_line(result):
+    """Check Gap Analysis 'Bottom Line' is coherent with Theory Gaps /
+    Priority Actions tables above.
+
+    Catches the specific failure mode where an individual gap row gets
+    flipped to CLOSED/DONE but the hardcoded summary in 'Bottom Line'
+    still cites that same gap as the biggest outstanding one.
+    """
+    print("\n--- Gap Analysis Coherence ---")
+    html = read_page("gap")
+    if not html:
+        result.warn("Gap Analysis page not found")
+        return
+
+    bl_pos = html.find("Bottom Line")
+    if bl_pos < 0:
+        result.warn("Gap Analysis: no Bottom Line section")
+        return
+
+    body = html[:bl_pos]
+    bottom = html[bl_pos:]
+
+    # Gather topics that have been CLOSED/DONE/SEALED in the tables above.
+    # Walk row-by-row: any <tr> whose status column carries a badge-done
+    # with CLOSED/DONE/SEALED wording is considered closed.
+    closed_topics = []
+    for row in re.findall(r"<tr>(.*?)</tr>", body, flags=re.DOTALL):
+        if not re.search(r"badge-done", row):
+            continue
+        if not re.search(r"\b(CLOSED|DONE|SEALED|PREDICTION READY|P3 PASS)\b",
+                         row, flags=re.IGNORECASE):
+            continue
+        first_td = re.search(r"<td[^>]*>(.*?)</td>", row, flags=re.DOTALL)
+        if not first_td:
+            continue
+        topic = _html.unescape(re.sub(r"<[^>]+>", " ", first_td.group(1)))
+        topic = re.sub(r"\s+", " ", topic).strip()
+        if 3 <= len(topic) <= 160:
+            closed_topics.append(topic.lower())
+
+    # Extract the "Biggest gap right now" cell content.
+    m = re.search(
+        r"Biggest gap right now</td>\s*<td>(.+?)</td>",
+        bottom,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+    if not m:
+        result.warn("Gap Analysis: could not parse 'Biggest gap right now'")
+        return
+
+    biggest_raw = _html.unescape(re.sub(r"<[^>]+>", " ", m.group(1))).lower()
+
+    def _normalize(s):
+        # Collapse any non-alphanumeric (hyphens, Greek, HTML entities) to spaces.
+        return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", s)).strip()
+
+    biggest_norm = _normalize(biggest_raw)
+    biggest_says_closed = any(
+        tok in biggest_norm for tok in ("closed", "done", "sealed"))
+
+    # Any CLOSED topic still cited as the biggest gap?  That's stale.
+    for topic in closed_topics:
+        tokens = _normalize(topic).split()
+        tokens = [t for t in tokens if len(t) > 2 and t not in {
+            "and", "the", "for", "with", "mapping", "function", "analysis"}]
+        if len(tokens) < 2:
+            continue
+        key = " ".join(tokens[:2])
+        if key in biggest_norm and not biggest_says_closed:
+            result.error(
+                f"Gap Analysis 'Biggest gap right now' still cites "
+                f"'{key}' but that row is marked CLOSED/DONE in the tables above")
+            return
+
+    result.ok(f"Gap Analysis Bottom Line coherent ({len(closed_topics)} closed rows checked)")
+
+
 def validate_symbiose(repo, stats, result):
     """Cross-check against Symbiose snapshot (graph + Qdrant + GNN)."""
     print("\n--- Symbiose Council ---")
@@ -416,6 +494,7 @@ def main():
     validate_all_pages_numbers(stats, result)
     validate_inference_doi(result)
     validate_consistency(repo, stats, result)
+    validate_gap_bottom_line(result)
     validate_symbiose(repo, stats, result)
 
     print(f"\n{'=' * 60}")


### PR DESCRIPTION
The "Bottom Line" row in EFC_Gap_Analysis.html still listed Bellini–Sawicki α-function mapping as the biggest outstanding gap even though Section 3 and Priority Action #2 had been flipped to CLOSED/DONE (figshare 32011407). The AI-brain patcher only rewrites individual rows via GPT-5 and requires OPENAI_API_KEY, which means the summary drifts whenever the key is absent or the LLM ignores the synthesis step.

Changes:
- Update Bottom Line to reflect current reality: biggest gap is the Rubin DP2 + SO×Euclid E_G pre-registrations (HIGH / NOT STARTED, deadlines Jul–Sep 2026). Keep the Bellini–Sawicki closure visible as a parenthetical so reviewers see the status trail.
- Bump "Last update" to 2026-04-14.
- Add validate_gap_bottom_line() to efc_cross_validate.py: walks every row in the body, collects topics whose status cell carries badge-done
  + CLOSED/DONE/SEALED, then checks none of them is cited (by distinctive two-token prefix) in the "Biggest gap right now" cell unless that cell itself acknowledges closure. Raises a CRITICAL error (blocks publish) when the guard fires, so this specific regression can't slip through without an OpenAI key. Regression-tested both directions.