### PR TITLE
feat(ledgers): add Likelihood + Evaluation + Model Comparison ledgers

### DIFF
--- a/docs/public/EFC_Evaluation_Ledger.html
+++ b/docs/public/EFC_Evaluation_Ledger.html
@@ -1,0 +1,230 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Energy-Flow Cosmology (EFC) &ndash; Evaluation Ledger</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html { font-size: 16px; }
+    body { font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.7; color: #1a1a2e; background: #ffffff; max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem 3rem; }
+    h1 { font-size: 1.8rem; font-weight: 700; color: #0d1b3e; border-bottom: 3px solid #007bff; padding-bottom: 0.6rem; margin-bottom: 1.2rem; }
+    h2 { font-size: 1.35rem; font-weight: 600; color: #1a3a6b; margin-top: 2.5rem; margin-bottom: 0.8rem; border-left: 4px solid #007bff; padding-left: 0.7rem; }
+    h3 { font-size: 1.1rem; font-weight: 600; color: #2a4a7f; margin-top: 1.8rem; margin-bottom: 0.6rem; }
+    p { margin: 0.6rem 0; }
+    a { color: #0056b3; text-decoration: none; }
+    a:hover { text-decoration: underline; color: #003d80; }
+    hr { border: none; border-top: 1px solid #d0d7e3; margin: 2rem 0; }
+    ul, ol { padding-left: 1.6rem; }
+    li { margin-bottom: 0.3rem; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.88rem; box-shadow: 0 1px 4px rgba(0,0,0,0.06); border-radius: 6px; overflow: hidden; }
+    thead { background-color: #eaf0f9; }
+    th { border: 1px solid #d0d7e3; padding: 10px 12px; text-align: left; font-weight: 600; color: #1a3a6b; }
+    td { border: 1px solid #e2e6ed; padding: 8px 12px; vertical-align: top; }
+    tbody tr:hover { background-color: #f5f8fd; }
+    strong { color: #0d1b3e; }
+    sub, sup { font-size: 0.78em; }
+    code { font-family: 'Courier New', monospace; font-size: 0.90em; background: #f0f2f5; padding: 1px 5px; border-radius: 3px; }
+    pre { font-family: 'Courier New', monospace; font-size: 0.85em; background: #f0f2f5; padding: 12px 16px; border-radius: 6px; border-left: 4px solid #007bff; overflow-x: auto; line-height: 1.5; }
+    .badge-pass    { display:inline-block; background:#1a7a1a; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-tension { display:inline-block; background:#d4a017; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-fail    { display:inline-block; background:#c22;    color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-kc      { display:inline-block; background:#5b2d91; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    @media (max-width: 768px) { body { padding: 1rem; } h1 { font-size: 1.4rem; } table { font-size: 0.8rem; } th, td { padding: 6px 8px; } }
+  </style>
+</head>
+<body>
+
+<h1>Energy-Flow Cosmology (EFC) &mdash; Evaluation Ledger</h1>
+
+<div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
+  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Evaluation</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
+  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
+  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
+  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
+  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
+  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
+  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
+</div>
+
+<p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
+Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
+ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
+April 2026 &middot; CC-BY-4.0
+</p>
+
+<div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
+<p style="margin:0; font-size:15px;">
+<strong>Status:</strong> This ledger closes the <strong>global closure</strong> gap
+from the 2026-04-23 system audit: per-test outcomes are aggregated into a single,
+quantitative verdict via frozen thresholds and a documented score function.
+Verdicts are computed, not paraphrased. Falsification status and model preference
+are reported as <em>separate</em> fields &mdash; conflation was an explicit audit finding.
+Scope today: thresholds frozen, aggregation formula defined, weight registry
+seeded with defaults; live <code>current_state</code> computation after Likelihood
+Ledger pipelines execute.
+</p>
+</div>
+
+<hr>
+
+<h2>1. Purpose</h2>
+<p>The <a href="EFC_Validation_Ledger.html">Validation Ledger</a> records per-test
+results. The <a href="EFC_Likelihood_Ledger.html">Likelihood Ledger</a> records
+how those results were computed. This ledger computes the <strong>global verdict</strong>:
+how results combine, where the falsification line is, and what the current state
+of the framework is.</p>
+<p>Without this layer, the system can produce a wall of test outcomes without ever
+answering: is EFC currently falsified, in tension, or acceptable &mdash; and how
+does it compare overall against &Lambda;CDM?</p>
+
+<hr>
+
+<h2>2. Per-test verdict thresholds</h2>
+<p>Applied to every test with a <code>chi2</code> or <code>delta_chi2</code> in the
+Likelihood Ledger before aggregation.</p>
+<table>
+<thead><tr><th>Verdict</th><th>Criterion</th><th>Interpretation</th></tr></thead>
+<tbody>
+<tr><td><span class="badge-pass">PASS</span></td><td>|&Delta;&chi;&sup2;| &lt; 1</td><td>Indistinguishable from reference at current precision</td></tr>
+<tr><td><span class="badge-tension">TENSION</span></td><td>1 &le; |&Delta;&chi;&sup2;| &lt; 9 &nbsp; (~1&ndash;3&sigma;)</td><td>Notable deviation; not decisive</td></tr>
+<tr><td><span class="badge-fail">FAIL</span></td><td>|&Delta;&chi;&sup2;| &ge; 9 &nbsp; (&gt;3&sigma;)</td><td>Decisive deviation against expectation</td></tr>
+</tbody>
+</table>
+<p>Validation Ledger tests that carry the vocabulary value <code>COLLAPSED</code>
+map to <span class="badge-fail">FAIL</span>; <code>MARGINAL</code> maps to
+<span class="badge-tension">TENSION</span> when <code>|&Delta;&chi;&sup2;|</code>
+is unavailable.</p>
+
+<hr>
+
+<h2>3. Global score function</h2>
+<p><strong>Frequentist form (always computed):</strong></p>
+<pre>EFC_score = &Sigma;&#x1D62;  w&#x1D62; &middot; &Delta;&chi;&sup2;&#x1D62;</pre>
+<p>Sum runs over <strong>inference-grade tests only</strong> &mdash; those with a
+<a href="EFC_Likelihood_Ledger.html">Likelihood Ledger</a> row in status
+<code>executed</code> or <code>frozen</code>. Weights w&#x1D62; declared in the
+weight registry (default 1.0).</p>
+<p><strong>Bayesian form (when evidence is available):</strong></p>
+<pre>ln K_total = &Sigma;&#x1D62;  ln K&#x1D62;    &nbsp;&nbsp;(log-Bayes factor, EFC vs reference, per test)</pre>
+<p>Reported alongside the frequentist score whenever the Likelihood Ledger row
+includes <code>evidence</code> in its <code>outputs</code>.</p>
+
+<hr>
+
+<h2>4. System-level falsification rule</h2>
+<p>EFC is <strong>falsified at the system level</strong> if <em>either</em>:</p>
+<ol>
+<li>Any <span class="badge-kc">KC</span>-tagged kill-criterion test returns <span class="badge-fail">FAIL</span>, <em>or</em></li>
+<li>The global posterior odds <code>K_total</code> against &Lambda;CDM exceed <strong>1 : 100</strong> (decisive against, Jeffreys' scale).</li>
+</ol>
+<p>A non-kill-criterion test returning <span class="badge-fail">FAIL</span> produces
+<span class="badge-tension">TENSION</span> at the system level &mdash; flagged for
+review but not falsifying. The kill-criterion registry is pulled from
+<code>validation-ledger/data/grav.json</code> and mirrored into
+<code>evaluation-ledger/data/evaluation.json["thresholds"]["kill_criterion_ids"]</code>.</p>
+
+<hr>
+
+<h2>5. Falsification status &ne; model preference</h2>
+<p>An explicit gap in the 2026-04-23 audit: "non-rejectable" and "best model"
+were conflated. This ledger reports both as <strong>separate fields</strong>.</p>
+<table>
+<thead><tr><th>Field</th><th>Values</th><th>Source</th></tr></thead>
+<tbody>
+<tr><td><code>falsification_status</code></td><td><code>non-falsified</code> &middot; <code>tension</code> &middot; <code>falsified</code></td><td>Per rule in &sect;4</td></tr>
+<tr><td><code>model_preference</code></td><td><code>prefers_efc</code> &middot; <code>neutral</code> &middot; <code>prefers_lcdm</code> &middot; <code>insufficient_data</code></td><td>Per &Delta;AIC / ln K from <a href="EFC_Model_Comparison.html">Model Comparison</a></td></tr>
+</tbody>
+</table>
+<p>Both are reported every release. "&Lambda;CDM is currently preferred" and
+"EFC is currently not falsified" can both be true simultaneously &mdash; this
+ledger refuses to paper over that.</p>
+
+<hr>
+
+<h2>6. Weight registry</h2>
+<p>Non-unit weights must carry a rationale. Default is <code>weight = 1.0</code>.</p>
+<pre>{
+  "test_id": "s8_growth_fsigma8_2026",
+  "weight": 1.0,
+  "rationale": "Primary observable for &mu; &lt; 1 prediction"
+}</pre>
+<p>Down-weighting without a rationale string is rejected by the sync script.
+This blocks silent suppression of inconvenient tensions.</p>
+
+<hr>
+
+<h2>7. Atlas linkage <span class="badge-kc">read-only</span></h2>
+<p>The <a href="EFC_Atlas.html">Atlas</a> defines the model space. This ledger
+<strong>reads from</strong> Atlas via <code>data/atlas-link.json</code> to
+project per-test posteriors back into Atlas viability regions for reporting.</p>
+<table>
+<thead><tr><th>Field</th><th>Value / meaning</th></tr></thead>
+<tbody>
+<tr><td><code>atlas_ref</code></td><td>Pointer to the Atlas resource being consumed</td></tr>
+<tr><td><code>consumed_fields</code></td><td>e.g. <code>allowed_region</code>, <code>excluded_region</code></td></tr>
+<tr><td><code>modifies_atlas</code></td><td><code>false</code> (schema-enforced constant)</td></tr>
+</tbody>
+</table>
+<p><strong>This ledger does not write to the Atlas.</strong> Downstream projection
+(posteriors &rarr; Atlas regions) is a separate step; Atlas remains the source
+of truth for its own content.</p>
+
+<hr>
+
+<h2>8. Reporting block (per release)</h2>
+<p>Every generation of the ledger publishes a <code>current_state</code> block:</p>
+<pre>{
+  "falsification_status": "non-falsified | tension | falsified",
+  "model_preference":     "prefers_efc | neutral | prefers_lcdm | insufficient_data",
+  "efc_score":            &lt;number or null&gt;,
+  "ln_k_total":           &lt;number or null&gt;,
+  "tension_tests":        ["test_id", ...],
+  "fail_tests":           ["test_id", ...]
+}</pre>
+
+<hr>
+
+<h2>9. Open questions</h2>
+<ol>
+<li>Default weighting &mdash; uniform (w&#x1D62;=1) or proportional to data volume? <em>Current:</em> uniform with opt-in rationale-backed overrides.</li>
+<li>Correlated tests &mdash; should the sum be covariance-aware when observables overlap? <em>Planned:</em> covariance-aware variant for related observables.</li>
+<li>Kill-criterion registry &mdash; hard-coded here or pulled from <code>grav.json</code>? <em>Proposal:</em> pulled from <code>grav.json</code> (single source of truth).</li>
+</ol>
+
+<hr>
+
+<h2>Bottom line</h2>
+<table data-section="bottom-line">
+<tbody>
+<tr><td style="font-weight:bold; width:30%; background:#f8f9fa;">What this ledger fixes</td><td>Turns per-test results into a single quantitative system verdict with frozen thresholds &mdash; no more semantic verdicts.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Hard rule</td><td>Falsification status and model preference are reported separately, always. Conflation is blocked by schema.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Hard dependency</td><td><a href="EFC_Likelihood_Ledger.html">Likelihood Ledger</a> rows in status <code>executed</code> or <code>frozen</code>. No pipeline, no score.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Atlas safety</td><td>Read-only linkage via <code>atlas-link.json</code>; <code>modifies_atlas</code> pinned to <code>false</code> in schema.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Status</td><td>Thresholds and formulas frozen; weight registry seeded; <code>current_state</code> computation blocked until the first Likelihood Ledger pipeline executes.</td></tr>
+</tbody>
+</table>
+
+<hr>
+
+<p style="font-size:13px; color:#666;">
+&copy; 2026 Energy-Flow Cosmology Initiative &middot; Evaluation Ledger &mdash; frozen thresholds, documented aggregation, separated verdicts
+</p>
+
+<script>
+function notifyParentHeight() {
+  var h = document.documentElement.scrollHeight;
+  window.parent.postMessage({ efc_iframe_height: h }, '*');
+}
+window.addEventListener('load', notifyParentHeight);
+window.addEventListener('resize', notifyParentHeight);
+new MutationObserver(notifyParentHeight).observe(document.body, { childList: true, subtree: true });
+</script>
+
+</body>
+</html>

--- a/docs/public/EFC_Likelihood_Ledger.html
+++ b/docs/public/EFC_Likelihood_Ledger.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Energy-Flow Cosmology (EFC) &ndash; Likelihood Ledger</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html { font-size: 16px; }
+    body {
+      font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      line-height: 1.7;
+      color: #1a1a2e;
+      background: #ffffff;
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 2rem 2.5rem 3rem;
+    }
+    h1 { font-size: 1.8rem; font-weight: 700; color: #0d1b3e; border-bottom: 3px solid #007bff; padding-bottom: 0.6rem; margin-bottom: 1.2rem; }
+    h2 { font-size: 1.35rem; font-weight: 600; color: #1a3a6b; margin-top: 2.5rem; margin-bottom: 0.8rem; border-left: 4px solid #007bff; padding-left: 0.7rem; }
+    h3 { font-size: 1.1rem; font-weight: 600; color: #2a4a7f; margin-top: 1.8rem; margin-bottom: 0.6rem; }
+    p { margin: 0.6rem 0; }
+    a { color: #0056b3; text-decoration: none; }
+    a:hover { text-decoration: underline; color: #003d80; }
+    hr { border: none; border-top: 1px solid #d0d7e3; margin: 2rem 0; }
+    ul, ol { padding-left: 1.6rem; }
+    li { margin-bottom: 0.3rem; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.88rem; box-shadow: 0 1px 4px rgba(0,0,0,0.06); border-radius: 6px; overflow: hidden; }
+    thead { background-color: #eaf0f9; }
+    th { border: 1px solid #d0d7e3; padding: 10px 12px; text-align: left; font-weight: 600; color: #1a3a6b; }
+    td { border: 1px solid #e2e6ed; padding: 8px 12px; vertical-align: top; }
+    tbody tr:hover { background-color: #f5f8fd; }
+    strong { color: #0d1b3e; }
+    sub, sup { font-size: 0.78em; }
+    code { font-family: 'Courier New', monospace; font-size: 0.90em; background: #f0f2f5; padding: 1px 5px; border-radius: 3px; }
+    pre { font-family: 'Courier New', monospace; font-size: 0.85em; background: #f0f2f5; padding: 12px 16px; border-radius: 6px; border-left: 4px solid #007bff; overflow-x: auto; line-height: 1.5; }
+    .badge-declared { display:inline-block; background:#555;    color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-runnable { display:inline-block; background:#0a7bd1; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-executed { display:inline-block; background:#1a7a1a; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-frozen   { display:inline-block; background:#5b2d91; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-gap      { display:inline-block; background:#c22;    color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .like-card { background: #fafbfd; border: 1px solid #d0d7e3; border-left: 4px solid #007bff; border-radius: 6px; padding: 14px 18px; margin: 1rem 0 1.5rem; }
+    .like-card h3 { margin-top: 0; }
+    .like-card table { margin-bottom: 0.6rem; }
+    @media (max-width: 768px) { body { padding: 1rem; } h1 { font-size: 1.4rem; } table { font-size: 0.8rem; } th, td { padding: 6px 8px; } }
+  </style>
+</head>
+<body>
+
+<h1>Energy-Flow Cosmology (EFC) &mdash; Likelihood Ledger</h1>
+
+<div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
+  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Likelihood</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
+  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
+  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
+  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
+  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
+  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
+  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
+</div>
+
+<p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
+Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
+ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
+April 2026 &middot; CC-BY-4.0
+</p>
+
+<div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
+<p style="margin:0; font-size:15px;">
+<strong>Status:</strong> This ledger closes the <strong>Dataset &rarr; Likelihood</strong>
+gap identified in the 2026-04-23 system audit. Every empirical test in the
+<a href="EFC_Validation_Ledger.html">Validation Ledger</a> must declare here
+<em>which likelihood, which covariance, which priors, which code</em>. Tests
+without a Likelihood Ledger row are not eligible for inclusion in the
+<a href="EFC_Evaluation_Ledger.html">Evaluation Ledger</a> global score.
+Scope today: schema frozen, worked example included, bulk population pending
+pipeline declaration by maintainer.
+</p>
+</div>
+
+<hr>
+
+<h2>1. Purpose</h2>
+<p>
+The <a href="EFC_Validation_Ledger.html">Validation Ledger</a> records <em>what
+was tested and how it scored</em>. The Likelihood Ledger records <em>how the
+score was computed</em>. Without this layer, two identically-named tests in
+different pipelines (e.g. direct chi&sup2; vs full Cobaya posterior) can produce
+different verdicts &mdash; the system becomes non-reproducible.
+</p>
+<p>
+Every row here binds a <code>test_id</code> from the Validation Ledger to a
+fully declared pipeline: likelihood type, covariance source, parameter priors,
+code, entry point, inputs, outputs, and execution status.
+</p>
+
+<hr>
+
+<h2>2. Schema (summary)</h2>
+<table>
+<thead><tr><th>Field</th><th>Meaning</th><th>Required</th></tr></thead>
+<tbody>
+<tr><td><code>test_id</code></td><td>Foreign key into <code>validation-ledger/data/tests.json</code></td><td>yes</td></tr>
+<tr><td><code>likelihood_type</code></td><td><code>gaussian</code> &middot; <code>gaussian_cov</code> &middot; <code>binned_chi2</code> &middot; <code>mcmc_posterior</code> &middot; <code>analytic</code> &middot; <code>external</code></td><td>yes</td></tr>
+<tr><td><code>covariance</code></td><td>Path or DOI of covariance matrix; <code>diagonal</code> if independent errors</td><td>yes</td></tr>
+<tr><td><code>parameter_priors</code></td><td>dict of parameter &rarr; {type, range / mean &plusmn; sigma / ref}</td><td>yes</td></tr>
+<tr><td><code>code</code></td><td><code>cobaya</code> &middot; <code>mgcamb</code> &middot; <code>cosmoSIS</code> &middot; <code>direct_python</code> &middot; <code>external</code></td><td>yes</td></tr>
+<tr><td><code>code_version</code></td><td>Git SHA / package version / external tag</td><td>recommended</td></tr>
+<tr><td><code>entry_point</code></td><td>Repo-relative script or external URL</td><td>yes when code is not external</td></tr>
+<tr><td><code>inputs</code></td><td>Dataset DOIs / repo refs</td><td>yes</td></tr>
+<tr><td><code>outputs</code></td><td>Subset of: <code>chi2</code>, <code>best_fit</code>, <code>posterior_summary</code>, <code>evidence</code>, <code>log_likelihood</code>, <code>predictive_samples</code></td><td>yes</td></tr>
+<tr><td><code>status</code></td><td><span class="badge-declared">declared</span> <span class="badge-runnable">runnable</span> <span class="badge-executed">executed</span> <span class="badge-frozen">frozen</span></td><td>yes</td></tr>
+</tbody>
+</table>
+<p>Full JSON Schema: <code>docs/likelihood-ledger/schema.json</code>.</p>
+
+<hr>
+
+<h2>3. Pipeline registry (initial scan)</h2>
+<p>Status as of ledger creation. Entries marked <span class="badge-gap">GAP</span>
+have no pipeline declared and block their Validation Ledger counterparts from
+the Evaluation Ledger.</p>
+<table>
+<thead><tr><th>Category</th><th>Likelihood type</th><th>Code</th><th>Entry point</th><th>Status</th></tr></thead>
+<tbody>
+<tr><td>BAO (DESI, eBOSS)</td><td><code>gaussian_cov</code></td><td><code>direct_python</code></td><td><code>reproduce_bao.py</code></td><td><span class="badge-runnable">runnable</span></td></tr>
+<tr><td>CMB sanity</td><td><code>gaussian</code></td><td><code>direct_python</code></td><td><code>reproduce_cmb_sanity.py</code></td><td><span class="badge-runnable">runnable</span></td></tr>
+<tr><td>SPARC rotation curves</td><td><code>binned_chi2</code></td><td><code>direct_python</code></td><td><code>reproduce_sparc.py</code></td><td><span class="badge-runnable">runnable</span></td></tr>
+<tr><td>EFC integration (background)</td><td><code>analytic</code></td><td><code>direct_python</code></td><td><code>reproduce_efc.py</code></td><td><span class="badge-runnable">runnable</span></td></tr>
+<tr><td>f&sigma;<sub>8</sub> / S<sub>8</sub> (growth)</td><td><code>gaussian_cov</code></td><td>TBD (Cobaya likely)</td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
+<tr><td>Cosmic shear (DES, KiDS, Euclid)</td><td><code>mcmc_posterior</code></td><td><code>cobaya</code> + <code>mgcamb</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
+<tr><td>ISW cross-correlation</td><td><code>gaussian</code></td><td><code>direct_python</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
+<tr><td>GW propagation (KC6)</td><td><code>gaussian</code></td><td><code>direct_python</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
+<tr><td>Full CMB likelihood (plik_lite TTTEEE)</td><td><code>mcmc_posterior</code></td><td><code>cobaya</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
+</tbody>
+</table>
+
+<hr>
+
+<h2>4. Worked example (template)</h2>
+<div class="like-card" id="example-fsigma8">
+<h3>Template entry: f&sigma;<sub>8</sub> growth test <span class="badge-declared">declared</span></h3>
+<pre>{
+  "test_id": "s8_growth_fsigma8_2026",
+  "likelihood_type": "gaussian_cov",
+  "covariance": "data/cov/fsigma8_compilation_2026.json",
+  "parameter_priors": {
+    "Omega_m": {"type": "uniform", "range": [0.20, 0.40]},
+    "sigma8":  {"type": "uniform", "range": [0.70, 0.90]},
+    "mu_efc":  {"type": "uniform", "range": [0.80, 1.20]}
+  },
+  "code": "direct_python",
+  "code_version": "efc@&lt;git-sha&gt;",
+  "entry_point": "pipelines/fsigma8_runner.py",
+  "inputs": [
+    "doi:10.xxxx/desi-y3-fsigma8",
+    "doi:10.xxxx/des-y6-3x2pt"
+  ],
+  "outputs": ["chi2", "best_fit", "posterior_summary"],
+  "status": "declared"
+}</pre>
+<p>Once a run produces numbers, <code>status</code> advances to <code>executed</code>
+and the result is recorded in the Validation Ledger. If the declaration is then
+frozen for publication, it advances to <code>frozen</code>.</p>
+</div>
+
+<hr>
+
+<h2>5. Linking to the rest of the stack</h2>
+<table>
+<thead><tr><th>Ledger</th><th>Role</th><th>Direction</th></tr></thead>
+<tbody>
+<tr><td><a href="EFC_Validation_Ledger.html">Validation Ledger</a></td><td>Defines <code>test_id</code> vocabulary</td><td>Likelihood Ledger references it (FK)</td></tr>
+<tr><td><a href="EFC_Evaluation_Ledger.html">Evaluation Ledger</a></td><td>Global score function, falsification verdict</td><td>Consumes Likelihood Ledger rows with <code>status &isin; {executed, frozen}</code></td></tr>
+<tr><td><a href="EFC_Model_Comparison.html">Model Comparison</a></td><td>EFC vs &Lambda;CDM vs MG on identical likelihood</td><td>Consumes Likelihood Ledger row via <code>likelihood_id</code></td></tr>
+<tr><td><a href="EFC_Gap_Analysis.html">Gap Analysis</a></td><td>Tracks missing pipelines</td><td>Every <span class="badge-gap">GAP</span> row here should appear as a gap row there</td></tr>
+<tr><td><a href="EFC_Stage-IV_Data_Roadmap.html">Stage-IV Roadmap</a></td><td>Maps survey releases to tests</td><td>Each roadmap test should eventually gain a Likelihood Ledger row</td></tr>
+</tbody>
+</table>
+
+<hr>
+
+<h2>6. Sync hook (proposed, not yet written)</h2>
+<p><code>scripts/maintenance/efc_likelihood_sync.py</code> mirrors the pattern of
+<code>efc_ledger_impact_sync.py</code>:</p>
+<ul>
+<li>Reads every <code>test_id</code> from <code>validation-ledger/data/tests.json</code>.</li>
+<li>For each <code>vl_category &isin; {physics_test, phenomenological}</code> without a likelihood row, emits a warning.</li>
+<li>Validates that <code>inputs</code> DOIs exist in <code>validation-ledger/data/evidence-register.json</code>.</li>
+<li>Idempotent &mdash; re-runs are no-ops.</li>
+</ul>
+
+<hr>
+
+<h2>7. Open questions</h2>
+<ol>
+<li>Should likelihood entries live as separate JSON files per test, or as array entries inside <code>data/likelihoods.json</code>? <em>Proposal:</em> single-array file, mirroring <code>tests.json</code>.</li>
+<li>How are external likelihood codes (Cobaya, MGCAMB) version-pinned? <em>Proposal:</em> Git SHA in <code>code_version</code>; conda env export as supplementary artefact.</li>
+<li>Should <code>parameter_priors</code> inline ranges, or reference <code>validation-ledger/data/parameters.json</code>? <em>Proposal:</em> reference by default, allow inline only when a test uses a non-standard prior with documented rationale.</li>
+</ol>
+
+<hr>
+
+<h2>Bottom line</h2>
+<table data-section="bottom-line">
+<tbody>
+<tr><td style="font-weight:bold; width:30%; background:#f8f9fa;">What this ledger fixes</td><td>Makes every empirical score reproducible by declaring its pipeline explicitly. No test enters the global score without a row here.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Hard dependency</td><td><a href="EFC_Validation_Ledger.html">Validation Ledger</a> &mdash; provides the <code>test_id</code> vocabulary every row references.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Hard consumers</td><td><a href="EFC_Evaluation_Ledger.html">Evaluation Ledger</a> and <a href="EFC_Model_Comparison.html">Model Comparison</a> &mdash; neither can fire without executed likelihood rows.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Current gaps</td><td>f&sigma;<sub>8</sub> / S<sub>8</sub>, cosmic shear, ISW, GW propagation, full CMB likelihood. All marked <span class="badge-gap">GAP</span> until a pipeline is wired.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Status</td><td>Schema frozen; pipeline registry populated with all current <code>reproduce_*.py</code> scripts; bulk population of new pipelines follows maintainer review.</td></tr>
+</tbody>
+</table>
+
+<hr>
+
+<p style="font-size:13px; color:#666;">
+&copy; 2026 Energy-Flow Cosmology Initiative &middot; Likelihood Ledger &mdash; pipeline declarations for reproducible scoring
+</p>
+
+<script>
+function notifyParentHeight() {
+  var h = document.documentElement.scrollHeight;
+  window.parent.postMessage({ efc_iframe_height: h }, '*');
+}
+window.addEventListener('load', notifyParentHeight);
+window.addEventListener('resize', notifyParentHeight);
+new MutationObserver(notifyParentHeight).observe(document.body, { childList: true, subtree: true });
+</script>
+
+</body>
+</html>

--- a/docs/public/EFC_Model_Comparison.html
+++ b/docs/public/EFC_Model_Comparison.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Energy-Flow Cosmology (EFC) &ndash; Model Comparison</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; }
+    html { font-size: 16px; }
+    body { font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.7; color: #1a1a2e; background: #ffffff; max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem 3rem; }
+    h1 { font-size: 1.8rem; font-weight: 700; color: #0d1b3e; border-bottom: 3px solid #007bff; padding-bottom: 0.6rem; margin-bottom: 1.2rem; }
+    h2 { font-size: 1.35rem; font-weight: 600; color: #1a3a6b; margin-top: 2.5rem; margin-bottom: 0.8rem; border-left: 4px solid #007bff; padding-left: 0.7rem; }
+    h3 { font-size: 1.1rem; font-weight: 600; color: #2a4a7f; margin-top: 1.8rem; margin-bottom: 0.6rem; }
+    p { margin: 0.6rem 0; }
+    a { color: #0056b3; text-decoration: none; }
+    a:hover { text-decoration: underline; color: #003d80; }
+    hr { border: none; border-top: 1px solid #d0d7e3; margin: 2rem 0; }
+    ul, ol { padding-left: 1.6rem; }
+    li { margin-bottom: 0.3rem; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; font-size: 0.88rem; box-shadow: 0 1px 4px rgba(0,0,0,0.06); border-radius: 6px; overflow: hidden; }
+    thead { background-color: #eaf0f9; }
+    th { border: 1px solid #d0d7e3; padding: 10px 12px; text-align: left; font-weight: 600; color: #1a3a6b; }
+    td { border: 1px solid #e2e6ed; padding: 8px 12px; vertical-align: top; }
+    tbody tr:hover { background-color: #f5f8fd; }
+    strong { color: #0d1b3e; }
+    sub, sup { font-size: 0.78em; }
+    code { font-family: 'Courier New', monospace; font-size: 0.90em; background: #f0f2f5; padding: 1px 5px; border-radius: 3px; }
+    pre { font-family: 'Courier New', monospace; font-size: 0.85em; background: #f0f2f5; padding: 12px 16px; border-radius: 6px; border-left: 4px solid #007bff; overflow-x: auto; line-height: 1.5; }
+    .badge-placeholder { display:inline-block; background:#888;    color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-registered  { display:inline-block; background:#0a7bd1; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-efc         { display:inline-block; background:#1a7a1a; color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-lcdm        { display:inline-block; background:#333;    color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .badge-neutral     { display:inline-block; background:#888;    color:#fff; font-size:0.75em; padding:2px 7px; border-radius:3px; }
+    .comp-card { background: #fafbfd; border: 1px solid #d0d7e3; border-left: 4px solid #007bff; border-radius: 6px; padding: 14px 18px; margin: 1rem 0 1.5rem; }
+    .comp-card h3 { margin-top: 0; }
+    .comp-card table { margin-bottom: 0.6rem; }
+    @media (max-width: 768px) { body { padding: 1rem; } h1 { font-size: 1.4rem; } table { font-size: 0.8rem; } th, td { padding: 6px 8px; } }
+  </style>
+</head>
+<body>
+
+<h1>Energy-Flow Cosmology (EFC) &mdash; Model Comparison</h1>
+
+<div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
+  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Models</a>
+  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
+  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
+  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
+  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
+  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
+  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
+</div>
+
+<p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
+Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
+ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
+April 2026 &middot; CC-BY-4.0
+</p>
+
+<div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
+<p style="margin:0; font-size:15px;">
+<strong>Status:</strong> This ledger closes the <strong>cross-model comparison</strong>
+gap from the 2026-04-23 system audit: EFC has not had a structured, apples-to-apples
+evaluation against &Lambda;CDM and competing modified-gravity models on identical
+likelihoods. Rows here report <code>&Delta;&chi;&sup2;</code>, <code>&Delta;AIC</code>,
+<code>&Delta;BIC</code>, and <code>ln K</code> with the reference model declared. Scope
+today: comparison protocol frozen, model registry seeded with placeholders, zero runs
+yet executed.
+</p>
+</div>
+
+<hr>
+
+<h2>1. Purpose</h2>
+<p>The <a href="EFC_Validation_Ledger.html">Validation Ledger</a> shows how EFC scores
+individually. This ledger shows how EFC scores <em>against alternatives</em> on
+identical data with identical likelihood and identical nuisance-parameter treatment.
+Anything else is apples-to-oranges and cannot feed
+<code>model_preference</code> in the <a href="EFC_Evaluation_Ledger.html">Evaluation Ledger</a>.</p>
+
+<hr>
+
+<h2>2. Comparison protocol (frozen)</h2>
+<p>A comparison row is valid only if all four conditions hold:</p>
+<ol>
+<li><strong>Same dataset</strong> (same DOI, same data version)</li>
+<li><strong>Same likelihood code</strong> (same <code>likelihood_id</code> from the <a href="EFC_Likelihood_Ledger.html">Likelihood Ledger</a>)</li>
+<li><strong>Same nuisance parameters and priors</strong></li>
+<li><strong>Different theoretical model</strong> (the only varying axis)</li>
+</ol>
+<p>Any deviation from these must be flagged in the row's <code>caveats</code> list.
+Comparisons that fail the protocol are rejected by the sync script.</p>
+
+<hr>
+
+<h2>3. Reported quantities</h2>
+<table>
+<thead><tr><th>Quantity</th><th>Required</th><th>Notes</th></tr></thead>
+<tbody>
+<tr><td><code>chi2</code> per model</td><td>yes</td><td>At best-fit point</td></tr>
+<tr><td><code>&Delta;chi2</code> (model &minus; reference)</td><td>yes</td><td>Reference declared explicitly per row</td></tr>
+<tr><td><code>AIC</code>, <code>BIC</code> per model</td><td>yes</td><td>Uses <code>n_params</code> from model registry</td></tr>
+<tr><td><code>&Delta;AIC</code>, <code>&Delta;BIC</code></td><td>yes</td><td>Reference model is baseline</td></tr>
+<tr><td><code>ln Z</code> (Bayesian evidence) per model</td><td>when available</td><td>Requires nested sampling</td></tr>
+<tr><td><code>ln K = ln Z_A &minus; ln Z_B</code></td><td>when both ln Z available</td><td>Reported with Jeffreys-scale interpretation</td></tr>
+<tr><td><code>n_params</code> per model</td><td>yes</td><td>Cosmological free parameters only</td></tr>
+<tr><td>Reference model</td><td>yes</td><td>Declared per row, typically &Lambda;CDM</td></tr>
+</tbody>
+</table>
+<p>Jeffreys-scale interpretations are recorded verbatim in <code>interpretation</code> &mdash;
+never paraphrased.</p>
+
+<hr>
+
+<h2>4. Model registry</h2>
+<table>
+<thead><tr><th>model_id</th><th>Description</th><th>n_free_params (cosmo)</th><th>Status</th></tr></thead>
+<tbody>
+<tr><td><code>lcdm</code></td><td>Standard &Lambda;CDM (reference)</td><td>6</td><td><span class="badge-registered">registered</span></td></tr>
+<tr><td><code>efc_v3</code></td><td>EFC current frozen version</td><td>TBD</td><td><span class="badge-registered">registered</span></td></tr>
+<tr><td><code>horndeski_min</code></td><td>Minimal Horndeski (&alpha;<sub>B</sub>, &alpha;<sub>M</sub> free)</td><td>8</td><td><span class="badge-placeholder">placeholder</span></td></tr>
+<tr><td><code>f_of_r_hu_sawicki</code></td><td>f(R) Hu&ndash;Sawicki</td><td>7</td><td><span class="badge-placeholder">placeholder</span></td></tr>
+<tr><td><code>dgp_normal</code></td><td>DGP normal branch</td><td>6</td><td><span class="badge-placeholder">placeholder</span></td></tr>
+<tr><td><code>wcdm</code></td><td>wCDM (constant w)</td><td>7</td><td><span class="badge-placeholder">placeholder</span></td></tr>
+</tbody>
+</table>
+<p>Each registered model must declare its likelihood-compatible code path (e.g.
+MGCAMB module name, or analytic f&sigma;<sub>8</sub> implementation) in
+<code>data/models.json</code>.</p>
+
+<hr>
+
+<h2>5. Comparison entry template</h2>
+<div class="comp-card" id="template-fsigma8">
+<h3>Template: f&sigma;<sub>8</sub> 2026 &mdash; EFC vs &Lambda;CDM <span class="badge-placeholder">placeholder</span></h3>
+<pre>{
+  "comparison_id": "fsigma8_2026__efc_vs_lcdm",
+  "likelihood_id": "s8_growth_fsigma8_2026",
+  "reference_model": "lcdm",
+  "models": [
+    {"model_id": "efc_v3",  "chi2": null, "aic": null, "bic": null, "ln_z": null, "n_params": null},
+    {"model_id": "lcdm",    "chi2": null, "aic": null, "bic": null, "ln_z": null, "n_params": 6}
+  ],
+  "delta_chi2": null,
+  "delta_aic":  null,
+  "delta_bic":  null,
+  "ln_k":       null,
+  "interpretation": "PENDING",
+  "caveats": [],
+  "status": "declared"
+}</pre>
+<p>Once the run executes, numeric fields populate and <code>interpretation</code>
+receives a verbatim Jeffreys-scale phrase (e.g. "positive evidence for EFC",
+"strong evidence against EFC", "inconclusive").</p>
+</div>
+
+<hr>
+
+<h2>6. Interaction with the Evaluation Ledger</h2>
+<p>Model Comparison results feed <strong>only</strong> the
+<code>model_preference</code> field of the
+<a href="EFC_Evaluation_Ledger.html">Evaluation Ledger</a> <code>current_state</code>
+block &mdash; <em>not</em> <code>falsification_status</code>.</p>
+<table>
+<thead><tr><th>Comparison outcome</th><th>model_preference set to</th></tr></thead>
+<tbody>
+<tr><td>&Delta;AIC &gt; +5 against EFC &nbsp;<strong>or</strong>&nbsp; ln K &gt; +4.6 for &Lambda;CDM</td><td><span class="badge-lcdm">prefers_lcdm</span></td></tr>
+<tr><td>|&Delta;AIC| &le; 5 &nbsp;<strong>and</strong>&nbsp; |ln K| &le; 1</td><td><span class="badge-neutral">neutral</span></td></tr>
+<tr><td>&Delta;AIC &lt; &minus;5 for EFC &nbsp;<strong>or</strong>&nbsp; ln K &gt; +4.6 for EFC</td><td><span class="badge-efc">prefers_efc</span></td></tr>
+</tbody>
+</table>
+<p><strong>Being dispreferred by AIC is not the same as being falsified.</strong>
+See Evaluation Ledger &sect;5. Both fields are always reported.</p>
+
+<hr>
+
+<h2>7. External landscape anchor</h2>
+<p>The <a href="EFC_External_Research_Ledger.html">External Research Ledger</a>
+tracks peer-reviewed constraints on MG models (Horndeski, f(R), DGP). When an
+external paper publishes a likelihood-compatible constraint, it can be imported
+here as a placeholder row with <code>status: "declared"</code> and
+<code>caveats: ["external_posterior_import"]</code> until a native run reproduces it.</p>
+
+<hr>
+
+<h2>8. Open questions</h2>
+<ol>
+<li>Are competing models run inside this repo, or imported as external posteriors? <em>Proposal:</em> native first, external imports only flagged via <code>caveats</code>.</li>
+<li>For Horndeski / f(R), do we use MGCAMB defaults or repo-pinned configs? <em>Proposal:</em> repo-pinned configs with MGCAMB defaults documented as baseline.</li>
+<li>Should comparisons against scalar-tensor MG split by screening regime? <em>Proposal:</em> yes &mdash; separate comparison rows per regime, tied to the Validation Ledger regime matrix.</li>
+</ol>
+
+<hr>
+
+<h2>Bottom line</h2>
+<table data-section="bottom-line">
+<tbody>
+<tr><td style="font-weight:bold; width:30%; background:#f8f9fa;">What this ledger fixes</td><td>Makes EFC-vs-alternatives quantitative on identical likelihoods. No more scattered, informal "looks comparable" claims.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Hard rule</td><td>Only rows meeting the four protocol conditions (&sect;2) are valid. Any deviation must appear in <code>caveats</code>.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Hard dependency</td><td><a href="EFC_Likelihood_Ledger.html">Likelihood Ledger</a> row with a shared <code>likelihood_id</code>.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Primary consumer</td><td><a href="EFC_Evaluation_Ledger.html">Evaluation Ledger</a> &rarr; <code>model_preference</code> only.</td></tr>
+<tr><td style="font-weight:bold; background:#f8f9fa;">Status</td><td>Protocol frozen; registry seeded with &Lambda;CDM + EFC registered and four MG placeholders; zero runs executed.</td></tr>
+</tbody>
+</table>
+
+<hr>
+
+<p style="font-size:13px; color:#666;">
+&copy; 2026 Energy-Flow Cosmology Initiative &middot; Model Comparison &mdash; same data, same likelihood, different model
+</p>
+
+<script>
+function notifyParentHeight() {
+  var h = document.documentElement.scrollHeight;
+  window.parent.postMessage({ efc_iframe_height: h }, '*');
+}
+window.addEventListener('load', notifyParentHeight);
+window.addEventListener('resize', notifyParentHeight);
+new MutationObserver(notifyParentHeight).observe(document.body, { childList: true, subtree: true });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Three new ledgers closing gaps from the 2026-04-23 system audit:

- **Likelihood Ledger** — per-test pipeline declaration (likelihood type, covariance, priors, code). Makes every empirical score reproducible.
- **Evaluation Ledger** — global decision rule: PASS/TENSION/FAIL thresholds, EFC_score aggregation, falsification rule. Reports `falsification_status` and `model_preference` as separate fields (conflation was an audit finding).
- **Model Comparison** — EFC vs ΛCDM vs MG (Horndeski, f(R), DGP, wCDM) on identical data + likelihood. Jeffreys' scale recorded verbatim.

## Audit gaps closed

| Audit finding | Closed by |
|---|---|
| Dataset → Likelihood not explicit | Likelihood Ledger |
| "Missing closure" — no global verdict | Evaluation Ledger |
| Falsification ≠ preference conflated | Evaluation Ledger schema enforces separate fields |
| No cross-model comparison | Model Comparison ledger |
| Atlas not linked to likelihoods | Evaluation Ledger read-only `atlas-link.json` |

## What's in this PR

**6 new additive locations. Zero existing files modified.**

| Path | Role |
|---|---|
| `docs/public/EFC_Likelihood_Ledger.html` | User-facing HTML (style-matched to `EFC_Predictions.html`) |
| `docs/public/EFC_Evaluation_Ledger.html` | User-facing HTML |
| `docs/public/EFC_Model_Comparison.html` | User-facing HTML |
| `docs/likelihood-ledger/` | Structured backing: README.md + index.md + index.jsonld + schema.json |
| `docs/evaluation-ledger/` | Structured backing (same 4-file pattern) |
| `docs/model-comparison/` | Structured backing (same 4-file pattern) |

## Atlas safety

**`EFC_Atlas.html` is not touched.** The Evaluation Ledger references the Atlas via `data/atlas-link.json` only; schema pins `modifies_atlas: false` as a hard constant. Atlas remains the source of truth for its own content and is still regenerated deterministically by `build_atlas.py`.

## Automation interaction — verified

New paths are outside the `paths:` filter of every CI workflow:

| Workflow | Triggered by this PR? |
|---|---|
| `efc-sync.yml` | No |
| `efc-verify.yml` | No |
| `efc-main-sync.yml` | No |
| `atlas-sync.yml` | No |
| `atlas-verify.yml` | No |
| `efc-ai-audit.yml` | Only on push-to-main after merge |
| `efc-ai-monitor.yml` | Only on schedule |

- `efc_precommit_gate.py` blocks empirical papers without Ledger entries — new files are not papers.
- `efc_drift_detector.py` `CHECK_FILES` is a fixed list — new files not scanned for paper-count drift.
- `efc_verify.py` (C1–C8) scoped to existing structure — new files pass by not being in scope.
- `_nav_helper.py` `CANONICAL_NAV_HTML` unchanged — new HTMLs have their own nav embedded.
- Symbiose AGI writes to `docs/validation-ledger/data/` — no overlap with new paths.

## Status

**All 3 ledgers are DRAFT / skeleton.** Schemas frozen, structure in place, worked examples included. No numerical weights, no execution, no DOIs — population follows maintainer review.

## Test plan

- [ ] Visual review of 3 new HTML files in browser
- [ ] Confirm nav-bar links all resolve (12 links)
- [ ] Confirm no existing file was modified (`git diff main...HEAD` shows only additions)
- [ ] Validate JSON-LD and schema.json against JSON Schema draft-07
- [ ] Decide Phase B: update `_nav_helper.py` canonical + AGENTS.md "Public pages" from 7 to 10

## Follow-up (separate PRs, not in scope here)

1. Update `_nav_helper.py` `CANONICAL_NAV_HTML` to include the 3 new ledgers + Atlas
2. Update `AGENTS.md` "Public pages that must stay in sync" from 7 to 10
3. Update `ecosystem.jsonld` `hasPart[]` with 3 new Dataset entries
4. Populate `data/likelihoods.json`, `data/evaluation.json`, `data/comparisons.json` with real entries

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) after a full system audit. Zero automation surfaces touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kq7hu525JxmmuL9b2jSgQn)_