### PR TITLE
fix(dois): close last 5 ledger gaps — full coverage of official figshare DOI list

### DIFF
--- a/.claude/dataset_scan_report.json
+++ b/.claude/dataset_scan_report.json
@@ -1,28 +1,28 @@
 {
   "date": "2026-04-25",
   "known": [
-    "DESI DR2",
-    "Euclid DR3",
-    "DES Y6",
     "DESI DR3",
-    "KiDS Legacy",
     "Euclid DR1",
+    "DES Y6",
+    "KiDS Legacy",
+    "DESI DR2",
+    "Simons Observatory",
     "DESI DR1",
-    "Euclid DR2",
-    "Simons Observatory"
+    "Euclid DR3",
+    "Euclid DR2"
   ],
   "findings": [
     {
       "source": "DESI",
       "term": "data release",
       "url": "https://data.desi.lbl.gov/doc/releases/",
-      "timestamp": "2026-04-25T10:25:36.728553"
+      "timestamp": "2026-04-25T17:15:55.297317"
     },
     {
       "source": "KiDS",
       "term": "DR5",
       "url": "https://kids.strw.leidenuniv.nl/DR5/",
-      "timestamp": "2026-04-25T10:25:37.416148"
+      "timestamp": "2026-04-25T17:15:55.977873"
     }
   ]
 }

