### PR TITLE
chore: drop Non-MCMC α-Parameter from unprocessed queue

### DIFF
--- a/.claude/unprocessed_papers.json
+++ b/.claude/unprocessed_papers.json
@@ -528,17 +528,6 @@
     "track": "unknown"
   },
   {
-    "directory": "Non-MCMC_Constraints_on_the_EFC_\u03b1-Parameter",
-    "doi": "32101213",
-    "title": "Non-MCMC Constraints on the EFC \u03b1-Parameter: BAO, Growth-Rate, and Cluster Evidence",
-    "missing_from": [
-      "Ledger",
-      "Changelog"
-    ],
-    "has_key_results": true,
-    "track": "unknown"
-  },
-  {
     "directory": "Persistent_Cognitive_Architectures_for_Human-AI_Co-Reasoning_Beyond_Retrieval_to_Structural_Intelligence",
     "doi": "31271707",
     "title": "Persistent Cognitive Architectures for Human-AI Co-Reasoning: Beyond Retrieval to Structural Intelligence",


### PR DESCRIPTION
## Summary

Maintenance-pass på session-start fjernet entry for "Non-MCMC_Constraints_on_the_EFC_α-Parameter" fra `.claude/unprocessed_papers.json` siden paperet nå er sporet i Ledger og Changelog (løst i upstream `c4b0d0e fix(ci): generate metadata + drift fixes for Non-MCMC α-Parameter paper`).

## Test plan

- [ ] `efc-maintain` bekrefter at unprocessed-køen er konsistent med Ledger/Changelog på neste pass
- [ ] Ingen nye drift-warnings i `efc_verify.py`

https://claude.ai/code/session_01ANfaN1ezQHKUFhqmrnRKTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANfaN1ezQHKUFhqmrnRKTW)_