### PR TITLE
fix(workflows): stop verify/main-sync race on push to main

### DIFF
--- a/.github/workflows/efc-verify.yml
+++ b/.github/workflows/efc-verify.yml
@@ -1,12 +1,17 @@
 name: EFC repo verify
 
 # Strict read-only verification that the EFC archive is self-consistent.
-# Runs on PRs and on push-to-main. Does NOT auto-commit corrections —
-# that's the job of .github/workflows/efc-sync.yml which runs on
-# development branches only. If this workflow fails on a PR, the PR
-# author should run `python3 scripts/maintenance/efc_maintain.py`
-# locally, commit the result, and push — the sync workflow will keep
-# them honest from that point on.
+# Runs on PRs only. Push-to-main is deliberately NOT a trigger here:
+# efc-main-sync.yml already runs the full maintenance pass (which
+# includes efc_verify.py) on every push to main and auto-commits any
+# corrections, so a parallel verify run on the same SHA would race
+# against the auto-fix and produce false failures whenever bare PDFs
+# are uploaded directly to main. Keep verify as the PR gate.
+#
+# If this workflow fails on a PR, the PR author should run
+# `python3 scripts/maintenance/efc_maintain.py` locally, commit the
+# result, and push -- the sync workflow will keep them honest from that
+# point on.
 
 on:
   pull_request:
@@ -19,17 +24,6 @@ on:
       - "scripts/maintenance/**"
       - "README.md"
       - ".github/workflows/efc-verify.yml"
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/papers/efc/**"
-      - "docs/validation-ledger/**"
-      - "docs/public/EFC_Validation_Ledger.html"
-      - "docs/public/EFC_Changelog.html"
-      - "docs/public/EFC_White_Paper_Series.html"
-      - "scripts/maintenance/**"
-      - "README.md"
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary

`EFC repo verify` (`efc-verify.yml`) and `EFC main auto-sync` (`efc-main-sync.yml`) both triggered on `push` to `main` with overlapping path filters (`docs/papers/efc/**`). They ran in parallel on the same SHA, which produced a race whenever bare PDFs were uploaded to `main` (e.g. via *Add files via upload*):

1. `efc-main-sync` saw bare PDFs, ran the full maintenance pipeline, generated `index.json` / `metadata.json` / `CITATION.cff` / `LICENSE` / `citations.bib` / `schema.json` / `*.jsonld` / `ai_manifest.json`, and auto-committed the result.
2. `efc-verify` ran concurrently on the same pre-fix snapshot, called `efc_gen_ai_friendly.py`, saw the freshly created metadata files in `git diff`, and failed at the **Fail on uncommitted changes** step.

Result: every direct upload to `main` produced a red `EFC repo verify` run, even though `main` was being self-healed in parallel.

## Fix

Drop the `push: branches: [main]` trigger from `efc-verify.yml`. The standalone verify run on `main` was redundant — `efc-main-sync` already invokes `efc_verify.py` as part of its pipeline:

```
efc_auto_metadata → efc_gen_ai_friendly → efc_sync_dois →
  efc_verify → efc_drift_detector --fix
```

`efc-verify` keeps its `pull_request` trigger so PR-time verification (the read-only gate) is unchanged.

## Test plan

- [ ] Push a bare PDF to a paper directory on `main` — only `EFC main auto-sync` should run; no `EFC repo verify` race-failure.
- [ ] Open a PR touching `docs/papers/efc/**` — `EFC repo verify` runs on the PR as before.
- [ ] Confirm `efc-main-sync`'s pipeline still surfaces verifier errors (it calls `efc_verify.py` internally and fails the job on non-zero rc).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5rhYEMjihawDyY9nDR6Ny)_