### PR TITLE
fix(ai-brain): bare 8-digit DOI in evidence register + repair 62 entries on main

### DIFF
--- a/docs/validation-ledger/data/evidence-register.json
+++ b/docs/validation-ledger/data/evidence-register.json
@@ -130,312 +130,297 @@
         "category": "empirical"
       },
       {
-        "doi": "m9.figshare.30656828",
+        "doi": "30656828",
         "name": "AUTH Layer: Origin, Provenance and Structural Signature of Energy-Flow Cosmology",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30275947",
+        "doi": "30275947",
         "name": "CEM: A Field-Theoretic Model of Consciousness Coupled to Energy-Flow Cosmology",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31564129",
+        "doi": "31564129",
         "name": "Double-Slit as Grid-Resolution Phenomenon in Grid-Rendering Cosmology",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28114370",
+        "doi": "28114370",
         "name": "EFC \u2014 A Deep Dive into the Halo Concept",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30636863",
+        "doi": "30636863",
         "name": "EFC \u2014 AI-Augmented Scientific Workflow Framework",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098308",
+        "doi": "28098308",
         "name": "EFC \u2013 Applications and Implications",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31042678",
+        "doi": "31042678",
         "name": "Bridging Scales: Energy-Flow Cosmology and the Free Energy Principle as Compleme",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28570088",
+        "doi": "28570088",
         "name": "Hypothesis on Cosmic Microwave Background as a Thermodynamic Temperature Gradien",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098350",
+        "doi": "28098350",
         "name": "EFC \u2014 Can Energy Flow Be Observed in Galactic Clusters?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098353",
+        "doi": "28098353",
         "name": "EFC \u2014 Can Entropy Drive Cosmic Evolution?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098344",
+        "doi": "28098344",
         "name": "Dynamic Balance: How Entropy Governs the Balance Between Order and Chaos in Cosm",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28113542",
+        "doi": "28113542",
         "name": "EFC \u2014 Energy Flow as the Fundamental Dynamic of the Universe",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30421807",
+        "doi": "30421807",
         "name": "Energy-Flow Cosmology: Field Equations for Entropy-Driven Spacetime",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28559510",
+        "doi": "28559510",
         "name": "EFC \u2014 Grid-Higgs Framework",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28560935",
+        "doi": "28560935",
         "name": "Paradigm Shift in Cosmology: Continuous Energy Recycling Through the Grid-Higgs ",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28559423",
+        "doi": "28559423",
         "name": "Grid Model: An Entropic and Dynamic Theory for Emergent Gravity in Cosmology",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098338",
+        "doi": "28098338",
         "name": "EFC \u2014 How Does Balance Shape Universal Structures?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098371",
+        "doi": "28098371",
         "name": "EFC \u2014 How Energy Flow Sustains Spacetime",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28557281",
+        "doi": "28557281",
         "name": "EFC \u2014 Hypothesis: Interrelation Between Energy and Entropy",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098386",
+        "doi": "28098386",
         "name": "Hypothesis: The Universe as an Energy-Driven System \u2013 Integrating Time, Space, C",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28578263",
+        "doi": "28578263",
         "name": "EFC \u2014 Integrated Hypothesis: Time and Entropy",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098341",
+        "doi": "28098341",
         "name": "EFC \u2014 Introduction to Energy Flow in Space-Time",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098320",
+        "doi": "28098320",
         "name": "EFC \u2014 Introduction to Entropy in Cosmic Evolution",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098347",
+        "doi": "28098347",
         "name": "EFC \u2014 Is Consciousness Linked to Entropy?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28111925",
+        "doi": "28111925",
         "name": "EFC \u2014 Light Speed as a Regulator of Energy Flow in the Universe",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098314",
+        "doi": "28098314",
         "name": "EFC \u2014 Mathematical Framework for Energy Flow in Space-Time",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098299",
+        "doi": "28098299",
         "name": "EFC \u2014 Observational Evidence for Entropy in Cosmic Evolution",
         "category": "empirical"
       },
       {
-        "doi": "m9.figshare.28098365",
+        "doi": "28098365",
         "name": "EFC \u2014 Observational Evidence for Energy Flow",
         "category": "empirical"
       },
       {
-        "doi": "m9.figshare.31096951",
+        "doi": "31096951",
         "name": "Dynamical Regime Transitions in Cosmology: A CMB-Safe Framework",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28112036",
+        "doi": "28112036",
         "name": "EFC \u2014 Subhypothesis: Light Speed Limit",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098332",
+        "doi": "28098332",
         "name": "EFC \u2014 Technical Documentation: Energy Flow in Space-Time",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30468737",
+        "doi": "30468737",
         "name": "The Energy\u2013Flow Interface: A Unified Thermodynamic Interpretation of Dark Matter",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30402427",
+        "doi": "30402427",
         "name": "Energy-Flow Cosmology: A Thermodynamic Bridge Between General Relativity and Qua",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098326",
+        "doi": "28098326",
         "name": "EFC \u2014 Unresolved Questions and Challenges: Entropy",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098380",
+        "doi": "28098380",
         "name": "EFC \u2014 What Happens at the Universe\u2019s Extremes?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098311",
+        "doi": "28098311",
         "name": "EFC \u2014 What is the Connection Between Energy Flow and the Now?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.28098305",
+        "doi": "28098305",
         "name": "EFC \u2013 Why Is Light Speed a Cosmic Limit?",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30563738",
+        "doi": "30563738",
         "name": "Energy\u2013Flow Cosmology v1.2: Foundational Framework and Cross-Field Continuity",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30478916",
+        "doi": "30478916",
         "name": "EFC v2.1 \u2013 Complete Edition",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30455237",
+        "doi": "30455237",
         "name": "Energy-Flow Cosmology (EFC v2.1): Modular Synthesis across Structure, Dynamics, ",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30530156",
+        "doi": "30530156",
         "name": "EFC \u2014 v2.2 Cross-Field Integration Summary",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31985163",
+        "doi": "31985163",
         "name": "EFC Background No-Go Theorem: Why Background-Level Modification Cannot Suppress ",
         "category": "empirical"
       },
       {
-        "doi": "m9.figshare.31135597",
+        "doi": "31135597",
         "name": "Foundations of Energy-Flow Cosmology (EFC): Regime Architecture and Methodologic",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31990212",
+        "doi": "31990212",
         "name": "ISW Void Sign-Flip Observational Pipeline: From EFC Theory to Data Confrontation",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31112536",
+        "doi": "31112536",
         "name": "L0\u2013L3 Regime Architecture in Entropy-Bounded Empiricism",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31864993",
+        "doi": "31864993",
         "name": "Natural and Mechanical Entropy: Intention Detection via Episenter\u2013Resonance Anal",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31271707",
+        "doi": "31271707",
         "name": "Persistent Cognitive Architectures for Human-AI Co-Reasoning: Beyond Retrieval t",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31223650",
+        "doi": "31223650",
         "name": "Regime-Based World Modeling: A Layered Epistemic Architecture for Complex System",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31564123",
+        "doi": "31564123",
         "name": "Regime-Bound Measurement in Complex Systems: Proxy, Placement, and Validity",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31140000",
+        "doi": "31140000",
         "name": "Regime-Dependent Growth Enhancement: A Transition Metric Interpretation of the F",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31833076",
+        "doi": "31833076",
         "name": "Regime-Locked Measurement as a General Structural Constraint: Cross-Domain Frame",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31293745",
+        "doi": "31293745",
         "name": "Structural Coherence Evaluation for Physical Theories: A Theory-Agnostic Framewo",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30773684",
+        "doi": "30773684",
         "name": "Symbiosis: A Human\u2013AI Co-Reflection Architecture Using Graph\u2013Vector Memory for L",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31990194",
+        "doi": "31990194",
         "name": "Consistent Modified Gravity Weak Lensing in Energy-Flow Cosmology: The \u00b5\u2013\u03a3 Eigen",
         "category": "empirical"
       },
       {
-        "doi": "m9.figshare.30630500",
+        "doi": "30630500",
         "name": "EFC \u2014 Formal Specification",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31061872",
+        "doi": "31061872",
         "name": "Energy-Flow Cosmology and Regime-Dependent Structure Formation (Paper III)",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.31122970",
+        "doi": "31122970",
         "name": "Validity-Aware AI: An Entropy-Bounded Architecture for Regime-Sensitive Inferenc",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.30642497",
+        "doi": "30642497",
         "name": "Variable Effective Light Speed in Entropic Transition States: A Formal Treatment",
         "category": "structural"
       },
       {
-        "doi": "m9.figshare.32011407",
-        "name": "Effective Horndeski Reduction of the EFC Perturbation Sector",
-        "category": "structural"
-      },
-      {
-        "doi": "m9.figshare.32010399",
-        "name": "Pre-Registered Predictions for the Entropy Flow Cosmology (EFC) Model",
-        "category": "empirical"
-      },
-      {
-        "doi": "m9.figshare.31986762",
-        "name": "Kill-Test v6 Universality \u2014 Extension of the EFC vs \u039bCDM Kill-Test to the Full S",
-        "category": "empirical"
-      },
-      {
-        "doi": "m9.figshare.31954125",
+        "doi": "31954125",
         "name": "Cross-Survey Parameter Transfer Validation of Energy-Flow Cosmology: DESI DR2 Pa",
         "category": "empirical"
       }

