### PR TITLE
fix(dois): correct DOI typos, resolve duplicates + bulk-populate evidence-register (66 entries)

### DIFF
--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/CITATION.cff
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/CITATION.cff
@@ -8,6 +8,6 @@ authors:
     affiliation: "Symbiose Research, Sandnes, Norway"
 date-released: "2026-01-31"
 version: "1.0"
-doi: "10.6084/m9.figshare.30563738"
+doi: "10.6084/m9.figshare.31222696"
 license: "CC-BY-4.0"
 repository-code: "https://github.com/supertedai/EFC"

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.jsonld
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.jsonld
@@ -6,7 +6,7 @@
   },
   "@type": "ScholarlyArticle",
   "@id": "efc-effective-phenomenological-law",
-  "identifier": "https://doi.org/10.6084/m9.figshare.30563738",
+  "identifier": "https://doi.org/10.6084/m9.figshare.31222696",
   "name": "Energy-Flow Cosmology: An Effective Phenomenological Law for Gravitational Response in Structure-Dominated Regimes",
   "headline": "Theoretical derivation of effective gravitational coupling μ(a) from EFC field equations",
   "author": {
@@ -112,7 +112,7 @@
   "citation": [
     {
       "@type": "ScholarlyArticle",
-      "@id": "doi:10.6084/m9.figshare.30563738",
+      "@id": "doi:10.6084/m9.figshare.31222696",
       "name": "Energy-Flow Cosmology v1.2"
     },
     {
@@ -128,6 +128,6 @@
   ],
   "encodingFormat": "application/pdf",
   "url": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.pdf",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.30563738",
-  "doi": "10.6084/m9.figshare.30563738"
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31222696",
+  "doi": "10.6084/m9.figshare.31222696"
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/README.md
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/README.md
@@ -2,7 +2,7 @@
 
 ## AI-Friendly Package
 
-- **DOI:** [10.6084/m9.figshare.30563738](https://doi.org/10.6084/m9.figshare.30563738)
+- **DOI:** [10.6084/m9.figshare.31222696](https://doi.org/10.6084/m9.figshare.31222696)
 - **Version:** 1.0
 - **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
 - **Date:** 2026-01-31

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/citations.bib
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/citations.bib
@@ -11,7 +11,7 @@
   title={Energy-Flow Cosmology v1.2: Foundational Framework},
   author={Magnusson, Morten},
   year={2026},
-  doi={10.6084/m9.figshare.30563738},
+  doi={10.6084/m9.figshare.31222696},
   note={Foundational EFC framework}
 }
 

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/efc-effective-phenomenological-law.jsonld
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/efc-effective-phenomenological-law.jsonld
@@ -11,8 +11,8 @@
   },
   "datePublished": "2026-01-31",
   "license": "https://creativecommons.org/licenses/by/4.0/",
-  "@id": "doi:10.6084/m9.figshare.30563738",
-  "identifier": "https://doi.org/10.6084/m9.figshare.30563738",
-  "doi": "10.6084/m9.figshare.30563738",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.30563738"
+  "@id": "doi:10.6084/m9.figshare.31222696",
+  "identifier": "https://doi.org/10.6084/m9.figshare.31222696",
+  "doi": "10.6084/m9.figshare.31222696",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31222696"
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/energy-flow-cosmology-an-effective-phenomenological-law-for-gravitational-response-in-structure-dominated-regimes.jsonld
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/energy-flow-cosmology-an-effective-phenomenological-law-for-gravitational-response-in-structure-dominated-regimes.jsonld
@@ -19,7 +19,7 @@
   "about": [
     "Spor 1 — Galactic/Cosmological"
   ],
-  "identifier": "https://doi.org/10.6084/m9.figshare.30563738",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.30563738",
-  "doi": "10.6084/m9.figshare.30563738"
+  "identifier": "https://doi.org/10.6084/m9.figshare.31222696",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31222696",
+  "doi": "10.6084/m9.figshare.31222696"
 }

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/index.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/index.json
@@ -5,7 +5,7 @@
   "description": "Introduces EFC v4.1, a frozen effective response law that maps baryonic to observed gravitational acceleration via a universal response function R(x) and a fixed acceleration scale a0. With fixed mass-to-light ratios, it accurately predicts galaxy rotation curves across the SPARC sample and is consistent with strong-lensing Einstein radii using the same a0, while specifying explicit domain limits and fail conditions.",
   "version": "1.0",
   "date": "2026-01-31",
-  "doi": "10.6084/m9.figshare.30563738",
+  "doi": "10.6084/m9.figshare.31222696",
   "keywords": [
     "Energy-Flow Cosmology",
     "response function R(x)",
@@ -105,7 +105,7 @@
   "files": {
     "pdf": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.pdf"
   },
-  "figshare_url": "https://doi.org/10.6084/m9.figshare.30563738",
+  "figshare_url": "https://doi.org/10.6084/m9.figshare.31222696",
   "short_title": "EFC Effective Phenomenological Law",
   "type": "formal",
   "status": "published",
@@ -164,7 +164,7 @@
   "dependencies": [
     {
       "id": "efc-v1.2",
-      "doi": "10.6084/m9.figshare.30563738"
+      "doi": "10.6084/m9.figshare.31222696"
     }
   ],
   "related_papers": [

--- a/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/metadata.json
+++ b/docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes/metadata.json
@@ -9,7 +9,7 @@
     "affiliation": "Symbiose Research, Sandnes, Norway"
   },
   "license": "CC-BY-4.0",
-  "doi": "10.6084/m9.figshare.30563738",
+  "doi": "10.6084/m9.figshare.31222696",
   "abstract": "Introduces EFC v4.1, a frozen effective response law that maps baryonic to observed gravitational acceleration via a universal response function R(x) and a fixed acceleration scale a0. With fixed mass-to-light ratios, it accurately predicts galaxy rotation curves across the SPARC sample and is consistent with strong-lensing Einstein radii using the same a0, while specifying explicit domain limits and fail conditions.",
   "keywords": [
     "Energy-Flow Cosmology",
@@ -29,7 +29,7 @@
     "pdf": "Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes.pdf"
   },
   "paper": {
-    "doi": "10.6084/m9.figshare.30563738",
-    "figshare_url": "https://doi.org/10.6084/m9.figshare.30563738"
+    "doi": "10.6084/m9.figshare.31222696",
+    "figshare_url": "https://doi.org/10.6084/m9.figshare.31222696"
   }
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/CITATION.cff
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/CITATION.cff
@@ -8,6 +8,6 @@ authors:
     affiliation: "Symbiose Research, Sandnes, Norway"
 date-released: "2026-03-06"
 version: "v6"
-doi: "10.6084/m9.figshare.31368433"
+doi: "10.6084/m9.figshare.31562200"
 license: "CC-BY-4.0"
 repository-code: "https://github.com/supertedai/EFC"

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/EFC-EFT-Ansatz.jsonld
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/EFC-EFT-Ansatz.jsonld
@@ -54,7 +54,7 @@
       "identifier": "arXiv:1710.05834"
     }
   ],
-  "identifier": "https://doi.org/10.6084/m9.figshare.31368433",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31368433",
-  "doi": "10.6084/m9.figshare.31368433"
+  "identifier": "https://doi.org/10.6084/m9.figshare.31562200",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31562200",
+  "doi": "10.6084/m9.figshare.31562200"
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/README.md
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/README.md
@@ -2,7 +2,7 @@
 
 ## AI-Friendly Package
 
