### PR TITLE
fix(workflows): expand efc-main-sync paths to cover full pipeline scope

### DIFF
--- a/.github/workflows/efc-main-sync.yml
+++ b/.github/workflows/efc-main-sync.yml
@@ -1,17 +1,27 @@
 name: EFC main auto-sync
 
-# Auto-fix maintenance issues on main when papers are uploaded directly.
-# Generates missing metadata (index.json, CITATION.cff, etc.) from bare
-# PDFs, fixes paper count drift, and propagates DOIs.
+# Auto-fix maintenance issues on main when papers are uploaded directly
+# or when any maintenance input changes. Generates missing metadata
+# (index.json, CITATION.cff, etc.) from bare PDFs, fixes paper count
+# drift between data files and public HTML, and propagates DOIs.
 #
 # This is the "everything automatic" workflow — covers the gap where
-# efc-sync.yml only runs on dev branches.
+# efc-sync.yml only runs on dev branches. The path filter is kept in
+# sync with efc-verify.yml so that every input the maintenance pipeline
+# reconciles triggers a sync on main.
 
 on:
   push:
     branches: [main]
     paths:
       - "docs/papers/efc/**"
+      - "docs/validation-ledger/**"
+      - "docs/public/EFC_Validation_Ledger.html"
+      - "docs/public/EFC_Changelog.html"
+      - "docs/public/EFC_White_Paper_Series.html"
+      - "scripts/maintenance/**"
+      - "README.md"
+      - ".github/workflows/efc-main-sync.yml"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

`efc-main-sync.yml` triggered only on `docs/papers/efc/**`, but its maintenance pipeline reconciles much more than papers:

```
efc_auto_metadata → efc_gen_ai_friendly → efc_sync_dois →
  efc_verify → efc_drift_detector --fix
```

The pipeline also touches:

- `docs/validation-ledger/**` (data files: ledger.json, atlas.json, evidence-register.json, changelog.json, ...)
- `docs/public/EFC_*.html` (public pages regenerated from the data)
- `scripts/maintenance/**` (the scripts themselves)
- `README.md` (paper count, etc.)

When the validation ledger or public pages were updated directly on `main` — e.g. the recurring "Auto-update validation ledger v3.0 — N tests, ..." commits from Symbiose AGI in the recent main history — no auto-sync ran, so drift between the data files and the public HTML accumulated silently until the next paper upload happened to retrigger the pipeline.

## Fix

Expand the `push` paths filter to match `efc-verify.yml`'s set, plus the workflow file itself:

```yaml
- "docs/papers/efc/**"
- "docs/validation-ledger/**"
- "docs/public/EFC_Validation_Ledger.html"
- "docs/public/EFC_Changelog.html"
- "docs/public/EFC_White_Paper_Series.html"
- "scripts/maintenance/**"
- "README.md"
- ".github/workflows/efc-main-sync.yml"
```

Now any push to `main` that touches a maintenance input runs the pipeline and self-heals.

## Test plan

- [ ] Push a `docs/validation-ledger/data/*.json` change directly to `main` — `EFC main auto-sync` runs (previously: nothing ran).
- [ ] Push a `docs/papers/efc/**` change — still runs (regression check).
- [ ] Push a change unrelated to maintenance (e.g. unrelated docs) — does not run.
- [ ] `concurrency: efc-main-sync` still serializes runs on main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5rhYEMjihawDyY9nDR6Ny)_