### PR TITLE
chore(maintenance): metadata package for A_structural_closure paper + fix verify CI

### DIFF
--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/CITATION.cff
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/CITATION.cff
@@ -1,0 +1,18 @@
+cff-version: 1.2.0
+message: "If you use this work, please cite it as below."
+title: "A structural closure of growth sector couplings"
+type: software
+authors:
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+    affiliation: "Symbiose Research, Norway"
+version: "1.0"
+date-released: "2026-04-23"
+license: "CC-BY-4.0"
+repository-code: "https://github.com/supertedai/EFC"
+keywords:
+  - "Energy-Flow Cosmology"
+  - "EFC"
+abstract: >
+  A structural closure of growth sector couplings. Part of the Energy-Flow Cosmology research programme.

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/LICENSE
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/LICENSE
@@ -1,0 +1,8 @@
+Creative Commons Attribution 4.0 International (CC-BY-4.0)
+
+Copyright (c) 2026 Morten Magnusson
+
+You are free to share and adapt this material for any purpose, including
+commercially, as long as you give appropriate credit.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/README.md
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/README.md
@@ -1,0 +1,22 @@
+# A structural closure of growth sector couplings
+
+**Author:** Morten Magnusson (ORCID 0009-0002-4860-5095) · Symbiose Research
+**License:** CC-BY-4.0 · **Track:** Spor 1 — Galactic/Cosmological · **Regimes:** —
+
+**Primary PDF:** `A_structural_closure_of_growth_sector_couplings.pdf`
+
+This directory is an **AI-friendly** package: machine-readable metadata
+(`index.json`, `metadata.json`, `ai_manifest.json`, `*.jsonld`) accompanies the
+source materials so that LLMs and automated agents can ingest, cite, and
+reproduce the work without scraping the PDF.
+
+## Files
+
+- `A_structural_closure_of_growth_sector_couplings.pdf` (357433 B)
+- `A_structural_closure_of_growth_sector_couplings.tex` (32139 B)
+
+## Provenance
+
+Auto-generated AI-friendly wrapper (2026-04-23). Hand-curated packages
+(`WP4_BOSS_transfer_validation`, `Multi_epoch_Growth_Rate_Test_of_EFC`) provide
+the schema reference; this directory follows the same conventions.

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/a-structural-closure-of-growth-sector-couplings.jsonld
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/a-structural-closure-of-growth-sector-couplings.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": "https://schema.org",
+  "@type": "ScholarlyArticle",
+  "name": "A structural closure of growth sector couplings",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095",
+    "affiliation": {
+      "@type": "Organization",
+      "name": "Symbiose Research"
+    }
+  },
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "EFC"
+  ],
+  "about": [
+    "Spor 1 — Galactic/Cosmological"
+  ]
+}

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/ai_manifest.json
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/ai_manifest.json
@@ -1,0 +1,62 @@
+{
+  "id": "a-structural-closure-of-growth-sector-couplings",
+  "directory": "A_structural_closure_of_growth_sector_couplings",
+  "title": "A structural closure of growth sector couplings",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "package_type": "ai-friendly-paper",
+  "schema_version": "1.0",
+  "generated": "2026-04-23",
+  "track": "Spor 1 — Galactic/Cosmological",
+  "regimes": [],
+  "primary_pdf": "A_structural_closure_of_growth_sector_couplings.pdf",
+  "all_pdfs": [
+    "A_structural_closure_of_growth_sector_couplings.pdf"
+  ],
+  "files": [
+    {
+      "path": "A_structural_closure_of_growth_sector_couplings.pdf",
+      "bytes": 357433
+    },
+    {
+      "path": "A_structural_closure_of_growth_sector_couplings.tex",
+      "bytes": 32139
+    },
+    {
+      "path": "CITATION.cff",
+      "bytes": 592
+    },
+    {
+      "path": "LICENSE",
+      "bytes": 298
+    },
+    {
+      "path": "README.md",
+      "bytes": 940
+    },
+    {
+      "path": "a-structural-closure-of-growth-sector-couplings.jsonld",
+      "bytes": 534
+    },
+    {
+      "path": "citations.bib",
+      "bytes": 297
+    },
+    {
+      "path": "index.json",
+      "bytes": 559
+    },
+    {
+      "path": "metadata.json",
+      "bytes": 764
+    },
+    {
+      "path": "schema.json",
+      "bytes": 642
+    }
+  ],
+  "n_files": 10,
+  "n_pdfs": 1
+}

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/citations.bib
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/citations.bib
@@ -1,0 +1,8 @@
+@misc{magnusson2026_a_structural_closure_of_growth_sector_co,
+  author = {Magnusson, Morten},
+  title = {A structural closure of growth sector couplings},
+  year = {2026},
+  publisher = {Figshare},
+  url = {https://github.com/supertedai/EFC},
+  note = {Energy-Flow Cosmology research programme}
+}

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/index.json
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/index.json
@@ -1,0 +1,16 @@
+{
+  "id": "a-structural-closure-of-growth-sector-couplings",
+  "title": "A structural closure of growth sector couplings",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "track": "Spor 1 — Galactic/Cosmological",
+  "regimes": [],
+  "primary_pdf": "A_structural_closure_of_growth_sector_couplings.pdf",
+  "files": [
+    "A_structural_closure_of_growth_sector_couplings.pdf",
+    "A_structural_closure_of_growth_sector_couplings.tex"
+  ],
+  "see_also": "ai_manifest.json"
+}

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/metadata.json
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/metadata.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0",
+  "package_type": "ai-friendly-paper",
+  "paper": {
+    "title": "A structural closure of growth sector couplings",
+    "directory": "A_structural_closure_of_growth_sector_couplings",
+    "author": {
+      "name": "Morten Magnusson",
+      "orcid": "0009-0002-4860-5095",
+      "affiliation": "Symbiose Research"
+    },
+    "license": "CC-BY-4.0"
+  },
+  "domain": {
+    "track": "Spor 1 — Galactic/Cosmological",
+    "regimes": []
+  },
+  "files": [
+    {
+      "path": "A_structural_closure_of_growth_sector_couplings.pdf",
+      "bytes": 357433
+    },
+    {
+      "path": "A_structural_closure_of_growth_sector_couplings.tex",
+      "bytes": 32139
+    }
+  ],
+  "primary_pdf": "A_structural_closure_of_growth_sector_couplings.pdf"
+}