-- **DOI:** [10.6084/m9.figshare.31368433](https://doi.org/10.6084/m9.figshare.31368433)
+- **DOI:** [10.6084/m9.figshare.31562200](https://doi.org/10.6084/m9.figshare.31562200)
 - **Version:** v6
 - **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
 - **Date:** 2026-03-06

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/citations.bib
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/citations.bib
@@ -66,5 +66,5 @@
   title  = {Minimal {EFC} Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Entropy Gradients},
   year   = {2026},
   note   = {Research Note v6},
-  doi    = {10.6084/m9.figshare.31368433}
+  doi    = {10.6084/m9.figshare.31562200}
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/data/eft_parameters.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/data/eft_parameters.json
@@ -1,5 +1,5 @@
 {
-  "paper_doi": "10.6084/m9.figshare.31368433",
+  "paper_doi": "10.6084/m9.figshare.31562200",
   "conventions": {
     "metric": "ds^2 = -(1+2Psi)dt^2 + a^2(1-2Phi)dx^2",
     "slip_definition": "eta = Phi/Psi",

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/index.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/index.json
@@ -5,7 +5,7 @@
   "description": "Proposes a minimal effective field theory completion for Energy-Flow Cosmology (EFC) in two formulations: a Horndeski-like scalar\u2013tensor EFT and a vector\u2013tensor EFT with a dynamical energy-flow 4-vector. Both are driven by a sigmoid entropy field S(a) that ensures GR recovery at high redshift and targets a mid\u2011z signature with weakened growth (mu < 1), gravitational slip (eta > 1), and enhanced lensing (Sigma > 1). The note defines the observables, derives the slip mechanism from entropy-gradient anisotropic stress, and specifies stability/consistency conditions, with numerical evaluation deferred to hi_class/EFTCosmoMC.",
   "version": "v6",
   "date": "2026-03-06",
-  "doi": "10.6084/m9.figshare.31368433",
+  "doi": "10.6084/m9.figshare.31562200",
   "keywords": [
     "Energy-Flow Cosmology",
     "effective field theory of dark energy",
@@ -115,7 +115,7 @@
     "pdf": "Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients.pdf",
     "readme": "README.md"
   },
-  "figshare_url": "https://doi.org/10.6084/m9.figshare.31368433",
+  "figshare_url": "https://doi.org/10.6084/m9.figshare.31562200",
   "paper_id": "EFC-EFT-Ansatz-v6",
   "orcid": "0009-0002-4860-5095",
   "status": "Proposed EFT completion \u2014 not canonical baseline EFC-D",

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/metadata.json
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/metadata.json
@@ -9,7 +9,7 @@
     "affiliation": "Symbiose Research, Sandnes, Norway"
   },
   "license": "CC-BY-4.0",
-  "doi": "10.6084/m9.figshare.31368433",
+  "doi": "10.6084/m9.figshare.31562200",
   "abstract": "Proposes a minimal effective field theory completion for Energy-Flow Cosmology (EFC) in two formulations: a Horndeski-like scalar\u2013tensor EFT and a vector\u2013tensor EFT with a dynamical energy-flow 4-vector. Both are driven by a sigmoid entropy field S(a) that ensures GR recovery at high redshift and targets a mid\u2011z signature with weakened growth (mu < 1), gravitational slip (eta > 1), and enhanced lensing (Sigma > 1). The note defines the observables, derives the slip mechanism from entropy-gradient anisotropic stress, and specifies stability/consistency conditions, with numerical evaluation deferred to hi_class/EFTCosmoMC.",
   "keywords": [
     "Energy-Flow Cosmology",
@@ -30,7 +30,7 @@
     "readme": "README.md"
   },
   "paper": {
-    "doi": "10.6084/m9.figshare.31368433",
-    "figshare_url": "https://doi.org/10.6084/m9.figshare.31368433"
+    "doi": "10.6084/m9.figshare.31562200",
+    "figshare_url": "https://doi.org/10.6084/m9.figshare.31562200"
   }
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/minimal-efc-effective-field-theory-ansatz-scalar-tensor-and-vector-tensor-formulations-with-gravitational-slip-from-entr.jsonld
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/minimal-efc-effective-field-theory-ansatz-scalar-tensor-and-vector-tensor-formulations-with-gravitational-slip-from-entr.jsonld
@@ -19,7 +19,7 @@
   "about": [
     "Spor general"
   ],
-  "identifier": "https://doi.org/10.6084/m9.figshare.31368433",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31368433",
-  "doi": "10.6084/m9.figshare.31368433"
+  "identifier": "https://doi.org/10.6084/m9.figshare.31562200",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31562200",
+  "doi": "10.6084/m9.figshare.31562200"
 }

--- a/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/minimal-efc-effective-field-theory-ansatz-scalar-tensor-and-vector-tensor-formulations-with-gravitational-slip-from-entropy-gradients.jsonld
+++ b/docs/papers/efc/Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients/minimal-efc-effective-field-theory-ansatz-scalar-tensor-and-vector-tensor-formulations-with-gravitational-slip-from-entropy-gradients.jsonld
@@ -11,8 +11,8 @@
   },
   "datePublished": "2026-03-06",
   "license": "https://creativecommons.org/licenses/by/4.0/",
-  "@id": "doi:10.6084/m9.figshare.31368433",
-  "identifier": "https://doi.org/10.6084/m9.figshare.31368433",
-  "doi": "10.6084/m9.figshare.31368433",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31368433"
+  "@id": "doi:10.6084/m9.figshare.31562200",
+  "identifier": "https://doi.org/10.6084/m9.figshare.31562200",
+  "doi": "10.6084/m9.figshare.31562200",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31562200"
 }

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/CITATION.cff
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/CITATION.cff
@@ -8,6 +8,6 @@ authors:
     affiliation: "Symbiose Research, Sandnes, Norway"
 date-released: "2026-01-24"
 version: "1.0"
-doi: "10.6084/m9.figshare.31140000"
+doi: "10.6084/m9.figshare.31144030"
 license: "CC-BY-4.0"
 repository-code: "https://github.com/supertedai/EFC"

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/README.md
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/README.md
@@ -2,7 +2,7 @@
 
 ## AI-Friendly Package
 
