### PR TITLE
chore: refresh symbiose_snapshot timestamp

### DIFF
--- a/.claude/symbiose_snapshot.json
+++ b/.claude/symbiose_snapshot.json
@@ -1,6 +1,6 @@
 {
   "source": "ledger_fallback",
-  "generated_at": "2026-04-20T04:35:44.768276Z",
+  "generated_at": "2026-04-20T16:00:34.999325Z",
   "tests": {
     "total": 119,
     "active": 101,


### PR DESCRIPTION
Auto-generated by efc_symbiose_snapshot.py --from-ledger during session-start maintenance pass. Only generated_at field changed.

https://claude.ai/code/session_013Ts6A475iWJVcurMTUE2WM