### PR TITLE
fix(atlas): soften KT-4 "shared mechanism" overclaim (reviewer-robust…

### DIFF
--- a/docs/public/EFC_Atlas.html
+++ b/docs/public/EFC_Atlas.html
@@ -310,7 +310,7 @@ data, and the arbiter instrument scheduled to resolve it.
     </span>
   </div>
   <h3 style="margin-top:0.4rem; font-size:1.18rem; color:#0d1b3e;">fσ₈ crossover at z_cross = 2.04 ± 0.07</h3>
-  <p style="margin-top:0.4rem; color:#1a3a6b; font-size:0.94rem;">KT-4 is the L1-growth companion to P1's L2-lensing crossover. The same primitive-chain that produces Σ_eff sign-change at z ≈ 0.44 produces fσ₈ crossover at z ≈ 2.04. This is not two independent predictions — it is one dynamical system evaluated at two scales. Cross-survey BAO transfer (BOSS ↔ DESI) already passes without refit, proving primitive rigidity.</p>
+  <p style="margin-top:0.4rem; color:#1a3a6b; font-size:0.94rem;">KT-4 is the L1-growth companion to P1's L2-lensing crossover. A shared primitive-chain is hypothesized to produce both Σ_eff sign-change (L2) and fσ₈ crossover (L1) as projections of the same underlying regime transition; the atlas treats this as a hypothesis consistent with both sector implementations, not a proven derivation. Cross-survey BAO transfer (BOSS ↔ DESI) already passes without refit, which is consistent with primitive rigidity under tested surveys.</p>
 
   <div class="hero-meta"><div class="cell"><span class="lbl">EFC</span><span class="val" style="font-size:0.86rem;">z_cross = 2.04 ± 0.07; D_H/r_d(1.0) = 16.527; D_H/r_d(0.7) = 19.797; fσ₈(0.7) = 0.430</span></div><div class="cell"><span class="lbl">ΛCDM</span><span class="val" style="font-size:0.86rem;">no crossover; D_H/r_d(1.0) = 17.466; D_H/r_d(0.7) = 20.719; fσ₈(0.7) = 0.449</span></div><div class="cell"><span class="lbl">Seal DOI</span><span class="val" style="font-size:0.86rem;"><a href="https://doi.org/10.6084/m9.figshare.32013156">10.6084/m9.figshare.32013156</a></span></div><div class="cell"><span class="lbl">Hash</span><span class="val" style="font-size:0.86rem;">7a850cfa58477701</span></div><div class="cell"><span class="lbl">Frozen at</span><span class="val" style="font-size:0.86rem;">2026-02-18T05:07:13Z</span></div><div class="cell"><span class="lbl">Arbiter</span><span class="val" style="font-size:0.86rem;">DESI DR2+ (z &gt; 1.5) full-shape RSD + BAO</span></div></div>
 
@@ -330,7 +330,7 @@ data, and the arbiter instrument scheduled to resolve it.
     </tbody>
   </table>
 
-  <h4 style="color:#0d1b3e; margin-top:1rem;">Exclusion lemma</h4><p style="background:#f0f5fc; border:1px solid #c9d4e4; border-radius:4px; padding:8px 12px; margin:0.3rem 0 0.8rem; font-size:0.90rem;">KT-4 and P1 are two roots of the same dynamical system at different scales (growth vs lensing). They cannot be independently tuned — moving one moves the other by a fixed relation. This is the stiffness of the closed primitive-chain {α, K, T, ξ, S_flow, S_latent}.</p>
+  <h4 style="color:#0d1b3e; margin-top:1rem;">Exclusion lemma</h4><p style="background:#f0f5fc; border:1px solid #c9d4e4; border-radius:4px; padding:8px 12px; margin:0.3rem 0 0.8rem; font-size:0.90rem;">KT-4 and P1 are hypothesized to share a dynamical root via the closed primitive-chain {α, K, T, ξ, S_flow, S_latent}. Their empirical co-motion across surveys is consistent with — but does not yet prove — a shared mechanism. Independent falsification at either anchor (DESI DR2 at z≈2.04 or Euclid DR1 at z≈0.44) would constrain the hypothesis.</p>
 
   <h4 style="color:#0d1b3e; margin-top:1rem;">Stage-III empirical sandwich</h4>
   <ul style="margin:0.4rem 0 0.2rem;">

--- a/docs/validation-ledger/data/atlas.json
+++ b/docs/validation-ledger/data/atlas.json
@@ -377,13 +377,13 @@
       "falsifier_condition": "No crossover observed in f\u03c3\u2088(z) up to z=2.5 at >2\u03c3, OR DESI DR2 BAO at z>1.5 consistent with \u039bCDM at >3\u03c3",
       "arbiter_instrument": "DESI DR2+ (z > 1.5) full-shape RSD + BAO",
       "source_evidence": "KT-4 sealed 2026-02-18",
-      "exclusion_lemma": "KT-4 and P1 are two roots of the same dynamical system at different scales (growth vs lensing). They cannot be independently tuned \u2014 moving one moves the other by a fixed relation. This is the stiffness of the closed primitive-chain {\u03b1, K, T, \u03be, S_flow, S_latent}.",
+      "exclusion_lemma": "KT-4 and P1 are hypothesized to share a dynamical root via the closed primitive-chain {\u03b1, K, T, \u03be, S_flow, S_latent}. Their empirical co-motion across surveys is consistent with \u2014 but does not yet prove \u2014 a shared mechanism. Independent falsification at either anchor (DESI DR2 at z\u22482.04 or Euclid DR1 at z\u22480.44) would constrain the hypothesis.",
       "stage_iii_sandwich": [
         {"survey": "BOSS+eBOSS full-shape", "role": "low-z anchor", "result": "BAO transfer PASS without refit (\u0394\u03c7\u00b2 = \u22127.77)"},
         {"survey": "DESI DR1", "role": "mid-z anchor", "result": "f\u03c3\u2088(0.706) \u2248 0.413 \u2014 on EFC trajectory"},
         {"survey": "DESI DR2 (pending)", "role": "decisive test", "result": "z>1.5 measurements will directly probe the crossover"}
       ],
-      "narrative_intro": "KT-4 is the L1-growth companion to P1's L2-lensing crossover. The same primitive-chain that produces \u03a3_eff sign-change at z \u2248 0.44 produces f\u03c3\u2088 crossover at z \u2248 2.04. This is not two independent predictions \u2014 it is one dynamical system evaluated at two scales. Cross-survey BAO transfer (BOSS \u2194 DESI) already passes without refit, proving primitive rigidity."
+      "narrative_intro": "KT-4 is the L1-growth companion to P1's L2-lensing crossover. A shared primitive-chain is hypothesized to produce both \u03a3_eff sign-change (L2) and f\u03c3\u2088 crossover (L1) as projections of the same underlying regime transition; the atlas treats this as a hypothesis consistent with both sector implementations, not a proven derivation. Cross-survey BAO transfer (BOSS \u2194 DESI) already passes without refit, which is consistent with primitive rigidity under tested surveys."
     }
   ]
 }


### PR DESCRIPTION
…ness)

External critique flagged that KT-4's exclusion_lemma and narrative_intro asserted "two roots of the same dynamical system" and "proving primitive rigidity" — claims that are hypothesized and consistent-with-data, not yet proven derivations.

Changes (atlas.json KT-4 only):
  - exclusion_lemma: "two roots of the same dynamical system... cannot be independently tuned" → "hypothesized to share a dynamical root... consistent with but does not yet prove a shared mechanism"
  - narrative_intro: "same primitive-chain... proving primitive rigidity" → "shared primitive-chain is hypothesized... consistent with primitive rigidity under tested surveys"

No structural changes. Graph-derived fields (efc_value, badge, seal_doi, claim, falsifier, arbiter, mechanism, addressings) remain 1:1 with the Symbiose graph. Curated narrative fields (narrative_intro, exclusion_lemma, stage_iii_sandwich) stay in atlas.json as manually maintained editorial content — not promoted to the graph by design.

P1's GW-speed exclusion lemma is a genuine structural proof and is left unchanged.