-- **DOI:** [10.6084/m9.figshare.31140000](https://doi.org/10.6084/m9.figshare.31140000)
+- **DOI:** [10.6084/m9.figshare.31144030](https://doi.org/10.6084/m9.figshare.31144030)
 - **Version:** 1.0
 - **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
 - **Date:** 2026-01-24

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/citations.bib
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/citations.bib
@@ -2,7 +2,7 @@
   author = {Magnusson, Morten},
   title = {Regime-Dependent Growth Enhancement: A Transition Metric Interpretation of the Fugaku--DESI Matter Density Offset},
   year = {2026},
-  doi = {10.6084/m9.figshare.31140000}
+  doi = {10.6084/m9.figshare.31144030}
 }
 
 @article{desi2024,

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/data/fugaku_desi_data.json
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/data/fugaku_desi_data.json
@@ -1,6 +1,6 @@
 {
   "description": "Transition metric data for Fugaku-DESI matter density offset interpretation",
-  "reference": "Magnusson (2026), DOI: 10.6084/m9.figshare.31140000",
+  "reference": "Magnusson (2026), DOI: 10.6084/m9.figshare.31144030",
   "transition_estimator": {
     "Delta_F": 0.1,
     "interpretation": "Integrated transition strength, not fundamental density shift"

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/index.json
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/index.json
@@ -5,7 +5,7 @@
   "description": "The paper reinterprets the ~10% matter-density offset seen in DESI-calibrated Fugaku N-body simulations as an integrated transition-strength estimator, \u0394F \u2248 0.1, of a regime-dependent effective gravitational coupling \u03bc(a) \u2261 G_eff/G. It introduces a bounded transition kernel and an observational window W(a) to define \u0394F, and shows a single \u03bc(a) can satisfy CMB (\u03bc\u22481 at recombination), DESI/Fugaku growth (\u0394F\u22480.1 in the sensitivity band), and galaxy-scale (\u03bc\u21921+\u0394\u03bc) consistency simultaneously.",
   "version": "1.0",
   "date": "2026-01-24",
-  "doi": "10.6084/m9.figshare.31140000",
+  "doi": "10.6084/m9.figshare.31144030",
   "keywords": [
     "DESI DR2",
     "Fugaku simulations",
@@ -79,7 +79,7 @@
     "tex": "efc_transition_metric.tex",
     "toolkit": "efc-toolkit/"
   },
-  "figshare_url": "https://doi.org/10.6084/m9.figshare.31140000",
+  "figshare_url": "https://doi.org/10.6084/m9.figshare.31144030",
   "short_title": "Fugaku-DESI Transition Metric",
   "type": "empirical_analysis",
   "status": "published",

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/metadata.json
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/metadata.json
@@ -9,7 +9,7 @@
     "affiliation": "Symbiose Research, Sandnes, Norway"
   },
   "license": "CC-BY-4.0",
-  "doi": "10.6084/m9.figshare.31140000",
+  "doi": "10.6084/m9.figshare.31144030",
   "abstract": "The paper reinterprets the ~10% matter-density offset seen in DESI-calibrated Fugaku N-body simulations as an integrated transition-strength estimator, \u0394F \u2248 0.1, of a regime-dependent effective gravitational coupling \u03bc(a) \u2261 G_eff/G. It introduces a bounded transition kernel and an observational window W(a) to define \u0394F, and shows a single \u03bc(a) can satisfy CMB (\u03bc\u22481 at recombination), DESI/Fugaku growth (\u0394F\u22480.1 in the sensitivity band), and galaxy-scale (\u03bc\u21921+\u0394\u03bc) consistency simultaneously.",
   "keywords": [
     "DESI DR2",
@@ -31,7 +31,7 @@
     "toolkit": "efc-toolkit/"
   },
   "paper": {
-    "doi": "10.6084/m9.figshare.31140000",
-    "figshare_url": "https://doi.org/10.6084/m9.figshare.31140000"
+    "doi": "10.6084/m9.figshare.31144030",
+    "figshare_url": "https://doi.org/10.6084/m9.figshare.31144030"
   }
 }

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/regime-dependent-growth-enhancement-a-transition-metric-interpretation-of-the-fugaku-desi-matter-density-offset.jsonld
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/regime-dependent-growth-enhancement-a-transition-metric-interpretation-of-the-fugaku-desi-matter-density-offset.jsonld
@@ -23,7 +23,7 @@
   "about": [
     "Spor 1 — Galactic/Cosmological"
   ],
-  "identifier": "https://doi.org/10.6084/m9.figshare.31140000",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31140000",
-  "doi": "10.6084/m9.figshare.31140000"
+  "identifier": "https://doi.org/10.6084/m9.figshare.31144030",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31144030",
+  "doi": "10.6084/m9.figshare.31144030"
 }

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/regime-dependent-growth-enhancement-fugaku-desi.jsonld
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/regime-dependent-growth-enhancement-fugaku-desi.jsonld
@@ -11,8 +11,8 @@
   },
   "datePublished": "2026-01-24",
   "license": "https://creativecommons.org/licenses/by/4.0/",
-  "@id": "doi:10.6084/m9.figshare.31140000",
-  "identifier": "https://doi.org/10.6084/m9.figshare.31140000",
-  "doi": "10.6084/m9.figshare.31140000",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31140000"
+  "@id": "doi:10.6084/m9.figshare.31144030",
+  "identifier": "https://doi.org/10.6084/m9.figshare.31144030",
+  "doi": "10.6084/m9.figshare.31144030",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31144030"
 }

--- a/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/transition_metric.jsonld
+++ b/docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset/transition_metric.jsonld
@@ -5,7 +5,7 @@
     "doi": "https://doi.org/"
   },
   "@type": "ScholarlyArticle",
-  "@id": "doi:10.6084/m9.figshare.31140000",
+  "@id": "doi:10.6084/m9.figshare.31144030",
   "name": "Regime-Dependent Growth Enhancement: A Transition Metric Interpretation of the Fugaku-DESI Matter Density Offset",
   "headline": "10% matter density offset reinterpreted as integrated transition strength Delta_F",
   "author": {
@@ -45,7 +45,7 @@
     "name": "Energy-Flow Cosmology Framework",
     "url": "https://github.com/supertedai/EFC"
   },
-  "identifier": "https://doi.org/10.6084/m9.figshare.31140000",
-  "sameAs": "https://doi.org/10.6084/m9.figshare.31140000",
-  "doi": "10.6084/m9.figshare.31140000"
+  "identifier": "https://doi.org/10.6084/m9.figshare.31144030",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.31144030",
+  "doi": "10.6084/m9.figshare.31144030"
 }

--- a/docs/papers/efc/symbiotic-insight-framework/ai_manifest.json
+++ b/docs/papers/efc/symbiotic-insight-framework/ai_manifest.json
@@ -8,7 +8,7 @@
   "license": "CC-BY-4.0",
   "package_type": "ai-friendly-paper",
   "schema_version": "1.0",
-  "generated": "2026-04-22",
+  "generated": "2026-04-25",
   "track": "Spor 1 — Galactic/Cosmological",
   "regimes": [],
   "primary_pdf": "symbiotic-insight-framework.pdf",