--- a/docs/validation-ledger/data/evidence-register.json
+++ b/docs/validation-ledger/data/evidence-register.json
@@ -1,57 +1,62 @@
 {
   "name": "Evidence Register",
   "version": "3.0",
-  "generated_at": "2026-04-25T09:59:15.635668Z",
+  "generated_at": "2026-04-25T16:57:05.374175Z",
   "categories": {
     "empirical": [
       {
         "doi": "28098299",
-        "name": "EFC \u2014 Observational Evidence for Entropy in Cosmic Evolution",
+        "name": "EFC — Observational Evidence for Entropy in Cosmic Evolution",
         "category": "empirical"
       },
       {
         "doi": "28098305",
-        "name": "EFC \u2013 Why Is Light Speed a Cosmic Limit?",
+        "name": "EFC – Why Is Light Speed a Cosmic Limit?",
         "category": "structural"
       },
       {
         "doi": "28098308",
-        "name": "EFC \u2013 Applications and Implications",
+        "name": "EFC – Applications and Implications",
         "category": "structural"
       },
       {
         "doi": "28098311",
-        "name": "EFC \u2014 What is the Connection Between Energy Flow and the Now?",
+        "name": "EFC — What is the Connection Between Energy Flow and the Now?",
         "category": "structural"
       },
       {
         "doi": "28098314",
-        "name": "EFC \u2014 Mathematical Framework for Energy Flow in Space-Time",
+        "name": "EFC — Mathematical Framework for Energy Flow in Space-Time",
         "category": "structural"
       },
       {
+        "doi": "28098317",
+        "name": "EFC — Can EnergyFlow Be Observed in Galactic Clusters?",
+        "category": "empirical"
+      },
+      {
         "doi": "28098320",
-        "name": "EFC \u2014 Introduction to Entropy in Cosmic Evolution",
+        "name": "EFC — Introduction to Entropy in Cosmic Evolution",
         "category": "structural"
       },
       {
         "doi": "28098326",
-        "name": "EFC \u2014 Unresolved Questions and Challenges: Entropy",
+        "name": "EFC — Unresolved Questions and Challenges: Entropy",
         "category": "structural"
       },
       {
         "doi": "28098332",
-        "name": "EFC \u2014 Technical Documentation: Energy Flow in Space-Time",
+        "name": "EFC — Technical Documentation: Energy Flow in Space-Time",
         "category": "structural"
       },
       {
         "doi": "28098338",
-        "name": "EFC \u2014 How Does Balance Shape Universal Structures?",
+        "name": "EFC — How Does Balance Shape Universal Structures?",
         "category": "structural"
       },
       {
         "doi": "28098341",
-        "name": "EFC \u2014 Introduction to Energy Flow in Space-Time",
+        "name": "EFC — Introduction to Energy Flow in Space-Time",
         "category": "structural"
       },
       {
@@ -61,67 +66,67 @@
       },
       {
         "doi": "28098347",
-        "name": "EFC \u2014 Is Consciousness Linked to Entropy?",
+        "name": "EFC — Is Consciousness Linked to Entropy?",
         "category": "structural"
       },
       {
         "doi": "28098350",
-        "name": "EFC \u2014 Can Energy Flow Be Observed in Galactic Clusters?",
+        "name": "EFC — Can Energy Flow Be Observed in Galactic Clusters?",
         "category": "structural"
       },
       {
         "doi": "28098353",
-        "name": "EFC \u2014 Can Entropy Drive Cosmic Evolution?",
+        "name": "EFC — Can Entropy Drive Cosmic Evolution?",
         "category": "structural"
       },
       {
         "doi": "28098365",
-        "name": "EFC \u2014 Observational Evidence for Energy Flow",
+        "name": "EFC — Observational Evidence for Energy Flow",
         "category": "empirical"
       },
       {
         "doi": "28098371",
-        "name": "EFC \u2014 How Energy Flow Sustains Spacetime",
+        "name": "EFC — How Energy Flow Sustains Spacetime",
         "category": "structural"
       },
       {
         "doi": "28098380",
-        "name": "EFC \u2014 What Happens at the Universe\u2019s Extremes?",
+        "name": "EFC — What Happens at the Universe’s Extremes?",
         "category": "structural"
       },
       {
         "doi": "28098386",
-        "name": "Hypothesis: The Universe as an Energy-Driven System \u2013 Integrating Time, Space, C",
+        "name": "Hypothesis: The Universe as an Energy-Driven System – Integrating Time, Space, C",
         "category": "structural"
       },
       {
         "doi": "28111925",
-        "name": "EFC \u2014 Light Speed as a Regulator of Energy Flow in the Universe",
+        "name": "EFC — Light Speed as a Regulator of Energy Flow in the Universe",
         "category": "structural"
       },
       {
         "doi": "28112036",
-        "name": "EFC \u2014 Subhypothesis: Light Speed Limit",
+        "name": "EFC — Subhypothesis: Light Speed Limit",
         "category": "structural"
       },
       {
         "doi": "28112096",
-        "name": "EFC \u2014 Flow, Entropy, and Spacetime Distortion in Cosmological Clusters",
+        "name": "EFC — Flow, Entropy, and Spacetime Distortion in Cosmological Clusters",
         "category": "empirical"
       },
       {
         "doi": "28113542",
-        "name": "EFC \u2014 Energy Flow as the Fundamental Dynamic of the Universe",
+        "name": "EFC — Energy Flow as the Fundamental Dynamic of the Universe",
         "category": "structural"
       },
       {
         "doi": "28114370",
-        "name": "EFC \u2014 A Deep Dive into the Halo Concept",
+        "name": "EFC — A Deep Dive into the Halo Concept",
         "category": "structural"
       },
       {
         "doi": "28557281",
-        "name": "EFC \u2014 Hypothesis: Interrelation Between Energy and Entropy",
+        "name": "EFC — Hypothesis: Interrelation Between Energy and Entropy",
         "category": "structural"
       },
       {
@@ -131,7 +136,7 @@
       },
       {
         "doi": "28559510",
-        "name": "EFC \u2014 Grid-Higgs Framework",
+        "name": "EFC — Grid-Higgs Framework",
         "category": "structural"
       },
       {
@@ -146,7 +151,7 @@
       },
       {
         "doi": "28578263",
-        "name": "EFC \u2014 Integrated Hypothesis: Time and Entropy",
+        "name": "EFC — Integrated Hypothesis: Time and Entropy",
         "category": "structural"
       },
       {
@@ -171,37 +176,42 @@
       },
       {
         "doi": "30468737",
-        "name": "The Energy\u2013Flow Interface: A Unified Thermodynamic Interpretation of Dark Matter",
+        "name": "The Energy–Flow Interface: A Unified Thermodynamic Interpretation of Dark Matter",
         "category": "structural"
       },
       {
         "doi": "30478916",
-        "name": "EFC v2.1 \u2013 Complete Edition",
+        "name": "EFC v2.1 – Complete Edition",
         "category": "structural"
       },
       {
         "doi": "30530156",
-        "name": "EFC \u2014 v2.2 Cross-Field Integration Summary",
+        "name": "EFC — v2.2 Cross-Field Integration Summary",
         "category": "structural"
       },
       {
         "doi": "30563738",
-        "name": "Energy\u2013Flow Cosmology v1.2: Foundational Framework and Cross-Field Continuity",
+        "name": "Energy–Flow Cosmology v1.2: Foundational Framework and Cross-Field Continuity",
         "category": "structural"
       },
       {
         "doi": "30630500",
-        "name": "EFC \u2014 Formal Specification",
+        "name": "EFC — Formal Specification",
         "category": "structural"
       },
       {
         "doi": "30636863",
-        "name": "EFC \u2014 AI-Augmented Scientific Workflow Framework",
+        "name": "EFC — AI-Augmented Scientific Workflow Framework",
         "category": "structural"
       },
       {
         "doi": "30642497",
         "name": "Variable Effective Light Speed in Entropic Transition States: A Formal Treatment",
+        "category": "structural"
+      },
+      {
+        "doi": "30656351",
+        "name": "Symbiotic Insight Framework (SIF): A Structural Methodology for High-Velocity Sc",
         "category": "structural"
       },
       {
@@ -211,7 +221,7 @@
       },
       {
         "doi": "30773684",
-        "name": "Symbiosis: A Human\u2013AI Co-Reflection Architecture Using Graph\u2013Vector Memory for L",
+        "name": "Symbiosis: A Human–AI Co-Reflection Architecture Using Graph–Vector Memory for L",
         "category": "structural"
       },
       {
@@ -251,7 +261,7 @@
       },
       {
         "doi": "31064929",
-        "name": "CMB \u2014 Thermodynamic Interpretation",
+        "name": "CMB — Thermodynamic Interpretation",
         "category": "empirical"
       },
       {
@@ -266,7 +276,7 @@
       },
       {
         "doi": "31112536",
-        "name": "L0\u2013L3 Regime Architecture in Entropy-Bounded Empiricism",
+        "name": "L0–L3 Regime Architecture in Entropy-Bounded Empiricism",
         "category": "structural"
       },
       {
@@ -341,7 +351,7 @@
       },
       {
         "doi": "31231522",
-        "name": "EFC BAO Predictions: DESI DR2 \u2192 BOSS DR12 Transfer",
+        "name": "EFC BAO Predictions: DESI DR2 → BOSS DR12 Transfer",
         "category": "empirical"
       },
       {
@@ -361,7 +371,7 @@
       },
       {
         "doi": "31271917",
-        "name": "Regime-Activated Lensing Response \u2014 KiDS-1000 Cosmic Shear",
+        "name": "Regime-Activated Lensing Response — KiDS-1000 Cosmic Shear",
         "category": "empirical"
       },
       {
@@ -425,6 +435,11 @@
         "category": "empirical"
       },
       {
+        "doi": "31562200",
+        "name": "Minimal EFC Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formu",
+        "category": "structural"
+      },
+      {
         "doi": "31564123",
         "name": "Regime-Bound Measurement in Complex Systems: Proxy, Placement, and Validity",
         "category": "structural"
@@ -441,7 +456,7 @@
       },
       {
         "doi": "31864993",
-        "name": "Natural and Mechanical Entropy: Intention Detection via Episenter\u2013Resonance Anal",
+        "name": "Natural and Mechanical Entropy: Intention Detection via Episenter–Resonance Anal",
         "category": "structural"
       },
       {
@@ -461,7 +476,7 @@
       },
       {
         "doi": "31940604",
-        "name": "Homo Fluxus v2.0 \u2014 A Civilization Map Through Energy-Flow Cosmology: From Grid to Governance \u2014 One Gradient, All Regimes",
+        "name": "Homo Fluxus v2.0 — A Civilization Map Through Energy-Flow Cosmology: From Grid to Governance — One Gradient, All Regimes",
         "category": "empirical"
       },
       {
@@ -486,7 +501,7 @@
       },
       {
         "doi": "31955871",
-        "name": "Multi-epoch Growth Rate Test of EFC Perturbation-Sector Coupling: f \u03c38(z) from BOSS DR12, eBOSS DR16, and DESI DR1",
+        "name": "Multi-epoch Growth Rate Test of EFC Perturbation-Sector Coupling: f σ8(z) from BOSS DR12, eBOSS DR16, and DESI DR1",
         "category": "empirical"
       },
       {
@@ -496,17 +511,17 @@
       },
       {
         "doi": "31986762",
-        "name": "Kill-Test v6 Universality \u2014 Extension of the EFC vs \u039bCDM Kill-Test to the Full SPARC 175 Sample",
+        "name": "Kill-Test v6 Universality — Extension of the EFC vs ΛCDM Kill-Test to the Full SPARC 175 Sample",
         "category": "empirical"
       },
       {
         "doi": "31990194",
-        "name": "Consistent Modified Gravity Weak Lensing in Energy-Flow Cosmology: The \u00b5\u2013\u03a3 Eigenmode, Destructive Interference, and E_G ",
+        "name": "Consistent Modified Gravity Weak Lensing in Energy-Flow Cosmology: The µ–Σ Eigenmode, Destructive Interference, and E_G ",
         "category": "empirical"
       },
       {
         "doi": "32013156",
-        "name": "Sealed Blind Predictions for Growth-Rate Observables: Energy-Flow Cosmology vs \u039bCDM",
+        "name": "Sealed Blind Predictions for Growth-Rate Observables: Energy-Flow Cosmology vs ΛCDM",
         "category": "empirical"
       },
       {
@@ -536,7 +551,7 @@
       },
       {
         "doi": "32080083",
-        "name": "EFC-\u039bCDM Comparative Test Specification v1.1",
+        "name": "EFC-ΛCDM Comparative Test Specification v1.1",
         "category": "structural"
       },
       {
@@ -547,16 +562,6 @@
       {
         "doi": "32091700",
         "name": "EFC-C v2.1: Degree-Heterogeneity Entropy-Gradient Predictions for Cognitive Stat",
-        "category": "structural"
-      },
-      {
-        "doi": "31562200",
-        "name": "Minimal EFC Effective Field Theory Ansatz: Scalar-Tensor and Vector-Tensor Formu",
-        "category": "structural"
-      },
-      {
-        "doi": "30656351",
-        "name": "Symbiotic Insight Framework (SIF): A Structural Methodology for High-Velocity Sc",
         "category": "structural"
       }
     ],
@@ -607,12 +612,22 @@
         "category": "methodological"
       },
       {
+        "doi": "31970904",
+        "name": "EFC White Paper Part 3: Data, Validation Ledger, and Falsification Protocol",
+        "category": "methodological"
+      },
+      {
         "doi": "31985163",
         "name": "EFC Background No-Go Theorem: Why Background-Level Modification Cannot Suppress Structure Growth",
         "category": "methodological"
       }
     ],
     "structural": [
+      {
+        "doi": "28102772",
+        "name": "Hypothesis: Entropy and Energy Flow",
+        "category": "structural"
+      },
       {
         "doi": "31045126",
         "name": "Regime-Dependent Validity in Galaxy Rotation Curve Modeling: Comprehensive Analysis of 175 SPARC Galaxies",
@@ -650,17 +665,17 @@
       },
       {
         "doi": "31333600",
-        "name": "Perturbation-Level \u03c38 Suppression via \u03bc(a) < 1: Structural Limits of Scale-Free Modifications",
+        "name": "Perturbation-Level σ8 Suppression via μ(a) < 1: Structural Limits of Scale-Free Modifications",
         "category": "structural"
       },
       {
         "doi": "31348411",
-        "name": "Discrete Entropic Gravity on a Cubic Graph: Emergent Newtonian and MOND Regimes with \u039b-Locked Screening",
+        "name": "Discrete Entropic Gravity on a Cubic Graph: Emergent Newtonian and MOND Regimes with Λ-Locked Screening",
         "category": "structural"
       },
       {
         "doi": "31348414",
-        "name": "Cosmological Growth Constraints on \u039b-Locked Discrete Entropic Gravity",
+        "name": "Cosmological Growth Constraints on Λ-Locked Discrete Entropic Gravity",
         "category": "structural"
       },
       {
@@ -670,7 +685,7 @@
       },
       {
         "doi": "31876324",
-        "name": "EFC Relativistic Action: Field Equations, Perturbation Theory, and Extraction of \u00b5, \u03a3, \u03b7",
+        "name": "EFC Relativistic Action: Field Equations, Perturbation Theory, and Extraction of µ, Σ, η",
         "category": "structural"
       },
       {
@@ -710,17 +725,17 @@
       },
       {
         "doi": "31942800",
-        "name": "Density of States of Gravitationally Active Grid Modes: Derivation of Deff (\u03c1) and Completion of the \u0393(\u03c1) Bridge",
+        "name": "Density of States of Gravitationally Active Grid Modes: Derivation of Deff (ρ) and Completion of the Γ(ρ) Bridge",
         "category": "structural"
       },
       {
         "doi": "31942821",
-        "name": "Derivation of the Entropy Production Function \u0393(\u03c1) from Grid-Mode Bose\u2013Einstein Statistics",
+        "name": "Derivation of the Entropy Production Function Γ(ρ) from Grid-Mode Bose–Einstein Statistics",
         "category": "structural"
       },
       {
         "doi": "31943361",
-        "name": "\u039bCDM as a Special Case of Energy-Flow Cosmology: Regime Structure, Empirical Confrontation, and the Limits of Background",
+        "name": "ΛCDM as a Special Case of Energy-Flow Cosmology: Regime Structure, Empirical Confrontation, and the Limits of Background",
         "category": "structural"
       },
       {
@@ -730,12 +745,22 @@
       },
       {
         "doi": "31964847",
-        "name": "EFC vs \u039bCDM: Complete Kill-Test \u2014 From Rotation Curves to Planck: A Consistent Low-Dimensional Alternative",
+        "name": "EFC vs ΛCDM: Complete Kill-Test — From Rotation Curves to Planck: A Consistent Low-Dimensional Alternative",
         "category": "structural"
       },
       {
         "doi": "31969983",
         "name": "Closing the EFC Consciousness Bridge: Dimensionless, Scale-Invariant Unification of Entropy, Dynamics, and Awareness",
+        "category": "structural"
+      },
+      {
+        "doi": "31970898",
+        "name": "EFC White Paper Part 2: Field Equations and Observable Mapping",
+        "category": "structural"
+      },
+      {
+        "doi": "31970907",
+        "name": "EFC White Paper Part 4: Regime Susceptibility and Cross-Scale Mapping",
         "category": "structural"
       },
       {
@@ -770,7 +795,7 @@
       },
       {
         "doi": "32023788",
-        "name": "Pre-Registered EFC Prediction: EG Statistic from SO \u00d7 Euclid Cross-Correlation",
+        "name": "Pre-Registered EFC Prediction: EG Statistic from SO × Euclid Cross-Correlation",
         "category": "structural"
       },
       {

--- a/figshare/doi-map.json
+++ b/figshare/doi-map.json
@@ -933,5 +933,11 @@
     "title": "Symbiotic Insight Framework (SIF): A Human-System Methodology for High-Scale Scientific Reasoning",
     "path": "docs/papers/efc/symbiotic-insight-framework",
     "url": "https://doi.org/10.6084/m9.figshare.30656351"
+  },
+  "10.6084/m9.figshare.28102772": {
+    "figshare_id": 28102772,
+    "title": "Hypothesis: Entropy and Energy Flow",
+    "path": null,
+    "url": "https://doi.org/10.6084/m9.figshare.28102772"
   }
 }

--- a/maintain.log
+++ b/maintain.log
@@ -50,7 +50,6 @@ pdftotext: /usr/bin/pdftotext
     [WARN] OpenAI empty (finish_reason=length) attempt 3/4
     [WARN] OpenAI empty (finish_reason=length) attempt 4/4
     [INFO] openai exhausted — trying fallback provider
-    Added 2 DOI(s) to evidence register
 
 ============================================================
 EFC AI BRAIN — done
@@ -62,15 +61,6 @@ EFC DOI sync — 154 paper dirs scanned
   papers with registered DOI : 153
   papers without DOI         : 1
   papers with conflicts      : 0
-
-PROPAGATED DOIs into 1 papers:
-  symbiotic-insight-framework -> index.json, metadata.json, CITATION.cff, *.jsonld, README.md
-
-SYNCED efc_index.json (4 entries):
-  Energy_Flow_Cosmology__An_Effective_Phenomenological_Law_for_Gravitational_Response_in_Structure_Dominated_Regimes
-  Minimal_EFC_Effective_Field_Theory_Ansatz_Scalar_Tensor_and_Vector_Tensor_Formulations_with_Gravitational_Slip_from_Entropy_Gradients
-  Regime_Dependent_Growth_Enhancement___A_Transition_Metric_Interpretation_of_the_Fugaku_DESI_Matter_Density_Offset
-  symbiotic-insight-framework
 ========================================================================
 [efc-gen] 154 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
 [efc-verify] 154 paper dirs · 0 errors · 1 warnings
@@ -125,9 +115,7 @@ Scanning 4 sources...
 
 Report saved to /home/runner/work/EFC/EFC/.claude/dataset_scan_report.json
 [efc-auto-changelog] checking for changes...
-[efc-auto-changelog] 2 paper packages enriched; Ledger data: evidence-register.json.
-[efc-auto-changelog] updated EFC_Changelog.html
-[efc-auto-changelog] updated changelog.json
+[efc-auto-changelog] only script/workflow changes — skipping changelog
 ============================================================
 EFC CROSS-VALIDATION GATE (with Symbiose Council)
 ============================================================


### PR DESCRIPTION
## Summary

Closes the last 5 DOI gaps after PR #224. After this, every DOI from the official figshare list (156 entries) is reflected in both `doi-map.json` and `evidence-register.json`.

| DOI | Title | Added to |
|---|---|---|
| 28098317 | Can EnergyFlow Be Observed in Galactic Clusters? | evidence-register (empirical) |
| 28102772 | Hypothesis: Entropy and Energy Flow | doi-map + evidence-register (structural) |
| 31970898 | White Paper Part 2: Field Equations and Observable Mapping | evidence-register (structural) |
| 31970904 | White Paper Part 3: Data, Validation Ledger, and Falsification Protocol | evidence-register (methodological) |
| 31970907 | White Paper Part 4: Regime Susceptibility and Cross-Scale Mapping | evidence-register (structural) |

### Counts
- `doi-map.json`: 155 → **156** entries
- `evidence-register.json`: 154 → **159** entries

### Caveat
These papers exist on figshare but **do not yet have dedicated top-level paper directories** in this repo. The 4 White Paper parts are bundled under `efc_white_paper_part_1_to_4/` as subdirectories with the actual PDFs. The two `28098*/28102*` early dissertations are not yet imported as full AI-friendly paper packages.

This PR closes the **ledger** gap. Importing the missing papers as full directories is a separate task (would require pulling the PDFs from figshare and running the AI-friendly generator).

## Verification
- ✅ `efc_verify.py`: 154 paper dirs · 0 errors · 1 unrelated warning
- ✅ `evidence-register.json` parses as valid JSON
- ✅ `doi-map.json` parses as valid JSON

https://claude.ai/code/session_01AbnfiyZgXZ4ebUe6t8aai2

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbnfiyZgXZ4ebUe6t8aai2)_