--- a/scripts/maintenance/efc_ai_brain.py
+++ b/scripts/maintenance/efc_ai_brain.py
@@ -908,8 +908,16 @@ def update_evidence_register(paper_list):
         doi = idx.get("doi", "")
         if not doi:
             continue
-        # Extract just the figshare ID
-        doi_id = doi.split("/")[-1] if "/" in doi else doi
+        # Extract the bare numeric Figshare article ID.  The evidence
+        # register and efc_verify.py (C2) require 7–9 digits only — any
+        # prefix like "10.6084/m9.figshare." must be stripped.  Using
+        # split("/")[-1] here silently leaked "m9.figshare.XXX" strings
+        # whenever the input was the canonical DOI form, so match the
+        # numeric tail explicitly.
+        m = re.search(r"(\d{7,9})", doi)
+        doi_id = m.group(1) if m else ""
+        if not doi_id:
+            continue
         if doi_id not in existing_dois:
             paper_type = idx.get("paper_type", idx.get("type", "unknown"))
             cat = "empirical" if paper_type in ("empirical_test", "sealed_prediction") else "structural"


### PR DESCRIPTION
## Why main is red

`efc-verify.yml` on main is failing with 62 `C2 non-Figshare DOI`
errors because the `efc-main-sync` bot ran `efc_ai_brain.py` with
`OPENAI_API_KEY` set and wrote malformed entries like
`'m9.figshare.30656828'` into
`docs/validation-ledger/data/evidence-register.json`.