@@ -50,7 +50,7 @@
     },
     {
       "path": "index.json",
-      "bytes": 3802
+      "bytes": 3818
     },
     {
       "path": "metadata.json",

--- a/docs/papers/efc/symbiotic-insight-framework/index.json
+++ b/docs/papers/efc/symbiotic-insight-framework/index.json
@@ -4,13 +4,13 @@
   "title": "Symbiotic Insight Framework (SIF): A Structural Methodology for High-Velocity Scientific Reasoning",
   "description": "This paper introduces the Symbiotic Insight Framework (SIF), a structural methodology in which a human thinker and an adaptive computational system jointly produce stable scientific structure from high-velocity, parallel reasoning. SIF formalizes a closed-loop process of immediate externalization, structural consolidation, semantic indexing (e.g., JSON-LD), and version-locked preservation to maintain coherence across domains. The key contribution is a reproducible architecture that scales conceptual velocity into durable, cross-domain scientific artefacts.",
   "version": "1.0",
-  "date": "2025-11-01",
-  "doi": "",
+  "date": "2025-11-21",
+  "doi": "10.6084/m9.figshare.30656351",
   "keywords": [
     "symbiotic intelligence",
     "high-velocity reasoning",
     "scientific workflow",
-    "human\u2013computer interaction",
+    "human–computer interaction",
     "structural consolidation",
     "semantic indexing",
     "cross-domain integration",
@@ -27,7 +27,7 @@
   },
   "core_equations": {},
   "key_results": {
-    "main_finding": "SIF formalizes a human\u2013system symbiosis that stabilizes rapid, parallel cross-domain insight into reproducible scientific artefacts via structural consolidation, semantic integration, and version-locked pipelines.",
+    "main_finding": "SIF formalizes a human–system symbiosis that stabilizes rapid, parallel cross-domain insight into reproducible scientific artefacts via structural consolidation, semantic integration, and version-locked pipelines.",
     "delta_chi2": null,
     "significance_sigma": null,
     "parameters_tested": [],
@@ -36,11 +36,11 @@
   },
   "sealed_predictions": [],
   "kill_criteria": [
-    "KC1: Failure to reproduce identical outputs from identical inputs across versions (i.e., broken version-safe documentation or non-deterministic pipelines) undercuts SIF\u2019s core claim of reproducibility.",
+    "KC1: Failure to reproduce identical outputs from identical inputs across versions (i.e., broken version-safe documentation or non-deterministic pipelines) undercuts SIF’s core claim of reproducibility.",
     "KC2: Loss of cross-file or cross-domain semantic continuity during high-velocity edits, evidenced by unresolved JSON-LD links or schema violations persisting after automated validation, falsifies the claimed semantic integration.",
     "KC3: Ablation study shows a human-only workflow matches or exceeds SIF on both throughput and structural coherence (measured by predefined integrity and consistency metrics), negating the symbiotic advantage.",
     "KC4: System cannot reliably capture and externalize parallel conceptual fields before decay (e.g., repeated drop of content or irreversible drift between drafts and indexed artefacts), contradicting immediate externalization.",
-    "KC5: Repository integrity failures (e.g., index corruption or unrecoverable cross-references) that prevent end-to-end reconstruction of artefacts from version history invalidate the framework\u2019s preservation guarantees."
+    "KC5: Repository integrity failures (e.g., index corruption or unrecoverable cross-references) that prevent end-to-end reconstruction of artefacts from version history invalidate the framework’s preservation guarantees."
   ],
   "tier": "T3",
   "paper_type": "methodology",

--- a/docs/validation-ledger/data/evidence-register.json
+++ b/docs/validation-ledger/data/evidence-register.json
@@ -1,9 +1,219 @@
 {
   "name": "Evidence Register",
   "version": "3.0",
-  "generated_at": "2026-04-25T04:35:36Z",
+  "generated_at": "2026-04-25T09:59:15.635668Z",
   "categories": {
     "empirical": [
+      {
+        "doi": "28098299",
+        "name": "EFC — Observational Evidence for Entropy in Cosmic Evolution",
+        "category": "empirical"
+      },
+      {
+        "doi": "28098305",
+        "name": "EFC – Why Is Light Speed a Cosmic Limit?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098308",
+        "name": "EFC – Applications and Implications",
+        "category": "structural"
+      },
+      {
+        "doi": "28098311",
+        "name": "EFC — What is the Connection Between Energy Flow and the Now?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098314",
+        "name": "EFC — Mathematical Framework for Energy Flow in Space-Time",
+        "category": "structural"
+      },
+      {
+        "doi": "28098320",
+        "name": "EFC — Introduction to Entropy in Cosmic Evolution",
+        "category": "structural"
+      },
+      {
+        "doi": "28098326",
+        "name": "EFC — Unresolved Questions and Challenges: Entropy",
+        "category": "structural"
+      },
+      {
+        "doi": "28098332",
+        "name": "EFC — Technical Documentation: Energy Flow in Space-Time",
+        "category": "structural"
+      },
+      {
+        "doi": "28098338",
+        "name": "EFC — How Does Balance Shape Universal Structures?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098341",
+        "name": "EFC — Introduction to Energy Flow in Space-Time",
+        "category": "structural"
+      },
+      {
+        "doi": "28098344",
+        "name": "Dynamic Balance: How Entropy Governs the Balance Between Order and Chaos in Cosm",
+        "category": "structural"
+      },
+      {
+        "doi": "28098347",
+        "name": "EFC — Is Consciousness Linked to Entropy?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098350",
+        "name": "EFC — Can Energy Flow Be Observed in Galactic Clusters?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098353",
+        "name": "EFC — Can Entropy Drive Cosmic Evolution?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098365",
+        "name": "EFC — Observational Evidence for Energy Flow",
+        "category": "empirical"
+      },
+      {
+        "doi": "28098371",
+        "name": "EFC — How Energy Flow Sustains Spacetime",
+        "category": "structural"
+      },
+      {
+        "doi": "28098380",
+        "name": "EFC — What Happens at the Universe’s Extremes?",
+        "category": "structural"
+      },
+      {
+        "doi": "28098386",
+        "name": "Hypothesis: The Universe as an Energy-Driven System – Integrating Time, Space, C",
+        "category": "structural"
+      },
+      {
+        "doi": "28111925",
+        "name": "EFC — Light Speed as a Regulator of Energy Flow in the Universe",
+        "category": "structural"
+      },
+      {
+        "doi": "28112036",
+        "name": "EFC — Subhypothesis: Light Speed Limit",
+        "category": "structural"
+      },
+      {
+        "doi": "28112096",
+        "name": "EFC — Flow, Entropy, and Spacetime Distortion in Cosmological Clusters",
+        "category": "empirical"
+      },
+      {
+        "doi": "28113542",
+        "name": "EFC — Energy Flow as the Fundamental Dynamic of the Universe",
+        "category": "structural"
+      },
+      {
+        "doi": "28114370",
+        "name": "EFC — A Deep Dive into the Halo Concept",
+        "category": "structural"
+      },
+      {
+        "doi": "28557281",
+        "name": "EFC — Hypothesis: Interrelation Between Energy and Entropy",
+        "category": "structural"
+      },
+      {
+        "doi": "28559423",
+        "name": "Grid Model: An Entropic and Dynamic Theory for Emergent Gravity in Cosmology",
+        "category": "structural"
+      },
+      {
+        "doi": "28559510",
+        "name": "EFC — Grid-Higgs Framework",
+        "category": "structural"
+      },
+      {
+        "doi": "28560935",
+        "name": "Paradigm Shift in Cosmology: Continuous Energy Recycling Through the Grid-Higgs ",
+        "category": "structural"
+      },
+      {
+        "doi": "28570088",
+        "name": "Hypothesis on Cosmic Microwave Background as a Thermodynamic Temperature Gradien",
+        "category": "structural"
+      },
+      {
+        "doi": "28578263",
+        "name": "EFC — Integrated Hypothesis: Time and Entropy",
+        "category": "structural"
+      },
+      {
+        "doi": "30275947",
+        "name": "CEM: A Field-Theoretic Model of Consciousness Coupled to Energy-Flow Cosmology",
+        "category": "structural"
+      },
+      {
+        "doi": "30402427",
+        "name": "Energy-Flow Cosmology: A Thermodynamic Bridge Between General Relativity and Qua",
+        "category": "structural"
+      },
+      {
+        "doi": "30421807",
+        "name": "Energy-Flow Cosmology: Field Equations for Entropy-Driven Spacetime",
+        "category": "structural"
+      },
+      {
+        "doi": "30455237",
+        "name": "Energy-Flow Cosmology (EFC v2.1): Modular Synthesis across Structure, Dynamics, ",
+        "category": "structural"
+      },
+      {
+        "doi": "30468737",
+        "name": "The Energy–Flow Interface: A Unified Thermodynamic Interpretation of Dark Matter",
+        "category": "structural"
+      },
+      {
+        "doi": "30478916",
+        "name": "EFC v2.1 – Complete Edition",
+        "category": "structural"
+      },
+      {
+        "doi": "30530156",
+        "name": "EFC — v2.2 Cross-Field Integration Summary",
+        "category": "structural"
+      },
+      {
+        "doi": "30563738",
+        "name": "Energy–Flow Cosmology v1.2: Foundational Framework and Cross-Field Continuity",
+        "category": "structural"
+      },
+      {
+        "doi": "30630500",
+        "name": "EFC — Formal Specification",
+        "category": "structural"
+      },
+      {
+        "doi": "30636863",
+        "name": "EFC — AI-Augmented Scientific Workflow Framework",
+        "category": "structural"
+      },
+      {
+        "doi": "30642497",
+        "name": "Variable Effective Light Speed in Entropic Transition States: A Formal Treatment",
+        "category": "structural"
+      },
+      {
+        "doi": "30656828",
+        "name": "AUTH Layer: Origin, Provenance and Structural Signature of Energy-Flow Cosmology",
+        "category": "structural"
+      },
+      {
+        "doi": "30773684",
+        "name": "Symbiosis: A Human–AI Co-Reflection Architecture Using Graph–Vector Memory for L",
+        "category": "structural"
+      },
       {
         "doi": "31007248",
         "name": "Regime-Dependent Validity in EFC: SPARC Galaxy Rotation Curves",
@@ -13,6 +223,11 @@
         "doi": "31026151",
         "name": "Resolving H0 and S8 Tensions via Local-Global Inference Separation",
         "category": "empirical"
+      },
+      {
+        "doi": "31042678",
+        "name": "Bridging Scales: Energy-Flow Cosmology and the Free Energy Principle as Compleme",
+        "category": "structural"
       },
       {
         "doi": "31047703",
@@ -30,14 +245,49 @@
         "category": "empirical"
       },
       {
+        "doi": "31061872",
+        "name": "Energy-Flow Cosmology and Regime-Dependent Structure Formation (Paper III)",
+        "category": "structural"
+      },
+      {
         "doi": "31064929",
-        "name": "CMB \u2014 Thermodynamic Interpretation",
+        "name": "CMB — Thermodynamic Interpretation",
         "category": "empirical"
       },
       {
         "doi": "31095466",
         "name": "Systematic CMB Constraints on Early-Universe Modifications",
         "category": "empirical"
+      },
+      {
+        "doi": "31096951",
+        "name": "Dynamical Regime Transitions in Cosmology: A CMB-Safe Framework",
+        "category": "structural"
+      },
+      {
+        "doi": "31112536",
+        "name": "L0–L3 Regime Architecture in Entropy-Bounded Empiricism",
+        "category": "structural"
+      },
+      {
+        "doi": "31122970",
+        "name": "Validity-Aware AI: An Entropy-Bounded Architecture for Regime-Sensitive Inferenc",
+        "category": "structural"
+      },
+      {
+        "doi": "31127380",
+        "name": "EFC Phenomenology vs DESI DR2 BAO: A Comparative Fit Analysis",
+        "category": "empirical"
+      },
+      {
+        "doi": "31135597",
+        "name": "Foundations of Energy-Flow Cosmology (EFC): Regime Architecture and Methodologic",
+        "category": "structural"
+      },
+      {
+        "doi": "31140000",
+        "name": "Regime-Dependent Growth Enhancement: A Transition Metric Interpretation of the F",
+        "category": "structural"
       },
       {
         "doi": "31144030",
@@ -65,13 +315,33 @@
         "category": "empirical"
       },
       {
+        "doi": "31222696",
+        "name": "Energy-Flow Cosmology: An Effective Phenomenological Law for Gravitational Response in Structure-Dominated Regimes",
+        "category": "empirical"
+      },
+      {
+        "doi": "31223650",
+        "name": "Regime-Based World Modeling: A Layered Epistemic Architecture for Complex System",
+        "category": "structural"
+      },
+      {
+        "doi": "31224247",
+        "name": "The Hubble Tension as Regime Mismatch: Background Gravity vs Structure Gravity in Energy-Flow Cosmology",
+        "category": "empirical"
+      },
+      {
         "doi": "31224538",
         "name": "EFC Phase 3 SPARC Validation (RAR)",
         "category": "empirical"
       },
       {
+        "doi": "31230703",
+        "name": "Energy-Flow Cosmology: Regime-Transition Fit to DESI DR2 BAO",
+        "category": "empirical"
+      },
+      {
         "doi": "31231522",
-        "name": "EFC BAO Predictions: DESI DR2 \u2192 BOSS DR12 Transfer",
+        "name": "EFC BAO Predictions: DESI DR2 → BOSS DR12 Transfer",
         "category": "empirical"
       },
       {
@@ -85,14 +355,34 @@
         "category": "empirical"
       },
       {
+        "doi": "31271707",
+        "name": "Persistent Cognitive Architectures for Human-AI Co-Reasoning: Beyond Retrieval t",
+        "category": "structural"
+      },
+      {
         "doi": "31271917",
-        "name": "Regime-Activated Lensing Response \u2014 KiDS-1000 Cosmic Shear",
+        "name": "Regime-Activated Lensing Response — KiDS-1000 Cosmic Shear",
         "category": "empirical"
       },
       {
         "doi": "31286368",
         "name": "Pre-Registered Test of Entropy-Structure Coupling in Galaxy Clusters",
         "category": "empirical"
+      },
+      {
+        "doi": "31288063",
+        "name": "Directional Lensing Residuals at Cluster Merger Shock Fronts",
+        "category": "empirical"
+      },
+      {
+        "doi": "31292827",
+        "name": "From RSD to Clusters: A Parameter-Locked Test of Late-Time Structure Growth",
+        "category": "empirical"
+      },
+      {
+        "doi": "31293745",
+        "name": "Structural Coherence Evaluation for Physical Theories: A Theory-Agnostic Framewo",
+        "category": "structural"
       },
       {
         "doi": "31304980",
@@ -102,6 +392,11 @@
       {
         "doi": "31304995",
         "name": "Regime Consistency of Entropy-Gradient Coupling (Lya BAO + RSD)",
+        "category": "empirical"
+      },
+      {
+        "doi": "31305421",
+        "name": "Toward a Quantitative c_eff(a): Parameterization, Constraints, and Degeneracy-Breaking Tests",
         "category": "empirical"
       },
       {
@@ -115,18 +410,23 @@
         "category": "empirical"
       },
       {
-        "doi": "30656828",
-        "name": "AUTH Layer: Origin, Provenance and Structural Signature of Energy-Flow Cosmology",
-        "category": "structural"
-      },
-      {
-        "doi": "32084670",
-        "name": "A structural closure of growth-sector couplings between discrete gravity and cos",
+        "doi": "31329082",
+        "name": "ISW Paper Revision Patch: Proposed Corrections to ISW Cross-Correlation Predictions for EFC with DESI DR1 Tracers",
         "category": "empirical"
       },
       {
-        "doi": "30275947",
-        "name": "CEM: A Field-Theoretic Model of Consciousness Coupled to Energy-Flow Cosmology",
+        "doi": "31332730",
+        "name": "Robustness of the EFC Growth-Sector Signal: Leave-One-Out, Sound-Horizon, and Amplitude-Prior Controls for the Hubble-Fr",
+        "category": "empirical"
+      },
+      {
+        "doi": "31368433",
+        "name": "Systematic Localization of Late-Time Cosmological Signals in Modified Gravity: CMB Survival, the Lensing Barrier, and a ",
+        "category": "empirical"
+      },
+      {
+        "doi": "31564123",
+        "name": "Regime-Bound Measurement in Complex Systems: Proxy, Placement, and Validity",
         "category": "structural"
       },
       {
@@ -135,188 +435,98 @@
         "category": "structural"
       },
       {
-        "doi": "28114370",
-        "name": "EFC \u2014 A Deep Dive into the Halo Concept",
+        "doi": "31833076",
+        "name": "Regime-Locked Measurement as a General Structural Constraint: Cross-Domain Frame",
         "category": "structural"
       },
       {
-        "doi": "30636863",
-        "name": "EFC \u2014 AI-Augmented Scientific Workflow Framework",
+        "doi": "31864993",
+        "name": "Natural and Mechanical Entropy: Intention Detection via Episenter–Resonance Anal",
         "category": "structural"
       },
       {
-        "doi": "28098308",
-        "name": "EFC \u2013 Applications and Implications",
+        "doi": "31940469",
+        "name": "Energy-Flow Cosmology: Empirical Validation of the EFC Screening Model Against the Radial Acceleration Relation",
+        "category": "empirical"
+      },
+      {
+        "doi": "31940505",
+        "name": "EFC-C: A Thermodynamic Framework for Cognitive Entropy and Psychiatric Biomarkers",
+        "category": "empirical"
+      },
+      {
+        "doi": "31940547",
+        "name": "Cross-Domain Bridge Equations for the EFC Framework: Connecting Cosmology, Neural Entropy, and RLHF via Dissipative Grad",
+        "category": "empirical"
+      },
+      {
+        "doi": "31940604",
+        "name": "Homo Fluxus v2.0 — A Civilization Map Through Energy-Flow Cosmology: From Grid to Governance — One Gradient, All Regimes",
+        "category": "empirical"
+      },
+      {
+        "doi": "31942677",
+        "name": "Density-Dependent Gravitational Coupling Predicts ISW Sign-Flip in Deep Voids",
+        "category": "empirical"
+      },
+      {
+        "doi": "31942731",
+        "name": "The Cosmic Dipole Anomaly as Regime-Dependent Anisotropy in Energy-Flow Cosmology",
+        "category": "empirical"
+      },
+      {
+        "doi": "31951992",
+        "name": "EFC Lensing Validation Update: DES Year 6 Is Consistent With S8 Suppression Prediction",
+        "category": "empirical"
+      },
+      {
+        "doi": "31954125",
+        "name": "Cross-Survey Parameter Transfer Validation of Energy-Flow Cosmology: DESI DR2 Parameters Applied to BOSS/eBOSS BAO Witho",
+        "category": "empirical"
+      },
+      {
+        "doi": "31955871",
+        "name": "Multi-epoch Growth Rate Test of EFC Perturbation-Sector Coupling: f σ8(z) from BOSS DR12, eBOSS DR16, and DESI DR1",
+        "category": "empirical"
+      },
+      {
+        "doi": "31970886",
+        "name": "efc white paper part 1 to 4",
+        "category": "empirical"
+      },
+      {
+        "doi": "31986762",
+        "name": "Kill-Test v6 Universality — Extension of the EFC vs ΛCDM Kill-Test to the Full SPARC 175 Sample",
+        "category": "empirical"
+      },
+      {
+        "doi": "31990194",
+        "name": "Consistent Modified Gravity Weak Lensing in Energy-Flow Cosmology: The µ–Σ Eigenmode, Destructive Interference, and E_G ",
+        "category": "empirical"
+      },
+      {
+        "doi": "32013156",
+        "name": "Sealed Blind Predictions for Growth-Rate Observables: Energy-Flow Cosmology vs ΛCDM",
+        "category": "empirical"
+      },
+      {
+        "doi": "32019723",
+        "name": "Component-weighted bias in rotation curve model selection: A proxy-chain audit o",
         "category": "structural"
       },
       {
-        "doi": "31042678",
-        "name": "Bridging Scales: Energy-Flow Cosmology and the Free Energy Principle as Compleme",
-        "category": "structural"
+        "doi": "32029704",
+        "name": "Systematic elimination of local gravitational models on the SPARC 175 sample: Evidence for an irreducible galaxy-specifi",
+        "category": "empirical"
       },
       {
-        "doi": "28570088",
-        "name": "Hypothesis on Cosmic Microwave Background as a Thermodynamic Temperature Gradien",
-        "category": "structural"
+        "doi": "32037990",
+        "name": "EFC Perturbation Sector: Constraint-Driven Gravitational Slip and a Testable Lensing Crossover",
+        "category": "empirical"
       },
       {
-        "doi": "32091700",
-        "name": "EFC-C v2.1: Degree-Heterogeneity Entropy-Gradient Predictions for Cognitive Stat",
-        "category": "structural"
-      },
-      {
-        "doi": "28098350",
-        "name": "EFC \u2014 Can Energy Flow Be Observed in Galactic Clusters?",
-        "category": "structural"
-      },
-      {
-        "doi": "28098353",
-        "name": "EFC \u2014 Can Entropy Drive Cosmic Evolution?",
-        "category": "structural"
-      },
-      {
-        "doi": "28098344",
-        "name": "Dynamic Balance: How Entropy Governs the Balance Between Order and Chaos in Cosm",
-        "category": "structural"
-      },
-      {
-        "doi": "28113542",
-        "name": "EFC \u2014 Energy Flow as the Fundamental Dynamic of the Universe",
-        "category": "structural"
-      },
-      {
-        "doi": "30421807",
-        "name": "Energy-Flow Cosmology: Field Equations for Entropy-Driven Spacetime",
-        "category": "structural"
-      },
-      {
-        "doi": "28559510",
-        "name": "EFC \u2014 Grid-Higgs Framework",
-        "category": "structural"
-      },
-      {
-        "doi": "28560935",
-        "name": "Paradigm Shift in Cosmology: Continuous Energy Recycling Through the Grid-Higgs ",
-        "category": "structural"
-      },
-      {
-        "doi": "28559423",
-        "name": "Grid Model: An Entropic and Dynamic Theory for Emergent Gravity in Cosmology",
-        "category": "structural"
-      },
-      {
-        "doi": "28098338",
-        "name": "EFC \u2014 How Does Balance Shape Universal Structures?",
-        "category": "structural"
-      },
-      {
-        "doi": "28098371",
-        "name": "EFC \u2014 How Energy Flow Sustains Spacetime",
-        "category": "structural"
-      },
-      {
-        "doi": "28557281",
-        "name": "EFC \u2014 Hypothesis: Interrelation Between Energy and Entropy",
-        "category": "structural"
-      },
-      {
-        "doi": "28098386",
-        "name": "Hypothesis: The Universe as an Energy-Driven System \u2013 Integrating Time, Space, C",
-        "category": "structural"
-      },
-      {
-        "doi": "28578263",
-        "name": "EFC \u2014 Integrated Hypothesis: Time and Entropy",
-        "category": "structural"
-      },
-      {
-        "doi": "28098341",
-        "name": "EFC \u2014 Introduction to Energy Flow in Space-Time",
-        "category": "structural"
-      },
-      {
-        "doi": "28098320",
-        "name": "EFC \u2014 Introduction to Entropy in Cosmic Evolution",
-        "category": "structural"
-      },
-      {
-        "doi": "28098347",
-        "name": "EFC \u2014 Is Consciousness Linked to Entropy?",
-        "category": "structural"
-      },
-      {
-        "doi": "28111925",
-        "name": "EFC \u2014 Light Speed as a Regulator of Energy Flow in the Universe",
-        "category": "structural"
-      },
-      {
-        "doi": "28098314",
-        "name": "EFC \u2014 Mathematical Framework for Energy Flow in Space-Time",
-        "category": "structural"
-      },
-      {
-        "doi": "31096951",
-        "name": "Dynamical Regime Transitions in Cosmology: A CMB-Safe Framework",
-        "category": "structural"
-      },
-      {
-        "doi": "28112036",
-        "name": "EFC \u2014 Subhypothesis: Light Speed Limit",
-        "category": "structural"
-      },
-      {
-        "doi": "28098332",
-        "name": "EFC \u2014 Technical Documentation: Energy Flow in Space-Time",
-        "category": "structural"
-      },
-      {
-        "doi": "30468737",
-        "name": "The Energy\u2013Flow Interface: A Unified Thermodynamic Interpretation of Dark Matter",
-        "category": "structural"
-      },
-      {
-        "doi": "30402427",
-        "name": "Energy-Flow Cosmology: A Thermodynamic Bridge Between General Relativity and Qua",
-        "category": "structural"
-      },
-      {
-        "doi": "28098326",
-        "name": "EFC \u2014 Unresolved Questions and Challenges: Entropy",
-        "category": "structural"
-      },
-      {
-        "doi": "28098380",
-        "name": "EFC \u2014 What Happens at the Universe\u2019s Extremes?",
-        "category": "structural"
-      },
-      {
-        "doi": "28098311",
-        "name": "EFC \u2014 What is the Connection Between Energy Flow and the Now?",
-        "category": "structural"
-      },
-      {
-        "doi": "28098305",
-        "name": "EFC \u2013 Why Is Light Speed a Cosmic Limit?",
-        "category": "structural"
-      },
-      {
-        "doi": "30563738",
-        "name": "Energy\u2013Flow Cosmology v1.2: Foundational Framework and Cross-Field Continuity",
-        "category": "structural"
-      },
-      {
-        "doi": "30478916",
-        "name": "EFC v2.1 \u2013 Complete Edition",
-        "category": "structural"
-      },
-      {
-        "doi": "30455237",
-        "name": "Energy-Flow Cosmology (EFC v2.1): Modular Synthesis across Structure, Dynamics, ",
-        "category": "structural"
-      },
-      {
-        "doi": "30530156",
-        "name": "EFC \u2014 v2.2 Cross-Field Integration Summary",
+        "doi": "32080059",
+        "name": "Parameter-Controlled Regime Transitions in Energy-Flow Cosmology: Cross-Sector C",
         "category": "structural"
       },
       {
@@ -326,91 +536,31 @@
       },
       {
         "doi": "32080083",
-        "name": "EFC-\u039bCDM Comparative Test Specification v1.1",
+        "name": "EFC-ΛCDM Comparative Test Specification v1.1",
         "category": "structural"
       },
       {
-        "doi": "32080059",
-        "name": "Parameter-Controlled Regime Transitions in Energy-Flow Cosmology: Cross-Sector C",
-        "category": "structural"
+        "doi": "32084670",
+        "name": "A structural closure of growth-sector couplings between discrete gravity and cos",
+        "category": "empirical"
       },
       {
-        "doi": "31135597",
-        "name": "Foundations of Energy-Flow Cosmology (EFC): Regime Architecture and Methodologic",
-        "category": "structural"
-      },
-      {
-        "doi": "31112536",
-        "name": "L0\u2013L3 Regime Architecture in Entropy-Bounded Empiricism",
-        "category": "structural"
-      },
-      {
-        "doi": "31864993",
-        "name": "Natural and Mechanical Entropy: Intention Detection via Episenter\u2013Resonance Anal",
-        "category": "structural"
-      },
-      {
-        "doi": "31271707",
-        "name": "Persistent Cognitive Architectures for Human-AI Co-Reasoning: Beyond Retrieval t",
-        "category": "structural"
-      },
-      {
-        "doi": "31223650",
-        "name": "Regime-Based World Modeling: A Layered Epistemic Architecture for Complex System",
-        "category": "structural"
-      },
-      {
-        "doi": "31564123",
-        "name": "Regime-Bound Measurement in Complex Systems: Proxy, Placement, and Validity",
-        "category": "structural"
-      },
-      {
-        "doi": "31140000",
-        "name": "Regime-Dependent Growth Enhancement: A Transition Metric Interpretation of the F",
-        "category": "structural"
-      },
-      {
-        "doi": "31833076",
-        "name": "Regime-Locked Measurement as a General Structural Constraint: Cross-Domain Frame",
-        "category": "structural"
-      },
-      {
-        "doi": "31293745",
-        "name": "Structural Coherence Evaluation for Physical Theories: A Theory-Agnostic Framewo",
-        "category": "structural"
-      },
-      {
-        "doi": "30773684",
-        "name": "Symbiosis: A Human\u2013AI Co-Reflection Architecture Using Graph\u2013Vector Memory for L",
-        "category": "structural"
-      },
-      {
-        "doi": "32019723",
-        "name": "Component-weighted bias in rotation curve model selection: A proxy-chain audit o",
-        "category": "structural"
-      },
-      {
-        "doi": "30630500",
-        "name": "EFC \u2014 Formal Specification",
-        "category": "structural"
-      },
-      {
-        "doi": "31061872",
-        "name": "Energy-Flow Cosmology and Regime-Dependent Structure Formation (Paper III)",
-        "category": "structural"
-      },
-      {
-        "doi": "31122970",
-        "name": "Validity-Aware AI: An Entropy-Bounded Architecture for Regime-Sensitive Inferenc",
-        "category": "structural"
-      },
-      {
-        "doi": "30642497",
-        "name": "Variable Effective Light Speed in Entropic Transition States: A Formal Treatment",
+        "doi": "32091700",
+        "name": "EFC-C v2.1: Degree-Heterogeneity Entropy-Gradient Predictions for Cognitive Stat",
         "category": "structural"
       }
     ],
     "methodological": [
+      {
+        "doi": "30656351",
+        "name": "Symbiotic Insight Framework (SIF): A Structural Methodology for High-Velocity Scientific Reasoning",
+        "category": "methodological"
+      },
+      {
+        "doi": "31222900",
+        "name": "The Regime-Consistent Measurement Principle (RCMP): A Methodological Framework for Multi-Scale Physics",
+        "category": "methodological"
+      },
       {
         "doi": "31222903",
         "name": "EBE Core Principles v1.0",
@@ -425,17 +575,197 @@
         "doi": "31223668",
         "name": "EFC Ontological Foundations v1.0.2",
         "category": "methodological"
+      },
+      {
+        "doi": "31267297",
+        "name": "A Triangulation Test for Possible Thermodynamic Contributions to Gravitational Lensing in Galaxy Clusters",
+        "category": "methodological"
+      },
+      {
+        "doi": "31289806",
+        "name": "Consciousness as Field Resonance: From Ego-Filtered Ontology to Differentiation-Dominant Dynamics",
+        "category": "methodological"
+      },
+      {
+        "doi": "31348417",
+        "name": "Regime Structure and Entropic Flow Ontology in Discrete Gravity Models",
+        "category": "methodological"
+      },
+      {
+        "doi": "31963821",
+        "name": "Cross-Regime Measurement Failure in the KT3b Environmental Test",
+        "category": "methodological"
+      },
+      {
+        "doi": "31985163",
+        "name": "EFC Background No-Go Theorem: Why Background-Level Modification Cannot Suppress Structure Growth",
+        "category": "methodological"
       }
     ],
     "structural": [
+      {
+        "doi": "31045126",
+        "name": "Regime-Dependent Validity in Galaxy Rotation Curve Modeling: Comprehensive Analysis of 175 SPARC Galaxies",
+        "category": "structural"
+      },
+      {
+        "doi": "31173850",
+        "name": "Structural Constraints on Entropy-Gradient Gravity from Cluster Merger Geometry",
+        "category": "structural"
+      },
       {
         "doi": "31188193",
         "name": "EFC Weak Lensing Phenomenology (Case A)",
         "category": "structural"
       },
       {
+        "doi": "31223908",
+        "name": "Unified Origin of the Radial Acceleration Relation and the Hubble Tension via Entropic Gravity Modification",
+        "category": "structural"
+      },
+      {
         "doi": "31224466",
         "name": "EFC Closure Conjectures (Density Saturation)",
+        "category": "structural"
+      },
+      {
+        "doi": "31301953",
+        "name": "ISW Cross-Correlation Predictions for Energy-Flow Cosmology with DESI DR1 Tracers",
+        "category": "structural"
+      },
+      {
+        "doi": "31333414",
+        "name": "Sign structure of an additive gate-function modification to the Friedmann equation",
+        "category": "structural"
+      },
+      {
+        "doi": "31333600",
+        "name": "Perturbation-Level σ8 Suppression via μ(a) < 1: Structural Limits of Scale-Free Modifications",
+        "category": "structural"
+      },
+      {
+        "doi": "31348411",
+        "name": "Discrete Entropic Gravity on a Cubic Graph: Emergent Newtonian and MOND Regimes with Λ-Locked Screening",
+        "category": "structural"
+      },
+      {
+        "doi": "31348414",
+        "name": "Cosmological Growth Constraints on Λ-Locked Discrete Entropic Gravity",
+        "category": "structural"
+      },
+      {
+        "doi": "31562200",
+        "name": "Minimal EFC Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formulations with Gravitational Slip from Ent",
+        "category": "structural"
+      },
+      {
+        "doi": "31876324",
+        "name": "EFC Relativistic Action: Field Equations, Perturbation Theory, and Extraction of µ, Σ, η",
+        "category": "structural"
+      },
+      {
+        "doi": "31878334",
+        "name": "Covariant Effective Field Theory for Entropy-Driven Gravitational Modification: Derivation, Falsification, and Structura",
+        "category": "structural"
+      },
+      {
+        "doi": "31878760",
+        "name": "From Grid Microphysics to the Radial Acceleration Relation: A Minimal Gradient-Coupled Excitation Model",
+        "category": "structural"
+      },
+      {
+        "doi": "31940370",
+        "name": "Local Degree Heterogeneity Predicts Functional Variability Gradients in the Human Connectome",
+        "category": "structural"
+      },
+      {
+        "doi": "31940535",
+        "name": "Reinforcement Learning from Human Feedback as Thermodynamic Entropy Minimisation: A Formal Isomorphism and Testable Pred",
+        "category": "structural"
+      },
+      {
+        "doi": "31941465",
+        "name": "EFC Gradient-Coupled Grid Action",
+        "category": "structural"
+      },
+      {
+        "doi": "31941543",
+        "name": "Consistency of Scale-Dependent Gravitational Response in EFC: Numerical Regime Transition Test",
+        "category": "structural"
+      },
+      {
+        "doi": "31942734",
+        "name": "The Cosmic Entropy Budget as Constraint on the EFC S-Field",
+        "category": "structural"
+      },
+      {
+        "doi": "31942800",
+        "name": "Density of States of Gravitationally Active Grid Modes: Derivation of Deff (ρ) and Completion of the Γ(ρ) Bridge",
+        "category": "structural"
+      },
+      {
+        "doi": "31942821",
+        "name": "Derivation of the Entropy Production Function Γ(ρ) from Grid-Mode Bose–Einstein Statistics",
+        "category": "structural"
+      },
+      {
+        "doi": "31943361",
+        "name": "ΛCDM as a Special Case of Energy-Flow Cosmology: Regime Structure, Empirical Confrontation, and the Limits of Background",
+        "category": "structural"
+      },
+      {
+        "doi": "31963668",
+        "name": "The Bullet Cluster Under EFC: Confronting Entropy-Gradient Gravity with JWST-Era Mass Reconstructions",
+        "category": "structural"
+      },
+      {
+        "doi": "31964847",
+        "name": "EFC vs ΛCDM: Complete Kill-Test — From Rotation Curves to Planck: A Consistent Low-Dimensional Alternative",
+        "category": "structural"
+      },
+      {
+        "doi": "31969983",
+        "name": "Closing the EFC Consciousness Bridge: Dimensionless, Scale-Invariant Unification of Entropy, Dynamics, and Awareness",
+        "category": "structural"
+      },
+      {
+        "doi": "31985313",
+        "name": "Scale-Localised Modified Gravity from the EFC Action: A Single-Parameter Forecast via EG(k, z)",
+        "category": "structural"
+      },
+      {
+        "doi": "31990053",
+        "name": "EFC Euclid DR1 Boltzmann Pre-Registration",
+        "category": "structural"
+      },
+      {
+        "doi": "31990212",
+        "name": "ISW Void Sign-Flip Observational Pipeline: From EFC Theory to Data Confrontation",
+        "category": "structural"
+      },
+      {
+        "doi": "32010399",
+        "name": "Pre-Registered Predictions for the Entropy Flow Cosmology (EFC) Model",
+        "category": "structural"
+      },
+      {
+        "doi": "32011407",
+        "name": "Effective Horndeski Reduction of the EFC Perturbation Sector",
+        "category": "structural"
+      },
+      {
+        "doi": "32013738",
+        "name": "Pre-Registered Predictions for the Energy-Flow Cosmology Model Against the Rubin Observatory LSST DP2 Cosmic Shear Datas",
+        "category": "structural"
+      },
+      {
+        "doi": "32023788",
+        "name": "Pre-Registered EFC Prediction: EG Statistic from SO × Euclid Cross-Correlation",
+        "category": "structural"
+      },
+      {
+        "doi": "32045592",
+        "name": "Expected Outcomes for Energy-Flow Cosmology Cross-Survey Invariance and BIG-SPARC Tests",
         "category": "structural"
       }
     ]

--- a/figshare/doi-map.json
+++ b/figshare/doi-map.json
@@ -484,12 +484,6 @@
     "path": "docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
     "url": "https://doi.org/10.6084/m9.figshare.31144030"
   },
-  "10.6084/m9.figshare.31140000": {
-    "figshare_id": 31140000,
-    "title": "",
-    "path": "docs/papers/efc/Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset",
-    "url": "https://doi.org/10.6084/m9.figshare.31140000"
-  },
   "10.6084/m9.figshare.31135597": {
     "figshare_id": 31135597,
     "title": "Foundations of EFC: Regime Architecture",
@@ -612,8 +606,8 @@
   },
   "10.6084/m9.figshare.30563738": {
     "figshare_id": 30563738,
-    "title": "EFC v1.2 Foundational Framework",
-    "path": "docs/papers/efc/Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes",
+    "title": "Energy-Flow Cosmology v1.2: Foundational Framework and Cross-Field Continuity",
+    "path": "docs/papers/efc/EFC-v1.2-Foundational-Framework",
     "url": "https://doi.org/10.6084/m9.figshare.30563738"
   },
   "10.6084/m9.figshare.30530156": {
@@ -933,5 +927,11 @@
     "title": "EFC-C v2.1: Degree-Heterogeneity Entropy-Gradient Predictions for Cognitive States",
     "path": "docs/papers/efc/EFC-C_Cognitive_Entropy_Gradients_v2",
     "url": "https://doi.org/10.6084/m9.figshare.32091700"
+  },
+  "10.6084/m9.figshare.30656351": {
+    "figshare_id": 30656351,
+    "title": "Symbiotic Insight Framework (SIF): A Human-System Methodology for High-Scale Scientific Reasoning",
+    "path": "docs/papers/efc/symbiotic-insight-framework",
+    "url": "https://doi.org/10.6084/m9.figshare.30656351"
   }
 }


### PR DESCRIPTION
## Summary

Cross-checked the repo against the official figshare DOI list (**156 entries**) and applied four mechanical fixes. `efc_verify.py` still reports 0 errors after each step.

### A. DOI typo: `31140000` → `31144030`

Directory `Regime_Dependent_Growth_Enhancement___A_Transition_Metric...` had DOI `31140000` registered, which **does not exist on figshare**. The correct DOI for the Fugaku-DESI paper is `31144030`. Updated 9 files in the directory + `figshare/doi-map.json`.

### B. Cross-mapped DOIs (duplicates)

Two pairs of directories had the same DOI registered:

| Wrong DOI | Wrongly assigned to | → Correct DOI for that title |
|---|---|---|
| `30563738` | `Energy_Flow_Cosmology__An_Effective_Phenomenological_Law...` | `31222696` |
| `31368433` | `Minimal_EFC_Effective_Field_Theory_Ansatz...` | `31562200` |

The other directory in each pair (`EFC-v1.2-Foundational-Framework` for `30563738`, `Systematic_Localization_of_Late-Time_Cosmological_Signals` for `31368433`) was correct and remains unchanged. `figshare/doi-map.json` updated.

### C. Missing DOI: `30656351` → `symbiotic-insight-framework/`

Directory existed but `index.json` had `"doi": ""`. Added DOI for the Symbiotic Insight Framework (SIF) paper.

### D. `evidence-register.json` bulk-populated (+66 entries)

The register had only 86 of 152 paper DOIs. Auto-categorized 66 missing DOIs from `index.json` files into one of three categories based on title and keyword heuristics:

| Category | Before | After | Δ |
|---|---|---|---|
| empirical | 81 | 109 | +28 |
| methodological | 3 | 10 | +7 |
| structural | 2 | 33 | +31 |
| **TOTAL** | **86** | **152** | **+66** |

Categorization is heuristic; manual review encouraged for edge cases (some "structural" theory papers might be re-categorized as methodological, etc.). The categorization function is in the commit history if you want to tune it.

## Still missing

5 papers from the official list are NOT in the repo as directories:

- `28098317` — Can EnergyFlow Be Observed in Galactic Clusters?
- `28102772` — Hypothesis_Entropy_Energyflow
- `31970898` — White Paper Part 2 of 4
- `31970904` — White Paper Part 3 of 4
- `31970907` — White Paper Part 4 of 4

The 4 White Papers parts are bundled in `efc_white_paper_part_1_to_4/` (DOI of part 1). Recommended: split into 4 directories or add multi-DOI registration. The two `28098*` papers are early dissertations — investigate whether they exist under different paths.

## Verification
- ✅ `efc_verify.py`: 154 paper dirs · 0 errors · 1 unrelated warning
- ✅ All updated `index.json` and `evidence-register.json` parse as valid JSON
- ✅ `figshare/doi-map.json` now has 155 entries (was 154 with one stale)

## Test plan
- [x] Verify still passes
- [x] All JSON files parse
- [ ] CI green
- [ ] Reviewer confirms categorization heuristic is acceptable

https://claude.ai/code/session_01AbnfiyZgXZ4ebUe6t8aai2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbnfiyZgXZ4ebUe6t8aai2)_