--- a/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/schema.json
+++ b/docs/papers/efc/A_structural_closure_of_growth_sector_couplings/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "A structural closure of growth sector couplings Schema",
+  "type": "object",
+  "properties": {
+    "paper_id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "doi": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "key_results": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "parameters": {
+      "type": "object"
+    },
+    "predictions": {
+      "type": "array"
+    }
+  },
+  "required": [
+    "paper_id",
+    "title"
+  ]
+}

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,6 +1,6 @@
 {
   "generated": "2026-04-23",
-  "n_packages": 153,
+  "n_packages": 154,
   "packages": [
     {
       "name": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
@@ -37,6 +37,24 @@
       "primary_pdf": "A_Regime_Activated_Lensing_Response_Improves_the_Fit_to_KiDS_1000_Cosmic_Shear_and_Reframes_the_Interpretation_of_S_.pdf",
       "created": [],
       "n_files": 15
+    },
+    {
+      "name": "A_structural_closure_of_growth_sector_couplings",
+      "title": "A structural closure of growth sector couplings",
+      "track": "Spor 1 — Galactic/Cosmological",
+      "regimes": [],
+      "primary_pdf": "A_structural_closure_of_growth_sector_couplings.pdf",
+      "created": [
+        "index.json",
+        "metadata.json",
+        "a-structural-closure-of-growth-sector-couplings.jsonld",
+        "README.md",
+        "CITATION.cff",
+        "LICENSE",
+        "citations.bib",
+        "schema.json"
+      ],
+      "n_files": 10
     },
     {
       "name": "CEM-Consciousness-Ego-Mirror",


### PR DESCRIPTION
## Summary

- Paper `A_structural_closure_of_growth_sector_couplings` was uploaded in commit 9583486 with only PDF + TEX, no metadata package.
- `efc-verify.yml` regenerates manifests via `efc_gen_ai_friendly.py` and then fails on `git diff`, which was producing the failing verify run https://github.com/supertedai/EFC/actions/runs/24853583313.
- Commits the generated metadata package (CITATION.cff, LICENSE, README.md, index.json, metadata.json, ai_manifest.json, jsonld, citations.bib, schema.json) and bumps `ai_friendly_index.json` 153 → 154.

## Root cause

Race between three workflows on every new paper upload:

1. `efc-main-sync.yml` (runs maintain.py → generates metadata → commits) — slow, serialized via concurrency group
2. `efc-sync.yml` (dev-branch sync) — similar
3. `efc-verify.yml` (audit only, no --fix) — fast, fails red if the metadata hasn't been committed yet

Because the paper was pushed directly to main (not through a PR branch where sync has a chance to catch up first), and because main-sync has `cancel-in-progress: true`, repeated pushes kept cancelling the autofix job. This commit resolves the current red state; a follow-up may be needed to either have `efc-verify.yml` tolerate untracked-metadata for freshly-uploaded PDFs, or have `efc-main-sync.yml` post a required status check.

## Verification

All verify-pipeline checks run locally on this commit:

```
[efc-gen] 154 packages · 0 new files
efc_sync_dois --check → 150 registered, 4 pending (expected)
[efc-verify] 154 paper dirs · 0 errors · 1 pre-existing warning (C4)
[efc-drift] 154 papers · no drift detected
git diff --quiet → clean
```

## Test plan

- [x] `efc_gen_ai_friendly.py` produces 0 diff after fix
- [x] `efc_drift_detector.py` exits 0
- [x] `efc_verify.py` produces 0 errors
- [ ] `EFC repo verify` CI passes on this branch

https://claude.ai/code/session_01TdihsmVuea8DiEPacyskP4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdihsmVuea8DiEPacyskP4)_