### PR TITLE
fix+docs: EFC-C v2.1 migration + maintenance pipeline hardening

### DIFF
--- a/docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/ai_manifest.json
+++ b/docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/ai_manifest.json
@@ -8,7 +8,7 @@
   "license": "CC-BY-4.0",
   "package_type": "ai-friendly-paper",
   "schema_version": "1.0",
-  "generated": "2026-04-22",
+  "generated": "2026-04-24",
   "track": "Spor 1 — Galactic/Cosmological",
   "regimes": [
     "L0",
@@ -16,8 +16,10 @@
     "L2",
     "L3"
   ],
-  "primary_pdf": null,
-  "all_pdfs": [],
+  "primary_pdf": "efc-c-v2-1.pdf",
+  "all_pdfs": [
+    "efc-c-v2-1.pdf"
+  ],
   "files": [
     {
       "path": "CITATION.cff",
@@ -68,6 +70,10 @@
       "bytes": 563
     },
     {
+      "path": "efc-c-v2-1.pdf",
+      "bytes": 392398
+    },
+    {
       "path": "efc_c_v2.jsonld",
       "bytes": 1881
     },
@@ -96,6 +102,6 @@
       "bytes": 11106
     }
   ],
-  "n_files": 20,
-  "n_pdfs": 0
+  "n_files": 21,
+  "n_pdfs": 1
 }

--- a/docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/index.json
+++ b/docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/index.json
@@ -379,7 +379,7 @@
         "target": "data-kc-id=\"KC1\"",
         "action": "update_text",
         "new_badge": null,
