### PR TITLE
fix: update paper count from 148 to 149

### DIFF
--- a/.claude/symbiose_snapshot.json
+++ b/.claude/symbiose_snapshot.json
@@ -1,6 +1,6 @@
 {
   "source": "ledger_fallback",
-  "generated_at": "2026-04-16T20:00:47.848183Z",
+  "generated_at": "2026-04-16T20:03:09.172866Z",
   "tests": {
     "total": 119,
     "active": 101,

--- a/docs/papers/efc/efc_perturbation_sector/CITATION.cff
+++ b/docs/papers/efc/efc_perturbation_sector/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+title: "Efc Perturbation Sector"
+message: "If you use this work, please cite it as below."
+authors:
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+    affiliation: "Symbiose Research, Sandnes, Norway"
+date-released: "2026-04-16"
+version: "1.0"
+# doi: (pending)
+license: "CC-BY-4.0"
+repository-code: "https://github.com/supertedai/EFC"

--- a/docs/papers/efc/efc_perturbation_sector/LICENSE
+++ b/docs/papers/efc/efc_perturbation_sector/LICENSE
@@ -1,0 +1,8 @@
+Creative Commons Attribution 4.0 International (CC-BY-4.0)
+
+Copyright (c) 2026 Morten Magnusson
+
+You are free to share and adapt this material for any purpose, including
+commercially, as long as you give appropriate credit.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/docs/papers/efc/efc_perturbation_sector/README.md
+++ b/docs/papers/efc/efc_perturbation_sector/README.md
@@ -1,0 +1,16 @@
+# Efc Perturbation Sector
+
+## AI-Friendly Package
+
+- **DOI:** (pending)
+- **Version:** 1.0
+- **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
+- **Affiliation:** Symbiose Research, Sandnes, Norway
+- **Date:** 2026-04-16
+- **License:** CC-BY-4.0
+
+---
+
+## Overview
+
+Auto-generated metadata package for Efc Perturbation Sector.

--- a/docs/papers/efc/efc_perturbation_sector/ai_manifest.json
+++ b/docs/papers/efc/efc_perturbation_sector/ai_manifest.json
@@ -1,0 +1,87 @@
+{
+  "id": "efc-perturbation-sector",
+  "directory": "efc_perturbation_sector",
+  "title": "efc perturbation sector",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "package_type": "ai-friendly-paper",
+  "schema_version": "1.0",
+  "generated": "2026-04-16",
+  "track": "Spor 1 — Galactic/Cosmological",
+  "regimes": [],
+  "primary_pdf": "efc_perturbation_sector.pdf",
+  "all_pdfs": [
+    "efc_perturbation_sector.pdf",
+    "sigma_eff_crossover.pdf"
+  ],
+  "files": [
+    {
+      "path": "CITATION.cff",
+      "bytes": 414
+    },
+    {
+      "path": "LICENSE",
+      "bytes": 298
+    },
+    {
+      "path": "README.md",
+      "bytes": 374
+    },
+    {
+      "path": "citations.bib",
+      "bytes": 256
+    },
+    {
+      "path": "efc-perturbation-sector.jsonld",
+      "bytes": 540
+    },
+    {
+      "path": "efc_perturbation_engine.py",
+      "bytes": 17571
+    },
+    {
+      "path": "efc_perturbation_sector.pdf",
+      "bytes": 340322
+    },
+    {
+      "path": "efc_perturbation_sector.tex",
+      "bytes": 19310
+    },
+    {
+      "path": "horndeski_consistency.py",
+      "bytes": 9932
+    },
+    {
+      "path": "index.json",
+      "bytes": 529
+    },
+    {
+      "path": "lensing.py",
+      "bytes": 14658
+    },
+    {
+      "path": "metadata.json",
+      "bytes": 459
+    },
+    {
+      "path": "schema.json",
+      "bytes": 618
+    },
+    {
+      "path": "sigma_eff_crossover.pdf",
+      "bytes": 29260
+    },
+    {
+      "path": "valley_robustness_test.py",
+      "bytes": 6033
+    },
+    {
+      "path": "variant_h_result.json",
+      "bytes": 887
+    }
+  ],
+  "n_files": 17,
+  "n_pdfs": 2
+}

--- a/docs/papers/efc/efc_perturbation_sector/citations.bib
+++ b/docs/papers/efc/efc_perturbation_sector/citations.bib
@@ -1,0 +1,8 @@
+@misc{magnusson2026_efc_perturbation_sector,
+  author = {Magnusson, Morten},
+  title = {efc perturbation sector},
+  year = {2026},
+  publisher = {Figshare},
+  url = {https://github.com/supertedai/EFC},
+  note = {Energy-Flow Cosmology research programme}
+}

--- a/docs/papers/efc/efc_perturbation_sector/efc-perturbation-sector.jsonld
+++ b/docs/papers/efc/efc_perturbation_sector/efc-perturbation-sector.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+    "efc": "https://github.com/supertedai/EFC/ontology#"
+  },
+  "@type": "ScholarlyArticle",
+  "name": "Efc Perturbation Sector",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "affiliation": {
+      "@type": "Organization",
+      "name": "Symbiose Research",
+      "address": "Sandnes, Norway"
+    },
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-04-16",
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/docs/papers/efc/efc_perturbation_sector/index.json
+++ b/docs/papers/efc/efc_perturbation_sector/index.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "./schema.json",
+  "id": "efc-perturbation-sector",
+  "title": "Efc Perturbation Sector",
+  "description": "Auto-generated package for Efc Perturbation Sector.",
+  "version": "1.0",
+  "date": "2026-04-16",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "Perturbation",
+    "Sector"
+  ],
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Symbiose Research, Sandnes, Norway"
+  },
+  "files": {
+    "pdf": "sigma_eff_crossover.pdf",
+    "readme": "README.md"
+  }
+}

--- a/docs/papers/efc/efc_perturbation_sector/metadata.json
+++ b/docs/papers/efc/efc_perturbation_sector/metadata.json
@@ -1,0 +1,21 @@
+{
+  "title": "Efc Perturbation Sector",
+  "short_id": "efc-perturbation-sector",
+  "version": "1.0",
+  "date": "2026-04-16",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Symbiose Research, Sandnes, Norway"
+  },
+  "license": "CC-BY-4.0",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "Perturbation",
+    "Sector"
+  ],
+  "files": {
+    "pdf": "sigma_eff_crossover.pdf",
+    "readme": "README.md"
+  }
+}

--- a/docs/papers/efc/efc_perturbation_sector/schema.json
+++ b/docs/papers/efc/efc_perturbation_sector/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "efc perturbation sector Schema",
+  "type": "object",
+  "properties": {
+    "paper_id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "doi": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "key_results": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "parameters": {
+      "type": "object"
+    },
+    "predictions": {
+      "type": "array"
+    }
+  },
+  "required": [
+    "paper_id",
+    "title"
+  ]
+}


### PR DESCRIPTION
## Summary
- Updates paper count from 148 to 149 across README.md, AGENTS.md, Elevator Pitch, Changelog, and related files
- Adds auto-generated AI-friendly package for new `efc_perturbation_sector` paper (paper #149)
- Drift detector now reports zero drift

## Test plan
- [x] `efc_drift_detector.py` passes with no drift
- [x] `efc_maintain.py` runs clean (no new file changes)

https://claude.ai/code/session_01JCJkiQ7ccRtTefWhX1w8hU