Root cause: `update_evidence_register()` stripped the DOI prefix with
`doi.split("/")[-1]`, which turns `10.6084/m9.figshare.32011407` into
`m9.figshare.32011407` — not the `^\d{8}$` form `efc_verify` requires.
The bug was invisible locally because `OPENAI_API_KEY` is unset, so the
code path was never exercised.

## Fix

- `scripts/maintenance/efc_ai_brain.py`: use `re.search(r"(\d{7,9})", doi)`
  (same semantics as `bare_doi_id()` in `efc_sync_dois.py`) and skip
  entries with no recoverable numeric id.
- `docs/validation-ledger/data/evidence-register.json`: normalize the
  62 malformed rows in place, drop 3 duplicates, 87 → 84 clean
  empirical entries.

Also carries the earlier commit on this branch:

- `docs/public/EFC_Gap_Analysis.html`: Bottom Line no longer cites
  Bellini–Sawicki α-mapping (already CLOSED). Now points at the actual
  biggest gap — Rubin DP2 + SO × Euclid E<sub>G</sub> pre-registrations
  (Jul–Sep 2026). Last-update bumped to 2026-04-14.
- `scripts/maintenance/efc_cross_validate.py`: new
  `validate_gap_bottom_line()` guard — deterministic (no LLM / no
  OpenAI key required) — blocks publish if "Biggest gap right now"
  still cites any row marked CLOSED/DONE/SEALED in the tables above.

## Verified locally

- `python3 scripts/maintenance/efc_verify.py` → 0 errors, 1 pre-existing
  C4 warning.
- `python3 scripts/maintenance/efc_cross_validate.py` → PASS (only the
  pre-existing `shear_kids1000` χ² warning).
- Regression-tested the Gap Analysis guard both directions: stale
  Bottom Line → CRITICAL/BLOCK, fixed → OK.