-        "new_text": "KC1 baseline established: SPARC RAR unbinned ML fit confirms EFC screening form with k = 0.415 ± 0.029, g† = (2.51 ± 0.60) × 10⁻¹⁰ m/s², σ_int ≈ 0.14 dex (DOI 10.6084/m9.figshare.31940469). Paper-level KC1 (functional-form falsification, ΔBIC ≥ 10 against alternatives) deposited.",
+        "new_text": "KC1 baseline established: SPARC RAR unbinned ML fit supports EFC screening form with k = 0.415 ± 0.029, g† = (2.51 ± 0.60) × 10⁻¹⁰ m/s², σ_int ≈ 0.14 dex (DOI 10.6084/m9.figshare.31940469). Paper-level KC1 (functional-form falsification, ΔBIC ≥ 10 against alternatives) deposited.",
         "doi_refs": [
           "10.6084/m9.figshare.31940469"
         ],

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-23",
+  "generated": "2026-04-24",
   "n_packages": 154,
   "packages": [
     {
@@ -256,9 +256,9 @@
         "L2",
         "L3"
       ],
-      "primary_pdf": null,
+      "primary_pdf": "efc-c-v2-1.pdf",
       "created": [],
-      "n_files": 20
+      "n_files": 21
     },
     {
       "name": "EFC-C_Consciousness_Field_Resonance",

--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -163,8 +163,8 @@
     <strong>The test:</strong> Can this one rule reproduce what we see &mdash;
     spinning galaxies, the cosmic microwave background, the accelerating
     expansion, galaxy cluster collisions &mdash; without those two invisible
-    ingredients? Across <strong>101 active probes</strong> (119 total, 18 in pipeline), EFC has
-    survived 91. Nine probes have been falsified &mdash; showing that
+    ingredients? Across <strong>103 active probes</strong> (121 total, 18 in pipeline), EFC has
+    survived 93. Ten probes have been falsified &mdash; showing that
     the framework is genuinely testable. It does not yet <em>outperform</em> the standard model
     &mdash; the margins are too small to call a winner &mdash; and the decisive experiments
     are pre-registered in the
@@ -172,7 +172,7 @@
   </p>
   <p>
     <strong data-section="test-counts">Status:</strong> <span class="status-pill open">Global verdict OPEN</span>
-    &nbsp;<span class="status-pill survived">91/100 survived</span>
+    &nbsp;<span class="status-pill survived">93/103 survived</span>
     &nbsp;<span class="status-pill warn">10 falsified &middot; 18 in pipeline</span>
   </p>
 </div>
@@ -391,7 +391,7 @@
       <td>EFC is proven correct.</td>
     </tr>
     <tr>
-      <td>Of 101 active probes, EFC survives 91 (10 falsified, 18 in pipeline).</td>
+      <td>Of 103 active probes, EFC survives 93 (10 falsified, 18 in pipeline).</td>
       <td>EFC <em>outperforms</em> the standard model &mdash; the current margins are sub-statistical.</td>
     </tr>
     <tr>
@@ -487,7 +487,7 @@
     </tr>
     <tr>
       <td>The code, data, and reproducers</td>
-      <td><a href="https://github.com/supertedai/EFC">github.com/supertedai/EFC</a> &mdash; 147 AI-friendly paper packages, 119 tests (101 active, 91 survived, 10 falsified, 18 pipeline), full reproducible pipelines.</td>
+      <td><a href="https://github.com/supertedai/EFC">github.com/supertedai/EFC</a> &mdash; 154 AI-friendly paper packages, 121 tests (103 active, 93 survived, 10 falsified, 18 pipeline), full reproducible pipelines.</td>
     </tr>
     <tr>
       <td>The single-reference consolidation</td>

--- a/docs/public/EFC_Stage-IV_Data_Roadmap.html
+++ b/docs/public/EFC_Stage-IV_Data_Roadmap.html
@@ -190,7 +190,7 @@ April 2026 &middot; CC-BY-4.0
     survives or falls. Each row is a kill criterion frozen <em>before</em> the
     relevant data arrives, so no result can be back-fitted.
     <a href="EFC_Validation_Ledger.html">Ledger</a> for the
-    119 tests registered (101 active, 91 survived, 10 falsified, 18 in pipeline).
+    121 tests registered (103 active, 93 survived, 10 falsified, 18 in pipeline).
   </p>
 </div>
 

--- a/docs/public/EFC_White_Paper_Series.html
+++ b/docs/public/EFC_White_Paper_Series.html
@@ -182,8 +182,8 @@
     side-by-side comparison.
   </p>
   <p style="margin:0 0 10px 0; font-size:14.5px; color:#2e2e2e; line-height:1.65;">
-    <strong>Result so far</strong> (119 registered tests; 101 active, 91 survived, 10 falsified, 18 in pipeline &mdash; from galaxy rotation
-    curves to Planck 2018): EFC has survived 91 of 101 active probes. Ten probes have been falsified, demonstrating genuine testability. It does not yet
+    <strong>Result so far</strong> (121 registered tests; 103 active, 93 survived, 10 falsified, 18 in pipeline &mdash; from galaxy rotation
+    curves to Planck 2018): EFC has survived 93 of 103 active probes. Ten probes have been falsified, demonstrating genuine testability. It does not yet
     <em>outperform</em> the standard model &mdash; the margins are too small to call a winner. The
     decisive experiments are pre-registered in the
     <a href="EFC_Stage-IV_Data_Roadmap.html">Roadmap</a>.
@@ -228,7 +228,7 @@
     <tr>
       <td><strong>3</strong></td>
       <td>Data, Validation Ledger, and Falsification Protocol</td>
-      <td data-section="test-counts">119 tests (91 survived, 10 falsified); 2 sealed predictions; 5 kill criteria for Stage-IV</td>
+      <td data-section="test-counts">121 tests (93 survived, 10 falsified); 2 sealed predictions; 5 kill criteria for Stage-IV</td>
       <td><a href="https://doi.org/10.6084/m9.figshare.31970904">31970904</a></td>
     </tr>
     <tr>
@@ -466,7 +466,7 @@
     <tr style="background:transparent"><td style="border:none; padding:6px 12px; width:30%"><strong>What EFC does</strong></td><td style="border:none; padding:6px 12px">Modifies gravitational coupling in the perturbation sector via entropy gradients</td></tr>
     <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>Formal status</strong></td><td style="border:none; padding:6px 12px">Contains &Lambda;CDM as limiting case (perturbation sector); three independent recovery conditions proved</td></tr>
     <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>Current signal</strong></td><td style="border:none; padding:6px 12px">&alpha;<sub>L2</sub> = &minus;1.00 &plusmn; 0.46 (2.20&sigma;); &Delta;AIC = &minus;2.91; 7/7 LOO folds pass</td></tr>
-    <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>Validation</strong></td><td style="border:none; padding:6px 12px">119 tests (91 survived of 101 active, 10 falsified, 18 in pipeline); stage: non-rejectable model</td></tr>
+    <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>Validation</strong></td><td style="border:none; padding:6px 12px">121 tests (93 survived of 103 active, 10 falsified, 18 in pipeline); stage: non-rejectable model</td></tr>
     <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>Falsifiability</strong></td><td style="border:none; padding:6px 12px">5 kill criteria frozen before Stage-IV; 3 sealed blind predictions with cryptographic hashes (incl. Boltzmann-calibrated Euclid DR1 benchmark 2026-04-12)</td></tr>
     <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>New physics</strong></td><td style="border:none; padding:6px 12px">T(S) susceptibility function; dynamical dark energy w(a) &ne; &minus;1; cross-scale amplification &beta;<sub>cosm</sub>/&beta;<sub>gal</sub> &asymp; 6.25; scale-localised E<sub>G</sub> bump at k<sub>c</sub>=0.05&nbsp;h/Mpc (<a href="https://doi.org/10.6084/m9.figshare.31985313">31985313</a>)</td></tr>
     <tr style="background:transparent"><td style="border:none; padding:6px 12px"><strong>What it does NOT claim</strong></td><td style="border:none; padding:6px 12px">&ldquo;Better than &Lambda;CDM&rdquo;, &ldquo;no dark matter proven&rdquo;, or &ldquo;full cosmological validation&rdquo; &mdash; all remain UNDER REVIEW</td></tr>

--- a/figshare/doi-map.json
+++ b/figshare/doi-map.json
@@ -885,5 +885,47 @@
     "title": "EFC Euclid DR1 Boltzmann Pre-Registration",
     "path": "docs/papers/efc/efc_euclid_prediction",
     "url": "https://doi.org/10.6084/m9.figshare.31990053"
+  },
+  "10.6084/m9.figshare.32029704": {
+    "figshare_id": 32029704,
+    "title": "Systematic elimination of local gravitational models on the SPARC 175 sample: Evidence for an irreducible galaxy-specific degree of freedom",
+    "path": "docs/papers/efc/sparc175_elimination",
+    "url": "https://doi.org/10.6084/m9.figshare.32029704"
+  },
+  "10.6084/m9.figshare.32037990": {
+    "figshare_id": 32037990,
+    "title": "EFC Perturbation Sector: Constraint-Driven Gravitational Slip and a Testable Lensing Crossover",
+    "path": "docs/papers/efc/efc_perturbation_sector",
+    "url": "https://doi.org/10.6084/m9.figshare.32037990"
+  },
+  "10.6084/m9.figshare.32045592": {
+    "figshare_id": 32045592,
+    "title": "Expected Outcomes for Energy-Flow Cosmology Cross-Survey Invariance and BIG-SPARC Tests",
+    "path": "docs/papers/efc/EFC_Outcome_Estimation_CrossSurvey",
+    "url": "https://doi.org/10.6084/m9.figshare.32045592"
+  },
+  "10.6084/m9.figshare.32080059": {
+    "figshare_id": 32080059,
+    "title": "Parameter-Controlled Regime Transitions in Energy-Flow Cosmology: Cross-Sector Consistency Between Lensing and Background Observables",
+    "path": "docs/papers/efc/EFC_compound_paper",
+    "url": "https://doi.org/10.6084/m9.figshare.32080059"
+  },
+  "10.6084/m9.figshare.32080080": {
+    "figshare_id": 32080080,
+    "title": "Methodological Convergence in Stage-IV Cosmology: The Emergence of Epistemic Holism Under Precision Constraints, and Its Operationalization via RCMP",
+    "path": "docs/papers/efc/EFC_RCMP_Convergence_Observation",
+    "url": "https://doi.org/10.6084/m9.figshare.32080080"
+  },
+  "10.6084/m9.figshare.32080083": {
+    "figshare_id": 32080083,
+    "title": "EFC-ΛCDM Comparative Test Specification v1.1",
+    "path": "docs/papers/efc/EFC_RCMP_Test_Specification",
+    "url": "https://doi.org/10.6084/m9.figshare.32080083"
+  },
+  "10.6084/m9.figshare.32084670": {
+    "figshare_id": 32084670,
+    "title": "A structural closure of growth-sector couplings between discrete gravity and cosmology",
+    "path": "docs/papers/efc/A_structural_closure_of_growth_sector_couplings",
+    "url": "https://doi.org/10.6084/m9.figshare.32084670"
   }
 }

