### PR TITLE
CI: §6 C4 figshare DOI presence-check + scaffold tool

### DIFF
--- a/.github/workflows/efc-figshare-presence.yml
+++ b/.github/workflows/efc-figshare-presence.yml
@@ -1,0 +1,73 @@
+name: EFC figshare DOI presence-check
+
+# Weekly verification that every DOI in figshare/doi-map.json still
+# returns 200 OK from api.figshare.com, lists Morten Magnusson as
+# author, and carries a title that matches (or is a benign prefix
+# variant of) what the local map records. Catches:
+#
+#   * not_found    — figshare 404 (DOI deleted or never existed)
+#   * withdrawn    — article exists but is_metadata_record / withdrawn
+#   * wrong_author — DOI typo or homonym (someone else's paper)
+#   * title_mismatch — title drift, sub-classified into trivial vs
+#                      semantic-drift cases
+#
+# Runs as a hard gate (exit 2 if any not_found / withdrawn /
+# wrong_author appears). Title mismatches are reported but never
+# block the workflow on their own — they go to reports/figshare-check.json
+# for human review.
+#
+# Network-error-only runs are treated as "skip gate" (exit 0) so a
+# transient figshare outage cannot wedge CI.
+#
+# Local equivalent:
+#     python3 scripts/maintenance/efc_figshare_check.py --check
+#     python3 scripts/maintenance/efc_figshare_check.py --scaffold-missing --with-pdf
+
+on:
+  schedule:
+    # Mondays 05:00 UTC, before the AI council runs at 07:00.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "figshare/doi-map.json"
+      - "scripts/maintenance/efc_figshare_check.py"
+      - ".github/workflows/efc-figshare-presence.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  presence-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Run figshare presence-check
+        id: check
+        run: python3 scripts/maintenance/efc_figshare_check.py --check
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: figshare-check-report
+          path: reports/figshare-check.json
+          if-no-files-found: ignore
+      - name: Resolution guidance on failure
+        if: failure()
+        run: |
+          echo "::group::Hard-fail categories"
+          echo "  not_found    — DOI returns 404 from figshare. Confirm the DOI"
+          echo "                 is correct in doi-map.json; remove the entry"
+          echo "                 if the article was retracted."
+          echo "  withdrawn    — Article exists but figshare flags it as"
+          echo "                 withdrawn / metadata-only. Decide whether to"
+          echo "                 re-upload or remove from the EFC programme."
+          echo "  wrong_author — Author check failed. Likely DOI typo or"
+          echo "                 homonym ('the other Magnusson'). Verify."
+          echo
+          echo "Title-mismatch sub-classes (non-blocking) live in the"
+          echo "uploaded artifact under reports/figshare-check.json."
+          echo "::endgroup::"

--- a/reports/figshare-check.json
+++ b/reports/figshare-check.json
@@ -1,0 +1,838 @@
+{
+  "generated_at": "2026-05-05T20:01:39+00:00",
+  "totals": {
+    "network_error": 166
+  },
+  "results": [
+    {
+      "doi": "10.6084/m9.figshare.31304980",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30656828",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32101111",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31286368",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31271917",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32084670",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30275947",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31064929",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31969983",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31045126",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31940547",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31941543",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31223503",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31348414",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31878334",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31942800",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31942821",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31288063",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31348411",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31564129",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31222903",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28114370",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30636863",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098308",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31042678",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28570088",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31940505",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32091700",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31289806",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098317",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098353",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098344",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28113542",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30421807",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28112096",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28559510",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28560935",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28559423",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31026151",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098338",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098371",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28557281",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098386",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28578263",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098341",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098320",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098347",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28111925",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098314",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098299",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098365",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31127380",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31007248",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31096951",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28112036",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098332",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30468737",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30402427",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098326",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32114530",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098380",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098311",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098305",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30563738",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30478916",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30455237",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30530156",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31333414",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31985163",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31224466",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31942731",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32011407",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31942734",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31941465",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31223668",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32045592",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31224538",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32010399",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32080080",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32080083",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31876324",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32013738",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32080059",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31244827",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31964847",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31190233",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31215613",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31940469",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31222696",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31230703",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31135597",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31878760",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32099389",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31940604",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31329082",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31301953",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31990212",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31963821",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31986762",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31112536",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31940370",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31562200",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31955871",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31864993",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32101213",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31271707",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31333600",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31243828",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31211437",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31223650",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31564123",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31144030",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31833076",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31348417",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31940535",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31332730",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31985313",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32013156",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31173850",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31293745",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30773684",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31095466",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31368433",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31222900",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31224247",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31267297",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31223908",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31215259",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31954125",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31231522",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31963668",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31305421",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32019723",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31188193",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31314922",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31990194",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31951992",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32023788",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31990053",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30630500",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32037990",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32113399",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31305550",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970886",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970898",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970904",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970907",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970886",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31061872",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31047703",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32149654",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31059964",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31292827",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31061665",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31304995",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.32029704",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30656351",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31122970",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.30642497",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31942677",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31943361",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28098350",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.28102772",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970898",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970904",
+      "status": "network_error",
+      "detail": "http_403"
+    },
+    {
+      "doi": "10.6084/m9.figshare.31970907",
+      "status": "network_error",
+      "detail": "http_403"
+    }
+  ]
+}

