### PR TITLE
chore(efc-sync): metadata for jwst_hmf_prereg_v4 + drift sync

### DIFF
--- a/.claude/drift_report.json
+++ b/.claude/drift_report.json
@@ -1,45 +1,299 @@
 {
-  "paper_count": 158,
+  "paper_count": 159,
   "drift": [
+    {
+      "file": "README.md",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "full side-by-side.\n\nAcross **133 independent tests** so far (galaxy rotation cur"
+    },
+    {
+      "file": "README.md",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "v3.17 / v4.8 internal) tracks 133 public tests. Overall stage: **Non-rejecta"
+    },
     {
       "file": "Validation_Ledger",
       "type": "tests_total",
-      "claimed": 118,
-      "actual": 132,
-      "context": "below and the 118-test ledger further",
+      "claimed": 133,
+      "actual": 135,
+      "context": "below and the 133-test ledger further",
       "match_form": "(\\d{2,3})-tests?\\b"
     },
     {
       "file": "Validation_Ledger",
       "type": "tests_total",
-      "claimed": 119,
-      "actual": 132,
-      "context": "obes</strong> (119 total, 18 in pipelin",
+      "claimed": 133,
+      "actual": 135,
+      "context": "obes</strong> (133 total, 21 in pipelin",
       "match_form": "(\\d{2,3})\\s+total\\b"
     },
     {
       "file": "Validation_Ledger",
       "type": "tests_active",
-      "claimed": 101,
-      "actual": 112,
-      "context": "Across <strong>101 active probes</strong> (119",
+      "claimed": 112,
+      "actual": 113,
+      "context": "Across <strong>112 active probes</strong> (133",
       "match_form": "(\\d{2,3})\\s+active\\s+(?:probes"
     },
     {
       "file": "Validation_Ledger",
       "type": "tests_survived",
-      "claimed": 91,
-      "actual": 104,
-      "context": "r, EFC has\n    survived 91. Ten probes ha",
+      "claimed": 104,
+      "actual": 105,
+      "context": "r, EFC has\n    survived 104. Ten probes ha",
       "match_form": "survive[ds]?\\s+(\\d{2,3})\\b"
     },
     {
       "file": "Validation_Ledger",
       "type": "tests_pipeline",
-      "claimed": 18,
-      "actual": 20,
-      "context": "g> (119 total, 18 in pipeline) so far, EFC h",
+      "claimed": 21,
+      "actual": 22,
+      "context": "g> (133 total, 21 in pipeline) so far, EFC h",
       "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "trong>Result so far</strong> (133 registered tests; 112 active, 104 survived, 8"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "td data-section=\"test-counts\">133 tests (104 survived, 8 falsified);"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "order:none; padding:6px 12px\">133 tests (104 survived of 112 active,"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": "istered tests; 112 active, 104 survived, 8 falsified, 21 in pipeline &mdash; from g"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "istered tests; 112 active, 104 survived, 8 falsified, 21 in pipeline &mdash; from g"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": "istered tests; 112 active, 104 survived, 8 falsified, 21 in pipeline &mdash; from g"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": "urvived 104 of 112 active probes. Ten probes ha",
+      "match_form": "(\\d{2,3})\\s+active\\s+(?:probes"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "2018): EFC has survived 104 of 112 active",
+      "match_form": "survive[ds]?\\s+(\\d{2,3})\\b"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": ", 8 falsified, 21 in pipeline &mdash; from g",
+      "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "White_Paper_Series",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": ", 8 falsified, 21 in pipeline); stage: non-r",
+      "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "9 AI-friendly paper packages, 133 tests (112 active, 104 survived, 8"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": "es, 133 tests (112 active, 104 survived, 8 falsified, 21 pipeline), full reprodu"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "es, 133 tests (112 active, 104 survived, 8 falsified, 21 pipeline), full reprodu"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": "es, 133 tests (112 active, 104 survived, 8 falsified, 21 pipeline), full reprodu"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "<td>The 133-test validation sta",
+      "match_form": "(\\d{2,3})-tests?\\b"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": "obes</strong> (133 total, 21 in pipelin",
+      "match_form": "(\\d{2,3})\\s+total\\b"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": "Across <strong>112 active probes</strong> (133",
+      "match_form": "(\\d{2,3})\\s+active\\s+(?:probes"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": ">\n      <td>Of 112 active probes, EFC survives",
+      "match_form": "(\\d{2,3})\\s+active\\s+(?:probes"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "), EFC has\n    survived 104. Ten probes ha",
+      "match_form": "survive[ds]?\\s+(\\d{2,3})\\b"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "ve probes, EFC survives 104 (8 falsified,",
+      "match_form": "survive[ds]?\\s+(\\d{2,3})\\b"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": "g> (133 total, 21 in pipeline), EFC has",
+      "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": "ified &middot; 21 in pipeline</span>\n  </p>",
+      "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": "(8 falsified, 21 in pipeline).</td>\n      <",
+      "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "pill survived\">104/112 survived</span>\n    &nb",
+      "match_form": "ratio"
+    },
+    {
+      "file": "Elevator_Pitch",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": "pill survived\">104/112 survived</span>\n    &nb",
+      "match_form": "ratio"
+    },
+    {
+      "file": "Stage_IV_Roadmap",
+      "type": "tests_total",
+      "claimed": 133,
+      "actual": 135,
+      "context": ".html\">Ledger</a> for the\n    133 tests registered (112 active, 104 s"
+    },
+    {
+      "file": "Stage_IV_Roadmap",
+      "type": "tests_active",
+      "claimed": 112,
+      "actual": 113,
+      "context": "ts registered (112 active, 104 survived, 8 falsified, 21 in pipeline).\n  </p>\n</div"
+    },
+    {
+      "file": "Stage_IV_Roadmap",
+      "type": "tests_survived",
+      "claimed": 104,
+      "actual": 105,
+      "context": "ts registered (112 active, 104 survived, 8 falsified, 21 in pipeline).\n  </p>\n</div"
+    },
+    {
+      "file": "Stage_IV_Roadmap",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": "ts registered (112 active, 104 survived, 8 falsified, 21 in pipeline).\n  </p>\n</div"
+    },
+    {
+      "file": "Stage_IV_Roadmap",
+      "type": "tests_pipeline",
+      "claimed": 21,
+      "actual": 22,
+      "context": ", 8 falsified, 21 in pipeline).\n  </p>\n</div",
+      "match_form": "(\\d{2,3})\\s+in\\s+pipeline"
+    },
+    {
+      "file": "Changelog",
+      "type": "paper_count",
+      "claimed": 158,
+      "actual": 159,
+      "context": "/code> refactored &mdash; 128/158 paper packages enriched to 10/10 standard vi"
+    },
+    {
+      "file": "Changelog",
+      "type": "paper_count",
+      "claimed": 158,
+      "actual": 159,
+      "context": "ackages (219 new files across 158 packages). Fixed 53 paper README DOI d"
     }
   ]
 }

--- a/.claude/orcid_sync_report.json
+++ b/.claude/orcid_sync_report.json
@@ -1,7 +1,7 @@
 {
-  "checked_at": "2026-05-03T17:28:53.250713+00:00",
+  "checked_at": "2026-05-03T18:50:12.443824+00:00",
   "orcid_id": "0009-0002-4860-5095",
-  "source": "live",
+  "source": "cache",
   "orcid_works_count": 161,
   "orcid_dois_count": 161,
   "repo_dois_count": 156,

--- a/.claude/symbiose_snapshot.json
+++ b/.claude/symbiose_snapshot.json
@@ -1,19 +1,19 @@
 {
   "source": "ledger_fallback",
-  "generated_at": "2026-05-03T12:52:41.094440Z",
+  "generated_at": "2026-05-03T18:50:09.350348Z",
   "tests": {
-    "total": 133,
-    "active": 112,
-    "survived": 104,
+    "total": 135,
+    "active": 113,
+    "survived": 105,
     "falsified": 8,
-    "planned_pipeline": 21,
-    "physics_test": 47,
+    "planned_pipeline": 22,
+    "physics_test": 48,
     "consistency_check": 21,
     "phenomenological": 16,
     "framework_constraint": 28
   },
   "papers": {
-    "total": 158,
+    "total": 159,
     "with_doi": 157,
     "sealed_predictions_total": 339
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ license: CC-BY-4.0
 core_principle: "Energy flows along entropy gradients"
 validation_ledger_public: v3.20
 validation_ledger_internal: v4.7
-ai_packages: 158 (100% coverage)
+ai_packages: 159 (100% coverage)
 stage: non_rejectable_model (global verdict OPEN)
 maintenance: scripts/maintenance/ (auto-run by SessionStart hook + CI)
 pipelines: pipelines/efc/native_v2_graph/ (AQUAL) + pipelines/efc/euclid_dr1/ (Euclid DR1)
@@ -328,7 +328,7 @@ EFC/
 ├── theory/
 │   └── formal/         # LaTeX: S, D, R, H, C0 models
 ├── docs/
-│   ├── papers/efc/     # 158 papers (158 with AI-friendly packages, 100%)
+│   ├── papers/efc/     # 159 papers (159 with AI-friendly packages, 100%)
 │   └── public/         # Validation Ledger (v3.20), White Paper, Roadmap, Elevator Pitch, Changelog
 ├── src/efc/            # Core Python library
 ├── pipelines/          # Graph-AQUAL + Euclid DR1 pipelines
@@ -347,7 +347,7 @@ EFC/
 
 ## AI-Friendly Paper Packages (140)
 
-All 158 papers have full AI-friendly packages (10/10 standard: `src/`, `data/`, `examples/`, `CITATION.cff`, `LICENSE`, `citations.bib`, `schema.json`):
+All 159 papers have full AI-friendly packages (10/10 standard: `src/`, `data/`, `examples/`, `CITATION.cff`, `LICENSE`, `citations.bib`, `schema.json`):
 
 ### Consolidation
 | Paper | Module | DOI |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Across **133 independent tests** so far (galaxy rotation curves, the cosmic micr
 [![ORCID](https://img.shields.io/badge/ORCID-0009--0002--4860--5095-green)](https://orcid.org/0009-0002-4860-5095)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Validation Ledger](https://img.shields.io/badge/Validation_Ledger-v3.17-orange)](./docs/public/EFC_Validation_Ledger.html)
-[![AI Packages](https://img.shields.io/badge/AI_Packages-158-brightgreen)](#ai-friendly-paper-packages)
+[![AI Packages](https://img.shields.io/badge/AI_Packages-159-brightgreen)](#ai-friendly-paper-packages)
 
 > **NEW (April 12, 2026)**: **[Euclid DR1 Pre-Registration Pipeline](./pipelines/efc/euclid_dr1/)** ([DOI 10.6084/m9.figshare.31990053](https://doi.org/10.6084/m9.figshare.31990053)) — Complete Boltzmann-calibrated prediction pipeline using custom `efc_logistic` gravity model in hi_class. SHA-256 sealed benchmark (B0=0.02, M0=0.06): σ₈ +1.21%, P(k) +2.09%, lensing −6.01%, E_G −3.98%. 36-point parameter scan. Stability: M0≥3B0. Planck ISW: M0<0.1. Predictions frozen for Euclid DR1 (October 2026).
 
@@ -53,7 +53,7 @@ Across **133 independent tests** so far (galaxy rotation curves, the cosmic micr
 | **Theory Site** | [energyflow-cosmology.com](https://energyflow-cosmology.com/) |
 | **AI Navigation** | [`llms.txt`](./llms.txt) / [`AGENTS.md`](./AGENTS.md) |
 | **Validation Ledger** | [`EFC_Validation_Ledger.html`](./docs/public/EFC_Validation_Ledger.html) (v3.17 public / v4.8 internal) |
-| **Papers** | 158 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
+| **Papers** | 159 papers in [`/docs/papers/efc/`](./docs/papers/efc/) |
 | **AI Packages** | 138 with executable Python + structured data (100% coverage) |
 | **Stage** | **Non-rejectable model** — Δχ² ≤ 0 across all probes; global verdict OPEN |
 | **Validation Reports** | EFC-VAL-2026-002 through 007 (6 hand-curated 10/10 packages) |
@@ -284,13 +284,13 @@ Pre-registered conditions that would falsify EFC sectors. F7 (η=1) formally **P
 | Core Lock (Consistency Enforcement) | [31223503](https://doi.org/10.6084/m9.figshare.31223503) |
 | ISW Consistency Audit | [31329082](https://doi.org/10.6084/m9.figshare.31329082) |
 
-> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 158 papers, all with AI-friendly packages (100% coverage). Eight hand-curated 10/10 validation reports with full reproducible pipelines.
+> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 159 papers, all with AI-friendly packages (100% coverage). Eight hand-curated 10/10 validation reports with full reproducible pipelines.
 
 ---
 
 ## AI-Friendly Paper Packages
 
-All 158 papers have AI-friendly packages (100% coverage as of April 2026). Eight hand-curated 10/10 validation reports with full reproducible pipelines:
+All 159 papers have AI-friendly packages (100% coverage as of April 2026). Eight hand-curated 10/10 validation reports with full reproducible pipelines:
 
 | Package | Module | Key Functionality |
 |---------|--------|-------------------|
@@ -334,7 +334,7 @@ EFC/
 ├── theory/             # Formal mathematics
 │   └── formal/         # S, D, R, H, C0 models (LaTeX)
 ├── docs/
-│   ├── papers/efc/     # 158 papers with AI-friendly packages (100%)
+│   ├── papers/efc/     # 159 papers with AI-friendly packages (100%)
 │   ├── public/         # Validation Ledger (v3.15), Master Spec, figures
 │   ├── figures/        # Shared figures
 │   ├── notebooks/      # Jupyter notebooks

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-04-28",
-  "n_packages": 158,
+  "generated": "2026-05-03",
+  "n_packages": 159,
   "packages": [
     {
       "name": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
@@ -1398,6 +1398,15 @@
       "primary_pdf": "EBE_SPARC175_Complete_Documentation.pdf",
       "created": [],
       "n_files": 21
+    },
+    {
+      "name": "jwst_hmf_prereg_v4",
+      "title": "jwst hmf prereg v4",
+      "track": "Spor general",
+      "regimes": [],
+      "primary_pdf": "jwst_hmf_prereg_v4_FINAL.pdf",
+      "created": [],
+      "n_files": 10
     },
     {
       "name": "observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-COSMOS-web",

--- a/docs/papers/efc/efc_index.json
+++ b/docs/papers/efc/efc_index.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.1",
-  "generated": "2026-05-02T17:05:18.049480+00:00",
+  "version": "2.2",
+  "generated": "2026-05-03T18:50:07.570422+00:00",
   "root": "docs/papers/efc",
-  "paper_count": 158,
+  "paper_count": 159,
   "papers": [
     {
       "id": "a-one-parameter,-four-channel-consistency-test-for-efc-background-coupling",
@@ -1179,6 +1179,13 @@
       "doi": "10.6084/m9.figshare.31047703",
       "title": "Entropy-Bounded Empiricism: Regime-Dependent Validity in Galaxy Rotation Curves",
       "tier": "T2"
+    },
+    {
+      "id": "jwst-hmf-prereg-v4",
+      "path": "jwst_hmf_prereg_v4",
+      "type": "theory",
+      "doi": null,
+      "title": "Jwst Hmf Prereg V4"
     },
     {
       "id": "observed-galaxy-abundances-at-z-6-exceed-halo-limited-predictions-in-cosmos-web",

--- a/docs/papers/efc/jwst_hmf_prereg_v4/CITATION.cff
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/CITATION.cff
@@ -1,0 +1,13 @@
+cff-version: 1.2.0
+title: "Jwst Hmf Prereg V4"
+message: "If you use this work, please cite it as below."
+authors:
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+    affiliation: "Symbiose Research, Sandnes, Norway"
+date-released: "2026-05-03"
+version: "1.0"
+# doi: (pending)
+license: "CC-BY-4.0"
+repository-code: "https://github.com/supertedai/EFC"

--- a/docs/papers/efc/jwst_hmf_prereg_v4/LICENSE
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/LICENSE
@@ -1,0 +1,8 @@
+Creative Commons Attribution 4.0 International (CC-BY-4.0)
+
+Copyright (c) 2026 Morten Magnusson
+
+You are free to share and adapt this material for any purpose, including
+commercially, as long as you give appropriate credit.
+
+Full license text: https://creativecommons.org/licenses/by/4.0/legalcode

--- a/docs/papers/efc/jwst_hmf_prereg_v4/README.md
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/README.md
@@ -1,0 +1,16 @@
+# Jwst Hmf Prereg V4
+
+## AI-Friendly Package
+
+- **DOI:** (pending)
+- **Version:** 1.0
+- **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
+- **Affiliation:** Symbiose Research, Sandnes, Norway
+- **Date:** 2026-05-03
+- **License:** CC-BY-4.0
+
+---
+
+## Overview
+
+Auto-generated metadata package for Jwst Hmf Prereg V4.

--- a/docs/papers/efc/jwst_hmf_prereg_v4/ai_manifest.json
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/ai_manifest.json
@@ -1,0 +1,58 @@
+{
+  "id": "jwst-hmf-prereg-v4",
+  "directory": "jwst_hmf_prereg_v4",
+  "title": "jwst hmf prereg v4",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "package_type": "ai-friendly-paper",
+  "schema_version": "1.0",
+  "generated": "2026-05-03",
+  "track": "Spor general",
+  "regimes": [],
+  "primary_pdf": "jwst_hmf_prereg_v4_FINAL.pdf",
+  "all_pdfs": [
+    "jwst_hmf_prereg_v4_FINAL.pdf"
+  ],
+  "files": [
+    {
+      "path": "CITATION.cff",
+      "bytes": 409
+    },
+    {
+      "path": "LICENSE",
+      "bytes": 298
+    },
+    {
+      "path": "README.md",
+      "bytes": 364
+    },
+    {
+      "path": "citations.bib",
+      "bytes": 246
+    },
+    {
+      "path": "index.json",
+      "bytes": 569
+    },
+    {
+      "path": "jwst-hmf-prereg-v4.jsonld",
+      "bytes": 535
+    },
+    {
+      "path": "jwst_hmf_prereg_v4_FINAL.pdf",
+      "bytes": 235110
+    },
+    {
+      "path": "metadata.json",
+      "bytes": 446
+    },
+    {
+      "path": "schema.json",
+      "bytes": 613
+    }
+  ],
+  "n_files": 10,
+  "n_pdfs": 1
+}

--- a/docs/papers/efc/jwst_hmf_prereg_v4/citations.bib
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/citations.bib
@@ -1,0 +1,8 @@
+@misc{magnusson2026_jwst_hmf_prereg_v4,
+  author = {Magnusson, Morten},
+  title = {jwst hmf prereg v4},
+  year = {2026},
+  publisher = {Figshare},
+  url = {https://github.com/supertedai/EFC},
+  note = {Energy-Flow Cosmology research programme}
+}

--- a/docs/papers/efc/jwst_hmf_prereg_v4/index.json
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/index.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "./schema.json",
+  "id": "jwst-hmf-prereg-v4",
+  "title": "Jwst Hmf Prereg V4",
+  "description": "Auto-generated package for Jwst Hmf Prereg V4.",
+  "version": "1.0",
+  "date": "2026-05-03",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "Jwst",
+    "Prereg"
+  ],
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Symbiose Research, Sandnes, Norway"
+  },
+  "files": {
+    "pdf": "jwst_hmf_prereg_v4_FINAL.pdf",
+    "readme": "README.md"
+  },
+  "paper_type": "theory",
+  "paper_type_inferred": true
+}

--- a/docs/papers/efc/jwst_hmf_prereg_v4/jwst-hmf-prereg-v4.jsonld
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/jwst-hmf-prereg-v4.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+    "efc": "https://github.com/supertedai/EFC/ontology#"
+  },
+  "@type": "ScholarlyArticle",
+  "name": "Jwst Hmf Prereg V4",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "affiliation": {
+      "@type": "Organization",
+      "name": "Symbiose Research",
+      "address": "Sandnes, Norway"
+    },
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "datePublished": "2026-05-03",
+  "license": "https://creativecommons.org/licenses/by/4.0/"
+}

--- a/docs/papers/efc/jwst_hmf_prereg_v4/metadata.json
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/metadata.json
@@ -1,0 +1,21 @@
+{
+  "title": "Jwst Hmf Prereg V4",
+  "short_id": "jwst-hmf-prereg-v4",
+  "version": "1.0",
+  "date": "2026-05-03",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Symbiose Research, Sandnes, Norway"
+  },
+  "license": "CC-BY-4.0",
+  "keywords": [
+    "Energy-Flow Cosmology",
+    "Jwst",
+    "Prereg"
+  ],
+  "files": {
+    "pdf": "jwst_hmf_prereg_v4_FINAL.pdf",
+    "readme": "README.md"
+  }
+}

--- a/docs/papers/efc/jwst_hmf_prereg_v4/schema.json
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "jwst hmf prereg v4 Schema",
+  "type": "object",
+  "properties": {
+    "paper_id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    },
+    "doi": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "key_results": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "parameters": {
+      "type": "object"
+    },
+    "predictions": {
+      "type": "array"
+    }
+  },
+  "required": [
+    "paper_id",
+    "title"
+  ]
+}

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -86,6 +86,7 @@
 <h2>2026</h2>
 
 <ul>
+  <li><strong>2026-05-03</strong> &mdash; 2 paper packages enriched; Public pages updated: Elevator_Pitch.</li>
   <li><strong>2026-05-03</strong> &mdash; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-03</strong> &mdash; Public pages updated: Elevator_Pitch, Stage-IV_Data_Roadmap, Validation_Ledger, White_Paper_Series.</li>
   <li><strong>2026-05-03</strong> &mdash; 1 paper package enriched; Ledger data: evidence-register.json, ledger.json, stats.json, tests.json.</li>

--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -487,11 +487,11 @@
     </tr>
     <tr>
       <td>The code, data, and reproducers</td>
-      <td><a href="https://github.com/supertedai/EFC">github.com/supertedai/EFC</a> &mdash; 158 AI-friendly paper packages, 133 tests (112 active, 104 survived, 8 falsified, 21 pipeline), full reproducible pipelines.</td>
+      <td><a href="https://github.com/supertedai/EFC">github.com/supertedai/EFC</a> &mdash; 159 AI-friendly paper packages, 133 tests (112 active, 104 survived, 8 falsified, 21 pipeline), full reproducible pipelines.</td>
     </tr>
     <tr>
       <td>The single-reference consolidation</td>
-      <td><a href="https://doi.org/10.6084/m9.figshare.31943361">&Lambda;CDM as a Special Case of Energy-Flow Cosmology</a> (DOI 31943361) &mdash; 14 months and 158 papers in one reference.</td>
+      <td><a href="https://doi.org/10.6084/m9.figshare.31943361">&Lambda;CDM as a Special Case of Energy-Flow Cosmology</a> (DOI 31943361) &mdash; 14 months and 159 papers in one reference.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/validation-ledger/data/changelog.json
+++ b/docs/validation-ledger/data/changelog.json
@@ -7,7 +7,7 @@
     {
       "date": "2026-05-03",
       "type": "auto_maintenance",
-      "summary": "1 paper package enriched; Ledger data: evidence-register.json, ledger.json, stats.json, tests.json. Public pages updated: Elevator_Pitch, Stage-IV_Data_Roadmap, Validation_Ledger, White_Paper_Series. Ledger data: evidence-register.json, ledger.json."
+      "summary": "1 paper package enriched; Ledger data: evidence-register.json, ledger.json, stats.json, tests.json. Public pages updated: Elevator_Pitch, Stage-IV_Data_Roadmap, Validation_Ledger, White_Paper_Series. Ledger data: evidence-register.json, ledger.json. 2 paper packages enriched; Public pages updated: Elevator_Pitch."
     },
     {
       "name": "CMB acoustic peaks: Boltzmann-solver gap blocking (post arXiv:2504.20038)",
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "name": "GAP: kSZ_velocity — no dedicated EFC prediction paper",
+      "name": "GAP: kSZ_velocity \u2014 no dedicated EFC prediction paper",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-05-02T20:19:36.120000000+00:00",
@@ -40,7 +40,7 @@
       ]
     },
     {
-      "name": "BIG-SPARC Kill-Test v6 — pipeline re-kjøring seed=42",
+      "name": "BIG-SPARC Kill-Test v6 \u2014 pipeline re-kj\u00f8ring seed=42",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-05-01T19:01:37.537000000+00:00",
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "name": "JWST Bullet Cluster δκ — KILL-test data tilgjengelig, pipeline er bottleneck",
+      "name": "JWST Bullet Cluster \u03b4\u03ba \u2014 KILL-test data tilgjengelig, pipeline er bottleneck",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-05-01T19:01:34.860000000+00:00",
@@ -60,7 +60,7 @@
       ]
     },
     {
-      "name": "ACT+SPT+Planck CMB Lensing — Boltzmann Gap → BLOCKING",
+      "name": "ACT+SPT+Planck CMB Lensing \u2014 Boltzmann Gap \u2192 BLOCKING",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-05-01T19:01:32.272000000+00:00",
@@ -70,7 +70,7 @@
       ]
     },
     {
-      "name": "DES Y6 S8 — DAMAGE Test L2 (Cosmic Shear + 3×2pt)",
+      "name": "DES Y6 S8 \u2014 DAMAGE Test L2 (Cosmic Shear + 3\u00d72pt)",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-05-01T19:01:29.672000000+00:00",
@@ -80,7 +80,7 @@
       ]
     },
     {
-      "name": "DESI DR2 BAO — L2 Validation Ledger Row",
+      "name": "DESI DR2 BAO \u2014 L2 Validation Ledger Row",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-05-01T19:01:27.003000000+00:00",
@@ -100,7 +100,7 @@
       ]
     },
     {
-      "name": "EFCLASS sign test: ΔH² negative for additive gate",
+      "name": "EFCLASS sign test: \u0394H\u00b2 negative for additive gate",
       "status": "collapsed_in_expected_direction",
       "result": "COLLAPSED",
       "last_updated": "2026-04-29T06:45:00.000000000+00:00",
@@ -110,7 +110,7 @@
       ]
     },
     {
-      "name": "CMB+BAO Joint Fit: Background α-gate null result",
+      "name": "CMB+BAO Joint Fit: Background \u03b1-gate null result",
       "status": "collapsed_in_expected_direction",
       "result": "COLLAPSED",
       "last_updated": "2026-04-29T06:45:00.000000000+00:00",
@@ -120,7 +120,7 @@
       ]
     },
     {
-      "name": "CMB Planck constraint on EFC background gate α",
+      "name": "CMB Planck constraint on EFC background gate \u03b1",
       "status": "collapsed_in_expected_direction",
       "result": "COLLAPSED",
       "last_updated": "2026-04-29T06:45:00.000000000+00:00",
@@ -130,7 +130,7 @@
       ]
     },
     {
-      "name": "c_eff(a) via CDDR violation: D_L vs D_A(1+z)² consistency test",
+      "name": "c_eff(a) via CDDR violation: D_L vs D_A(1+z)\u00b2 consistency test",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-04-28T12:15:35.780000000+00:00",
@@ -140,7 +140,7 @@
       ]
     },
     {
-      "name": "S(z) single-parameter joint fit: CMB anomaly ↔ JWST early-galaxy excess",
+      "name": "S(z) single-parameter joint fit: CMB anomaly \u2194 JWST early-galaxy excess",
       "status": "pending",
       "result": "DEGENERACY_LIMITED",
       "last_updated": "2026-04-28T11:59:50.452000000+00:00",
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "name": "T_CMB(z) deviation from (1+z) scaling — SZ-cluster test",
+      "name": "T_CMB(z) deviation from (1+z) scaling \u2014 SZ-cluster test",
       "status": "planned",
       "result": "Planned",
       "last_updated": "2026-04-28T11:59:42.027000000+00:00",


### PR DESCRIPTION
## Summary
Auto-generated output from SessionStart `efc-maintain` hook after a bare PDF was uploaded for `jwst_hmf_prereg_v4`.

## Changes
**New paper package** (`docs/papers/efc/jwst_hmf_prereg_v4/`):
- `CITATION.cff`, `LICENSE`, `README.md`, `ai_manifest.json`, `citations.bib`, `index.json`, `jwst-hmf-prereg-v4.jsonld`, `metadata.json`, `schema.json`
- Inferred `paper_type=theory` (no DOI yet — will be linked when uploaded to Figshare)

**Drift sync:**
- `efc_index.json`: 158 → 159 papers (version 2.1 → 2.2)
- `ai_friendly_index.json`, ORCID sync report, symbiose snapshot, drift report
- `EFC_Changelog.html`, `EFC_Elevator_Pitch.html`, ledger changelog
- `AGENTS.md`, `README.md` cosmetic refresh

## Test plan
- [ ] `verify` passes (this is exactly the kind of change `efc-verify.yml` is designed to bless)
- [ ] No drift remaining after merge

https://claude.ai/code/session_01Y5sXeCYdH78eKFHpaN7K4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5sXeCYdH78eKFHpaN7K4o)_