### PR TITLE
chore: maintenance pass — refresh ai_friendly index, ORCID sync, changelog

### DIFF
--- a/.claude/orcid_sync_report.json
+++ b/.claude/orcid_sync_report.json
@@ -1,7 +1,7 @@
 {
-  "checked_at": "2026-05-04T18:23:34.305588+00:00",
+  "checked_at": "2026-05-04T19:10:56.065842+00:00",
   "orcid_id": "0009-0002-4860-5095",
-  "source": "live",
+  "source": "cache",
   "orcid_works_count": 162,
   "orcid_dois_count": 162,
   "repo_dois_count": 157,

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-03",
+  "generated": "2026-05-04",
   "n_packages": 159,
   "packages": [
     {
@@ -1250,11 +1250,11 @@
     {
       "name": "component_weighted_bias",
       "title": "component weighted bias",
-      "track": "Spor general",
+      "track": "Spor 1 — Galactic/Cosmological",
       "regimes": [],
       "primary_pdf": "component_weighted_bias.pdf",
       "created": [],
-      "n_files": 14
+      "n_files": 25
     },
     {
       "name": "efc-weak-lensing-phenomenology",

--- a/docs/papers/efc/component_weighted_bias/ai_manifest.json
+++ b/docs/papers/efc/component_weighted_bias/ai_manifest.json
@@ -8,12 +8,13 @@
   "license": "CC-BY-4.0",
   "package_type": "ai-friendly-paper",
   "schema_version": "1.0",
-  "generated": "2026-05-03",
-  "track": "Spor general",
+  "generated": "2026-05-04",
+  "track": "Spor 1 — Galactic/Cosmological",
   "regimes": [],
   "primary_pdf": "component_weighted_bias.pdf",
   "all_pdfs": [
-    "component_weighted_bias.pdf"
+    "component_weighted_bias.pdf",
+    "component_weighted_bias_v3p1.pdf"
   ],
   "files": [
     {
@@ -41,6 +42,14 @@
       "bytes": 286662
     },
     {
+      "path": "component_weighted_bias_v3p1.pdf",
+      "bytes": 345550
+    },
+    {
+      "path": "component_weighted_bias_v3p1.tex",
+      "bytes": 25781
+    },
+    {
       "path": "data/parameters.json",
       "bytes": 3474
     },
@@ -57,8 +66,44 @@
       "bytes": 1942
     },
     {
+      "path": "rcmp_decomposition.json",
+      "bytes": 72036
+    },
+    {
+      "path": "rcmp_decomposition.py",
+      "bytes": 11210
+    },
+    {
+      "path": "rcmp_robustness_rc.json",
+      "bytes": 548
+    },
+    {
+      "path": "rcmp_signflip.png",
+      "bytes": 67296
+    },
+    {
+      "path": "rcmp_signflip_table.json",
+      "bytes": 12739
+    },
+    {
+      "path": "rcmp_summary.json",
+      "bytes": 1133
+    },
+    {
       "path": "schema.json",
       "bytes": 618
+    },
+    {
+      "path": "sparc175_killtest_results.json",
+      "bytes": 118857
+    },
+    {
+      "path": "sparc175_killtest_universality_curves.py",
+      "bytes": 23126
+    },
+    {
+      "path": "sparc175_model_curves.json",
+      "bytes": 930482
     },
     {
       "path": "src/__init__.py",
@@ -69,6 +114,6 @@
       "bytes": 4826
     }
   ],
-  "n_files": 14,
-  "n_pdfs": 1
+  "n_files": 25,
+  "n_pdfs": 2
 }

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -86,6 +86,7 @@
 <h2>2026</h2>
 
 <ul>
+  <li><strong>2026-05-04</strong> &mdash; 1 paper package enriched.</li>
   <li><strong>2026-05-04</strong> &mdash; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-04</strong> &mdash; 1 paper package enriched; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-03</strong> &mdash; 3 paper packages enriched; Public pages updated: Changelog, Elevator_Pitch, Stage-IV_Data_Roadmap, Validation_Ledger, White_Paper_Series; Ledger data: evidence-register.json, ledger.json.</li>

--- a/docs/validation-ledger/data/changelog.json
+++ b/docs/validation-ledger/data/changelog.json
@@ -7,7 +7,7 @@
     {
       "date": "2026-05-04",
       "type": "auto_maintenance",
-      "summary": "Ledger data: evidence-register.json, ledger.json."
+      "summary": "Ledger data: evidence-register.json, ledger.json. 1 paper package enriched."
     },
     {
       "name": "Bullet \u03b4\u03ba test: promote from preregistered to in_pipeline (JWST data ready)",


### PR DESCRIPTION
## Summary

Auto-generated by the SessionStart maintenance hook while reviewing the
`component_weighted_bias` paper (figshare 32019723) against the EFC
validation/evaluation/likelihood ledgers and Atlas. No manual edits — these
are the housekeeping diffs the maintenance scripts produced on session
start.

- `efc_gen_ai_friendly`: re-scan of `component_weighted_bias/` picks up the
  v3p1 PDF + tex source, the new `rcmp_*` artefacts (decomposition, sign-flip
  table, summary, robustness rc, signflip plot), and the SPARC 175 killtest
  data (`sparc175_killtest_results.json`,
  `sparc175_killtest_universality_curves.py`,
  `sparc175_model_curves.json`). Track corrected from "Spor general" to
  "Spor 1 — Galactic/Cosmological".
- `efc_orcid_sync`: timestamp refresh (no DOI delta — repo still 5 behind on
  ORCID, separate work item).
- `efc_auto_changelog`: regenerated changelog HTML + JSON.

The substantive review of what this paper implies for Atlas + ledgers
(duplicate DOI cleanup, missing KC1–KC4 / P1 test rows, RCMP-protocol gating
on BIG-SPARC KT v6 / KT3 v3 / EFC-BIC v0.2, Atlas phenomenon for
`rotation_curve_model_selection`) is captured in chat — no code changes
made for those yet, awaiting confirmation before touching ledger data.

## Test plan

- [ ] CI passes (atlas-verify, atlas-sync workflows)
- [ ] `efc_maintain.py` is a no-op on a fresh checkout of this branch
      (idempotency check)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DgMRbBJvUZSyX72ydSecBe)_