### PR TITLE
chore(efc-sync): refresh symbiose snapshot timestamp

### DIFF
--- a/.claude/symbiose_snapshot.json
+++ b/.claude/symbiose_snapshot.json
@@ -1,6 +1,6 @@
 {
   "source": "ledger_fallback",
-  "generated_at": "2026-04-15T17:24:35.649590Z",
+  "generated_at": "2026-04-15T17:30:10.256189Z",
   "tests": {
     "total": 118,
     "active": 100,


### PR DESCRIPTION
Run maintenance pass locally per CI request. Only artifact produced is the snapshot timestamp (preceding ai_manifest changes were already landed in 9aa02ab on main).