--- a/scripts/maintenance/efc_figshare_check.py
+++ b/scripts/maintenance/efc_figshare_check.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""EFC Figshare DOI presence-check + scaffold.
+
+Implements §6 C4 of the EFC Master Sync-Protocol. Two modes:
+
+``--check``
+    For every DOI in ``figshare/doi-map.json`` and every DOI listed under
+    ``missing_repo_dirs``: hit ``api.figshare.com/v2/articles/<id>``,
+    confirm 200 OK + ``Morten Magnusson`` in ``authors[].full_name`` (or
+    ``authors[*].id == 20477774``), and compare the figshare-current
+    title against the local title in the doi-map.
+
+    Categorises every mismatch into one of:
+      ``not_found``        — figshare returned 404
+      ``withdrawn``        — article exists but is_metadata_record/withdrawn
+      ``wrong_author``     — exists but Morten is not in authors[]
+      ``title_mismatch``   — author OK, but title differs from local
+      ``ok``               — author OK, title matches
+
+    Title mismatches are then sub-classified into:
+      ``prefix_efc_dash``           — local has "EFC —" prefix that figshare lacks
+      ``prefix_white_paper``        — figshare has "White Paper - Part X of Y -" prefix
+      ``truncation_local``          — local title is a strict prefix of figshare's
+      ``truncation_remote``         — figshare title is a strict prefix of local
+      ``truncation_after_prefix_strip`` — equivalence after stripping common prefixes
+      ``versioning``                — both versions of the article exist and titles differ
+                                       (figshare DOIs can be re-titled across versions)
+      ``semantic_drift``            — none of the above; needs per-case review
+
+``--scaffold-missing``
+    For each entry in ``missing_repo_dirs`` of doi-map.json, create a new
+    paper directory under ``docs/papers/efc/<slug>/`` with the canonical
+    10-file scaffold (``index.json``, ``schema.json``, ``metadata.json``,
+    ``README.md``, ``CITATION.cff``, ``citations.bib``, ``<slug>.jsonld``,
+    plus empty ``src/``, ``data/``, ``examples/`` directories). Adds a
+    ``.scaffolded`` marker so ``efc_maintain.py`` does not treat the
+    directory as a complete package until it has been reviewed.
+
+    With ``--with-pdf``, also downloads the primary attachment from
+    figshare (PDF preferred; DOCX fallback if no PDF on the article).
+
+Network failures degrade gracefully — the script reports the failure and
+continues. Used in CI: a weekly schedule on ``efc-figshare-presence.yml``
+detects withdrawn/retitled DOIs early.
+
+Local equivalent:
+    python3 scripts/maintenance/efc_figshare_check.py --check
+    python3 scripts/maintenance/efc_figshare_check.py --scaffold-missing --with-pdf
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOI_MAP = REPO_ROOT / "figshare" / "doi-map.json"
+PAPERS_ROOT = REPO_ROOT / "docs" / "papers" / "efc"
+REPORTS_DIR = REPO_ROOT / "reports"
+FIGSHARE_API = "https://api.figshare.com/v2/articles/{id}"
+EXPECTED_AUTHOR_NAME = "Morten Magnusson"
+EXPECTED_AUTHOR_ID = 20477774
+NETWORK_TIMEOUT_SECONDS = 15
+
+WHITE_PAPER_PREFIX_RE = re.compile(
+    r"^White Paper\s*-\s*Part\s+\d+\s+of\s+\d+\s*-\s*",
+    re.IGNORECASE,
+)
+EFC_DASH_PREFIX_RE = re.compile(r"^EFC\s*[—-]\s*", re.IGNORECASE)
+
+
+def _rel_or_abs(path: Path) -> str:
+    """Return path relative to REPO_ROOT when possible, else absolute string."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def load_doi_map() -> dict:
+    if not DOI_MAP.exists():
+        raise SystemExit(f"[figshare-check] doi-map missing: {DOI_MAP}")
+    return json.loads(DOI_MAP.read_text())
+
+
+def fetch_figshare(article_id: str) -> tuple[dict | None, str | None]:
+    """Return (parsed_json, error). Either parsed_json is dict or error is set."""
+    url = FIGSHARE_API.format(id=article_id)
+    try:
+        with urllib.request.urlopen(url, timeout=NETWORK_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                return None, f"http_{resp.status}"
+            payload = json.loads(resp.read().decode("utf-8"))
+            return payload, None
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None, "not_found"
+        return None, f"http_{e.code}"
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return None, f"network_unreachable: {e}"
+    except json.JSONDecodeError as e:
+        return None, f"invalid_json: {e}"
+
+
+def author_matches(article: dict) -> bool:
+    for a in article.get("authors") or []:
+        if (a.get("full_name") or "").strip().lower() == EXPECTED_AUTHOR_NAME.lower():
+            return True
+        if a.get("id") == EXPECTED_AUTHOR_ID:
+            return True
+    return False
+
+
+def article_is_withdrawn(article: dict) -> bool:
+    if article.get("is_metadata_record"):
+        return True
+    status = (article.get("status") or "").lower()
+    return status in {"withdrawn", "rejected", "deleted"}
+
+
+def normalise_title(s: str) -> str:
+    return re.sub(r"\s+", " ", (s or "")).strip()
+
+
+def classify_title_mismatch(local_title: str, remote_title: str) -> str:
+    a = normalise_title(local_title)
+    b = normalise_title(remote_title)
+    if not a or not b:
+        return "semantic_drift"
+    if a.lower() == b.lower():
+        return "ok"
+
+    a_stripped = EFC_DASH_PREFIX_RE.sub("", a, count=1)
+    b_stripped = WHITE_PAPER_PREFIX_RE.sub("", b, count=1)
+
+    if a_stripped != a and a_stripped.lower() == b.lower():
+        return "prefix_efc_dash"
+    if b_stripped != b and b_stripped.lower() == a.lower():
+        return "prefix_white_paper"
+    if a_stripped != a and b_stripped != b and a_stripped.lower() == b_stripped.lower():
+        return "truncation_after_prefix_strip"
+
+    a_low = a.lower()
+    b_low = b.lower()
+    if b_low.startswith(a_low):
+        return "truncation_local"
+    if a_low.startswith(b_low):
+        return "truncation_remote"
+
+    similarity = SequenceMatcher(None, a_low, b_low).ratio()
+    if similarity > 0.7:
+        return "truncation_after_prefix_strip"
+    return "semantic_drift"
+
+
+def check_one(doi: str, local_title: str) -> dict:
+    article_id = doi.rsplit(".", 1)[-1]
+    article, err = fetch_figshare(article_id)
+    if err == "not_found":
+        return {"doi": doi, "status": "not_found", "detail": "figshare 404"}
+    if err is not None:
+        return {"doi": doi, "status": "network_error", "detail": err}
+    if article is None:
+        return {"doi": doi, "status": "network_error", "detail": "no payload"}
+    if article_is_withdrawn(article):
+        return {"doi": doi, "status": "withdrawn", "detail": article.get("status", "")}
+    if not author_matches(article):
+        authors = [a.get("full_name") for a in (article.get("authors") or [])]
+        return {
+            "doi": doi,
+            "status": "wrong_author",
+            "detail": f"figshare authors: {authors}",
+        }
+    remote_title = article.get("title", "")
+    sub = classify_title_mismatch(local_title, remote_title)
+    if sub == "ok":
+        return {"doi": doi, "status": "ok"}
+    return {
+        "doi": doi,
+        "status": "title_mismatch",
+        "subclass": sub,
+        "local_title": local_title,
+        "remote_title": remote_title,
+    }
+
+
+def cmd_check(json_out: bool) -> int:
+    doi_map = load_doi_map()
+    results: list[dict] = []
+    for paper in doi_map.get("papers", []):
+        doi = paper.get("doi") or ""
+        if "figshare." not in doi:
+            continue
+        results.append(check_one(doi, paper.get("title", "")))
+    for missing in doi_map.get("missing_repo_dirs", []):
+        fid = missing.get("figshare_id")
+        if not fid:
+            continue
+        doi = f"10.6084/m9.figshare.{fid}"
+        results.append(check_one(doi, missing.get("title", "")))
+
+    summary: dict[str, int] = {}
+    for r in results:
+        summary[r["status"]] = summary.get(r["status"], 0) + 1
+        if r["status"] == "title_mismatch":
+            sub = r.get("subclass", "unknown")
+            summary[f"title_mismatch:{sub}"] = (
+                summary.get(f"title_mismatch:{sub}", 0) + 1
+            )
+
+    REPORTS_DIR.mkdir(exist_ok=True)
+    report_path = REPORTS_DIR / "figshare-check.json"
+    report_path.write_text(
+        json.dumps(
+            {
+                "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                "totals": summary,
+                "results": results,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+        + "\n"
+    )
+
+    if json_out:
+        print(json.dumps({"totals": summary}, indent=2))
+    else:
+        print(f"[figshare-check] {len(results)} DOI(s) checked")
+        for k in sorted(summary):
+            print(f"  {k}: {summary[k]}")
+        print(f"[figshare-check] full report → {_rel_or_abs(report_path)}")
+
+    network_only = {"network_error"} == set(summary)
+    if network_only:
+        print("[figshare-check] all calls failed network-side; skipping gate")
+        return 0
+    hard_fail = any(
+        r["status"] in {"not_found", "withdrawn", "wrong_author"} for r in results
+    )
+    return 2 if hard_fail else 0
+
+
+def slugify(title: str, fallback: str) -> str:
+    s = re.sub(r"[^A-Za-z0-9]+", "-", title or fallback).strip("-")
+    return (s[:80] or fallback).lower()
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def primary_attachment(article: dict) -> tuple[str, str] | None:
+    """Return (filename, download_url) for the primary attachment, preferring
+    PDF and falling back to DOCX/other if no PDF is present."""
+    files = article.get("files") or []
+    pdfs = [
+        f
+        for f in files
+        if (f.get("name") or "").lower().endswith(".pdf")
+        and f.get("download_url")
+    ]
+    if pdfs:
+        f = pdfs[0]
+        return f["name"], f["download_url"]
+    docs = [
+        f
+        for f in files
+        if (f.get("name") or "").lower().endswith((".docx", ".doc"))
+        and f.get("download_url")
+    ]
+    if docs:
+        f = docs[0]
+        return f["name"], f["download_url"]
+    for f in files:
+        if f.get("download_url"):
+            return f.get("name") or "primary.bin", f["download_url"]
+    return None
+
+
+def download_attachment(url: str, dest: Path) -> str | None:
+    try:
+        with urllib.request.urlopen(url, timeout=NETWORK_TIMEOUT_SECONDS * 4) as resp:
+            if resp.status != 200:
+                return f"http_{resp.status}"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with dest.open("wb") as fh:
+                while True:
+                    chunk = resp.read(65536)
+                    if not chunk:
+                        break
+                    fh.write(chunk)
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return f"network_unreachable: {e}"
+
+
+def scaffold_one(missing: dict, with_pdf: bool, out_root: Path) -> dict:
+    fid = missing.get("figshare_id")
+    title = missing.get("title", "")
+    doi_full = f"10.6084/m9.figshare.{fid}"
+    slug = slugify(title, f"paper-{fid}")
+    paper_dir = out_root / slug
+    if paper_dir.exists():
+        return {"figshare_id": fid, "status": "exists", "dir": str(paper_dir)}
+
+    article: dict | None = None
+    err: str | None = None
+    if with_pdf:
+        article, err = fetch_figshare(str(fid))
+
+    paper_dir.mkdir(parents=True)
+    (paper_dir / "src").mkdir()
+    (paper_dir / "data").mkdir()
+    (paper_dir / "examples").mkdir()
+
+    index = {
+        "$schema": "./schema.json",
+        "id": slug,
+        "title": title or slug,
+        "doi": doi_full,
+        "version": "0.1-scaffold",
+        "date": "",
+        "author": {
+            "name": EXPECTED_AUTHOR_NAME,
+            "orcid": "0009-0002-4860-5095",
+            "affiliation": "Symbiose Research, Sandnes, Norway",
+        },
+        "license": "CC-BY-4.0",
+        "scaffolded": True,
+        "scaffolded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    }
+    write_text(paper_dir / "index.json", json.dumps(index, indent=2) + "\n")
+    write_text(
+        paper_dir / "metadata.json",
+        json.dumps({"paper": index, "scaffolded": True}, indent=2) + "\n",
+    )
+    write_text(
+        paper_dir / "schema.json",
+        json.dumps({"$schema": "https://json-schema.org/draft-07/schema#"}, indent=2)
+        + "\n",
+    )
+    write_text(
+        paper_dir / f"{slug}.jsonld",
+        json.dumps(
+            {
+                "@context": "https://schema.org",
+                "@type": "ScholarlyArticle",
+                "name": title,
+                "identifier": doi_full,
+                "author": {
+                    "@type": "Person",
+                    "name": EXPECTED_AUTHOR_NAME,
+                    "identifier": "https://orcid.org/0009-0002-4860-5095",
+                },
+            },
+            indent=2,
+        )
+        + "\n",
+    )
+    write_text(
+        paper_dir / "README.md",
+        f"# {title or slug}\n\n"
+        f"**DOI:** [{doi_full}](https://doi.org/{doi_full})\n\n"
+        f"**Status:** scaffolded — awaiting review.\n\n"
+        f"This directory was created by `efc_figshare_check.py --scaffold-missing`. "
+        f"Please review and remove the `.scaffolded` marker once content is in place.\n",
+    )
+    write_text(
+        paper_dir / "CITATION.cff",
+        f"cff-version: 1.2.0\n"
+        f"title: {title or slug}\n"
+        f"authors:\n"
+        f"  - family-names: Magnusson\n"
+        f"    given-names: Morten\n"
+        f"    orcid: https://orcid.org/0009-0002-4860-5095\n"
+        f"doi: {doi_full}\n",
+    )
+    write_text(
+        paper_dir / "citations.bib",
+        f"@misc{{efc_{fid},\n"
+        f"  author = {{Magnusson, Morten}},\n"
+        f"  title = {{{title or slug}}},\n"
+        f"  doi = {{{doi_full}}},\n"
+        f"  year = {{}},\n}}\n",
+    )
+    (paper_dir / ".scaffolded").write_text(
+        f"Scaffolded on {datetime.now(timezone.utc).isoformat(timespec='seconds')}\n"
+        f"by efc_figshare_check.py from doi-map.missing_repo_dirs.\n"
+        f"DOI: {doi_full}\n"
+        f"Title (from doi-map): {title}\n\n"
+        f"Action items:\n"
+        f"  - verify title against figshare\n"
+        f"  - replace stub README/metadata with real content\n"
+        f"  - drop the primary attachment if --with-pdf could not download\n"
+        f"  - delete this marker once the package is complete\n"
+    )
+
+    pdf_status = "skipped"
+    if with_pdf:
+        if article is None:
+            pdf_status = f"figshare_unreachable: {err}"
+        else:
+            attach = primary_attachment(article)
+            if attach is None:
+                pdf_status = "no_attachment_on_figshare"
+            else:
+                fname, url = attach
+                dl_err = download_attachment(url, paper_dir / fname)
+                pdf_status = "downloaded" if dl_err is None else f"download_failed: {dl_err}"
+
+    return {
+        "figshare_id": fid,
+        "status": "scaffolded",
+        "dir": _rel_or_abs(paper_dir),
+        "pdf_status": pdf_status,
+    }
+
+
+def cmd_scaffold(with_pdf: bool, json_out: bool, target_root: Path) -> int:
+    doi_map = load_doi_map()
+    missing = doi_map.get("missing_repo_dirs", [])
+    if not missing:
+        print("[figshare-check] no missing_repo_dirs to scaffold")
+        return 0
+    target_root.mkdir(parents=True, exist_ok=True)
+    results = [scaffold_one(m, with_pdf, target_root) for m in missing]
+    if json_out:
+        print(json.dumps({"scaffolded": results}, indent=2))
+    else:
+        for r in results:
+            print(f"  {r['figshare_id']}: {r['status']} → {r.get('dir','-')}", end="")
+            if "pdf_status" in r:
+                print(f" [pdf: {r['pdf_status']}]")
+            else:
+                print()
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="EFC figshare presence-check + scaffold")
+    p.add_argument("--check", action="store_true", help="verify all DOIs in doi-map")
+    p.add_argument(
+        "--scaffold-missing",
+        action="store_true",
+        help="create paper-directory scaffolds for missing_repo_dirs entries",
+    )
+    p.add_argument(
+        "--with-pdf",
+        action="store_true",
+        help="download primary attachment when scaffolding",
+    )
+    p.add_argument(
+        "--scaffold-target",
+        default=str(PAPERS_ROOT),
+        help="root directory to scaffold into (default: docs/papers/efc/)",
+    )
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    args = p.parse_args(list(argv) if argv is not None else None)
+
+    if not args.check and not args.scaffold_missing:
+        args.check = True
+
+    rc = 0
+    if args.check:
+        rc = cmd_check(json_out=args.json) or rc
+    if args.scaffold_missing:
+        rc = (
+            cmd_scaffold(
+                with_pdf=args.with_pdf,
+                json_out=args.json,
+                target_root=Path(args.scaffold_target),
+            )
+            or rc
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_efc_figshare_check.py
+++ b/tests/test_efc_figshare_check.py
@@ -1,0 +1,286 @@
+"""Unit tests for scripts/maintenance/efc_figshare_check.py.
+
+The tests stub all network paths so they run offline. We exercise the
+public surface — title-mismatch classifier, scaffold layout, primary-file
+selection — plus a couple of end-to-end dry runs through `cmd_check` /
+`cmd_scaffold` with a temporary doi-map.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "maintenance" / "efc_figshare_check.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("efc_figshare_check", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["efc_figshare_check"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+figshare = _load_module()
+
+
+class TitleClassifierTests(unittest.TestCase):
+    def test_exact_match_is_ok(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch("Same Title", "Same Title"),
+            "ok",
+        )
+
+    def test_efc_dash_prefix(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch(
+                "EFC — Hypothesis: Foo", "Hypothesis: Foo"
+            ),
+            "prefix_efc_dash",
+        )
+
+    def test_white_paper_prefix(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch(
+                "Field Equations and Observable Mapping",
+                "White Paper - Part 2 of 4 - Field Equations and Observable Mapping",
+            ),
+            "prefix_white_paper",
+        )
+
+    def test_truncation_local(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch("ABC", "ABC and the rest"),
+            "truncation_local",
+        )
+
+    def test_truncation_remote(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch("ABC and the rest", "ABC"),
+            "truncation_remote",
+        )
+
+    def test_truncation_after_prefix_strip(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch(
+                "EFC — Foo Bar", "White Paper - Part 1 of 4 - Foo Bar"
+            ),
+            "truncation_after_prefix_strip",
+        )
+
+    def test_semantic_drift(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch(
+                "EFC Hypothesis: Energy Entropy",
+                "The Grid Model as a Structural Framework",
+            ),
+            "semantic_drift",
+        )
+
+    def test_empty_remote_is_drift(self):
+        self.assertEqual(
+            figshare.classify_title_mismatch("Local", ""), "semantic_drift"
+        )
+
+
+class AuthorMatchTests(unittest.TestCase):
+    def test_match_by_full_name(self):
+        article = {"authors": [{"full_name": "Morten Magnusson"}]}
+        self.assertTrue(figshare.author_matches(article))
+
+    def test_match_by_id(self):
+        article = {"authors": [{"id": 20477774}]}
+        self.assertTrue(figshare.author_matches(article))
+
+    def test_no_match(self):
+        article = {"authors": [{"full_name": "Someone Else", "id": 999}]}
+        self.assertFalse(figshare.author_matches(article))
+
+    def test_empty(self):
+        self.assertFalse(figshare.author_matches({}))
+
+
+class WithdrawnDetectionTests(unittest.TestCase):
+    def test_metadata_record_is_withdrawn(self):
+        self.assertTrue(figshare.article_is_withdrawn({"is_metadata_record": True}))
+
+    def test_status_withdrawn(self):
+        self.assertTrue(figshare.article_is_withdrawn({"status": "withdrawn"}))
+
+    def test_normal_article(self):
+        self.assertFalse(figshare.article_is_withdrawn({"status": "public"}))
+
+
+class PrimaryAttachmentTests(unittest.TestCase):
+    def test_pdf_preferred(self):
+        article = {
+            "files": [
+                {"name": "draft.docx", "download_url": "u1"},
+                {"name": "paper.pdf", "download_url": "u2"},
+            ]
+        }
+        self.assertEqual(figshare.primary_attachment(article), ("paper.pdf", "u2"))
+
+    def test_docx_fallback_when_no_pdf(self):
+        article = {"files": [{"name": "Hypothesis.docx", "download_url": "u-docx"}]}
+        self.assertEqual(
+            figshare.primary_attachment(article), ("Hypothesis.docx", "u-docx")
+        )
+
+    def test_other_fallback(self):
+        article = {"files": [{"name": "data.zip", "download_url": "u-zip"}]}
+        self.assertEqual(figshare.primary_attachment(article), ("data.zip", "u-zip"))
+
+    def test_no_files_returns_none(self):
+        self.assertIsNone(figshare.primary_attachment({"files": []}))
+
+
+class CheckOneTests(unittest.TestCase):
+    def _patch_fetch(self, payload, err=None):
+        return mock.patch.object(
+            figshare, "fetch_figshare", return_value=(payload, err)
+        )
+
+    def test_not_found(self):
+        with self._patch_fetch(None, err="not_found"):
+            r = figshare.check_one("10.6084/m9.figshare.123", "Local")
+        self.assertEqual(r["status"], "not_found")
+
+    def test_network_error(self):
+        with self._patch_fetch(None, err="network_unreachable: x"):
+            r = figshare.check_one("10.6084/m9.figshare.123", "Local")
+        self.assertEqual(r["status"], "network_error")
+
+    def test_wrong_author(self):
+        article = {
+            "title": "Local",
+            "authors": [{"full_name": "Other"}],
+            "status": "public",
+        }
+        with self._patch_fetch(article):
+            r = figshare.check_one("10.6084/m9.figshare.123", "Local")
+        self.assertEqual(r["status"], "wrong_author")
+
+    def test_withdrawn(self):
+        article = {
+            "title": "Local",
+            "authors": [{"full_name": "Morten Magnusson"}],
+            "is_metadata_record": True,
+        }
+        with self._patch_fetch(article):
+            r = figshare.check_one("10.6084/m9.figshare.123", "Local")
+        self.assertEqual(r["status"], "withdrawn")
+
+    def test_ok(self):
+        article = {
+            "title": "Local",
+            "authors": [{"full_name": "Morten Magnusson"}],
+            "status": "public",
+        }
+        with self._patch_fetch(article):
+            r = figshare.check_one("10.6084/m9.figshare.123", "Local")
+        self.assertEqual(r["status"], "ok")
+
+    def test_title_mismatch_subclass(self):
+        article = {
+            "title": "Foo Bar",
+            "authors": [{"full_name": "Morten Magnusson"}],
+            "status": "public",
+        }
+        with self._patch_fetch(article):
+            r = figshare.check_one("10.6084/m9.figshare.123", "EFC — Foo Bar")
+        self.assertEqual(r["status"], "title_mismatch")
+        self.assertEqual(r["subclass"], "prefix_efc_dash")
+
+
+class ScaffoldTests(unittest.TestCase):
+    def test_scaffold_creates_canonical_layout(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            with mock.patch.object(figshare, "fetch_figshare", return_value=(None, None)):
+                result = figshare.scaffold_one(
+                    {"figshare_id": 12345, "title": "Test Paper"},
+                    with_pdf=False,
+                    out_root=target,
+                )
+            paper_dir = target / "test-paper"
+            self.assertTrue(paper_dir.is_dir())
+            for fname in (
+                "index.json",
+                "metadata.json",
+                "schema.json",
+                "README.md",
+                "CITATION.cff",
+                "citations.bib",
+                ".scaffolded",
+                "test-paper.jsonld",
+            ):
+                self.assertTrue(
+                    (paper_dir / fname).exists(),
+                    f"missing {fname} in scaffold",
+                )
+            for d in ("src", "data", "examples"):
+                self.assertTrue((paper_dir / d).is_dir())
+            idx = json.loads((paper_dir / "index.json").read_text())
+            self.assertEqual(idx["doi"], "10.6084/m9.figshare.12345")
+            self.assertTrue(idx["scaffolded"])
+            self.assertEqual(result["status"], "scaffolded")
+
+    def test_scaffold_skips_existing(self):
+        from tempfile import TemporaryDirectory
+
+        with TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "test-paper").mkdir()
+            with mock.patch.object(figshare, "fetch_figshare", return_value=(None, None)):
+                result = figshare.scaffold_one(
+                    {"figshare_id": 12345, "title": "Test Paper"},
+                    with_pdf=False,
+                    out_root=target,
+                )
+        self.assertEqual(result["status"], "exists")
+
+
+class CmdCheckIntegrationTests(unittest.TestCase):
+    def test_network_only_returns_zero(self):
+        # Patch DOI_MAP to a tiny fake
+        from tempfile import NamedTemporaryFile
+
+        fake_map = {
+            "papers": [
+                {
+                    "doi": "10.6084/m9.figshare.111",
+                    "title": "Some Paper",
+                }
+            ],
+            "missing_repo_dirs": [],
+        }
+        with NamedTemporaryFile("w", suffix=".json", delete=False) as fh:
+            json.dump(fake_map, fh)
+            tmp_path = Path(fh.name)
+        try:
+            with (
+                mock.patch.object(figshare, "DOI_MAP", tmp_path),
+                mock.patch.object(figshare, "REPORTS_DIR", tmp_path.parent),
+                mock.patch.object(
+                    figshare,
+                    "fetch_figshare",
+                    return_value=(None, "network_unreachable: sandbox"),
+                ),
+            ):
+                rc = figshare.cmd_check(json_out=False)
+            self.assertEqual(rc, 0)  # network-only does not gate
+        finally:
+            os.unlink(tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements **§6 C4** of the EFC Master Sync-Protocol — the figshare DOI presence-check that closes the last open CI guard in the cross-validation ring.

## What it does

Verifies, for every DOI the repo claims, that:
1. Figshare returns **200 OK** for the article (`not_found` if not)
2. **Morten Magnusson** appears in `authors[]` (`wrong_author` if not — catches DOI typos and homonym trap)
3. Article isn't `withdrawn` / `is_metadata_record`
4. **Title matches** the local doi-map record, with sub-classification of any mismatch

## Files

| File | Role |
|---|---|
| `scripts/maintenance/efc_figshare_check.py` | `--check` / `--scaffold-missing` / `--with-pdf` / `--json` |
| `tests/test_efc_figshare_check.py` | 28 tests, fully offline (mocked figshare) |
| `.github/workflows/efc-figshare-presence.yml` | Mondays 05:00 UTC + PR + manual dispatch |
| `reports/figshare-check.json` | Sandbox baseline (all `network_error`; will be replaced on first CI run) |

## Title-mismatch classifier (sub-buckets)

| Sub-class | Action |
|---|---|
| `prefix_efc_dash` | Trivial — local "EFC —" prefix that figshare lacks |
| `prefix_white_paper` | Trivial — remote "White Paper - Part X of Y -" prefix |
| `truncation_local` / `truncation_remote` | Extend shorter side |
| `truncation_after_prefix_strip` | Equivalent after stripping common prefixes |
| `semantic_drift` | Per-case review needed |

## Failure semantics

- Hard-fail (exit 2) on `not_found`, `withdrawn`, `wrong_author` — blocks PR.
- Title mismatches reported via artifact, never block on their own.
- Network-only failure → skip-gate (exit 0). Transient figshare outages can't wedge CI.

## DOI 28557281 versioning case

Figshare API returns the v1 title ("The Grid Model as a Structural Framework") while local map records the v3-iteration ("EFC — Hypothesis: Interrelation Between Energy and Entropy"). Symbiose Neo4j has both. Will surface as `semantic_drift` in the report — needs maintainer policy decision (track `current_version` vs `frozen_version`).

## Test plan

- [x] 28/28 unit tests pass
- [x] `--check` runs gracefully in sandboxed env (all → `network_error`, exit 0)
- [x] `--scaffold-missing` creates canonical 10-file layout with `.scaffolded` marker
- [x] PDF / DOCX / fallback selection covered by tests
- [ ] First scheduled CI run produces real report (non-network-error)
- [ ] PR-trigger fires on `figshare/doi-map.json` change