--- a/scripts/maintenance/efc_ledger_impact_sync.py
+++ b/scripts/maintenance/efc_ledger_impact_sync.py
@@ -385,16 +385,22 @@ def apply_page_updates(updates, bare_doi, idx, apply_mode):
     paper_desc = idx.get("description", "")
 
     for upd in updates:
-        page_key = upd.get("page", "")
-        target = upd.get("target", "")
-        action = upd.get("action", "")
-        new_badge = upd.get("new_badge", "")
-        new_text = upd.get("new_text", "")
-        doi_refs = upd.get("doi_refs", [])
+        page_key = upd.get("page") or ""
+        target = upd.get("target") or ""
+        action = upd.get("action") or ""
+        new_badge = upd.get("new_badge") or ""
+        new_text = upd.get("new_text") or ""
+        doi_refs = upd.get("doi_refs") or []
 
         page_path = PAGE_FILE_MAP.get(page_key)
         if not page_path or not os.path.exists(page_path):
             errors.append(f"page_updates: unknown page '{page_key}'")
+            continue
+
+        if not target:
+            errors.append(
+                f"page_updates: missing target for page '{page_key}' action='{action}'"
+            )
             continue
 
         # Load page HTML (use cached if already modified)


### PR DESCRIPTION
## Summary

Draft PR tracking two in-progress workstreams:

### 1. Maintenance-pipeline fixes (incremental)
- **Batch A ✅** `efc_ledger_impact_sync.py` — guard against `None` target values in page updates so the `EFC main auto-sync` workflow no longer crashes with `AttributeError` (root cause of the 25m 34s run).
- **Batch B ⏳** cross-validation count drift (Elevator Pitch `147→154`, ledger total `119→121`, active `101→103`, survived `91→93` across Elevator Pitch / White Paper Series / Stage-IV Roadmap HTML pages).
- **Batch C ⏳** forbidden_phrase `"confirms efc"` in `docs/papers/efc/Energy-Flow_Cosmology_Empirical_Validation_of_the_EFC_Screening_Model_Track_1/index.json`.
- **Batch D ⏳** 7 DOIs present in `index` but missing from `doi_map` + `internal_ledger_version` drift (`4.1` expected vs `3.0` observed).

### 2. EFC-C v2.0 → v2.1 migration (in progress)
Target: bring the 12 v2.0 files in `docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2/` into alignment with `efc-c-v2-1.pdf` (Bridge B1** degree-heterogeneity formulation `κ = Ceff · Dratio^γ`, replacing the v2.0 Fiedler formulation `κ = C/(1 + λ₂·τc)`).

Files to update: `EFC-C_v2.md`, `README.md`, `metadata.json`, `index.json`, `schema.json`, `ai_manifest.json`, `CITATION.cff`, `citations.bib`, 2 JSON-LD files, `src/__init__.py`, `src/cognitive_entropy.py`, `data/cognitive_entropy_data.json`, `examples/demo_cognitive_entropy.py`, and the `STATUS_and_next_steps.md` / `FINDING_regime_rescaling.md` / `derivation_regime_rescaling.md` trio for internal consistency.

## Test plan
- [x] `python3 -c "import ast; ast.parse(...)"` on modified script (syntax OK)
- [ ] Batch B: re-run `efc_cross_validate.py` locally after HTML count updates
- [ ] Batch C: re-run `efc_full_sync.py --verify` after Track_1 index fix
- [ ] Batch D: re-run `efc_full_sync.py --verify` after DOI-map sync
- [ ] v2.1 demo: `python3 examples/demo_cognitive_entropy.py` passes all assertions against new `κ = Ceff · Dratio^γ`

https://claude.ai/code/session_01WSJ6B4LYGyxGw5ZbYUvkM1

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSJ6B4LYGyxGw5ZbYUvkM1)_