### PR TITLE
Make canonical 12-item navbar the single source of truth

### DIFF
--- a/docs/public/EFC_Atlas.html
+++ b/docs/public/EFC_Atlas.html
@@ -188,7 +188,7 @@
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
-  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Atlas</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
 

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -80,7 +80,7 @@
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
-  <a href="EFC_Changelog.html" style="font-weight:600; color:#c22;">Changelog</a>
+  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
 
 <p>Complete changelog for the Energy-Flow Cosmology Validation Ledger, documenting all structural, methodological, and empirical updates since inception.</p>

--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -122,7 +122,7 @@
 <h1>Energy-Flow Cosmology &mdash; A 60-Second Version</h1>
 
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
-  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Pitch</a>
+  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>

--- a/docs/public/EFC_Evaluation_Ledger.html
+++ b/docs/public/EFC_Evaluation_Ledger.html
@@ -41,7 +41,7 @@
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
-  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Evaluation</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>

--- a/docs/public/EFC_External_Research_Ledger.html
+++ b/docs/public/EFC_External_Research_Ledger.html
@@ -81,7 +81,7 @@ footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7e3;
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
-  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">External</a>
+  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>

--- a/docs/public/EFC_Gap_Analysis.html
+++ b/docs/public/EFC_Gap_Analysis.html
@@ -103,7 +103,7 @@
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
-  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Gaps</a>
+  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>

--- a/docs/public/EFC_Likelihood_Ledger.html
+++ b/docs/public/EFC_Likelihood_Ledger.html
@@ -52,7 +52,7 @@
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
-  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Likelihood</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>

--- a/docs/public/EFC_Model_Comparison.html
+++ b/docs/public/EFC_Model_Comparison.html
@@ -46,7 +46,7 @@
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
-  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Models</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>

--- a/docs/public/EFC_Predictions.html
+++ b/docs/public/EFC_Predictions.html
@@ -115,7 +115,7 @@
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
-  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Predictions</a>
+  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>

--- a/docs/public/EFC_Stage-IV_Data_Roadmap.html
+++ b/docs/public/EFC_Stage-IV_Data_Roadmap.html
@@ -150,7 +150,7 @@
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
-  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Roadmap</a>
+  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>

--- a/docs/public/EFC_Validation_Ledger.html
+++ b/docs/public/EFC_Validation_Ledger.html
@@ -93,7 +93,7 @@
 
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
-  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Validation</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>

--- a/docs/public/EFC_White_Paper_Series.html
+++ b/docs/public/EFC_White_Paper_Series.html
@@ -140,7 +140,7 @@
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
-  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">White Paper</a>
+  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>

--- a/scripts/build_atlas.py
+++ b/scripts/build_atlas.py
@@ -247,7 +247,10 @@ HTML_TEMPLATE = r"""<!doctype html>
 
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
-  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Ledger</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>

--- a/scripts/maintenance/_nav_helper.py
+++ b/scripts/maintenance/_nav_helper.py
@@ -6,9 +6,10 @@ ensure_nav(content) before writing, so the nav block is normalized
 to the current canonical form. Idempotent and safe to run every write.
 
 This guarantees:
-  - Short labels (Pitch, Ledger, White Paper, Roadmap, Gaps, ...)
-  - External Research link present
-  - Consistent ordering across all ledgers
+  - Same 12 labels in the same order across every public page
+    (Pitch, Validation, Likelihood, Evaluation, Models, White Paper,
+    Roadmap, Gaps, External, Predictions, Atlas, Changelog)
+  - All cross-section ledgers reachable from any page
 """
 from __future__ import annotations
 import re
@@ -19,12 +20,16 @@ CANONICAL_NAV_HTML = (
     'border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; '
     'font-size:0.92rem;">\n'
     '  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>\n'
-    '  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Ledger</a>\n'
+    '  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>\n'
+    '  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>\n'
+    '  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>\n'
+    '  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>\n'
     '  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>\n'
     '  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>\n'
     '  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>\n'
-    '  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External Research</a>\n'
+    '  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>\n'
     '  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>\n'
+    '  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>\n'
     '  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>\n'
     '</div>'
 )


### PR DESCRIPTION
## Summary

Follow-up to #272, fixing two stability issues uncovered by the post-merge CI.

1. **`atlas-verify` was failing** on #272 because `docs/public/EFC_Atlas.html` is auto-generated by `scripts/build_atlas.py`, and a fresh rebuild reverted the navbar to the old 9-item form. Update the navbar template inside `build_atlas.py` to emit the canonical 12-item navbar.
2. **`scripts/maintenance/_nav_helper.py`** owns the canonical navbar used by every renderer that writes auto-generated public pages (Validation Ledger, Changelog, Roadmap, White Paper, Pitch, Gap Analysis) via `ensure_nav()`. Its `CANONICAL_NAV_HTML` still held the old 9-item form, so the next maintenance pass would have wiped out #272 on each of those pages. Update `CANONICAL_NAV_HTML` to the new 12-item form.

Also drop the per-page `color:#c22` highlights so every page is byte-for-byte identical in the nav block — single source of truth, fully idempotent under both `ensure_nav()` and `build_atlas.py`.

## Verified locally

- `python3 scripts/build_atlas.py` → 0 diff against the committed `EFC_Atlas.html`
- `python3 scripts/maintenance/efc_verify.py` → 0 errors
- `python3 scripts/maintenance/efc_drift_detector.py` → only pre-existing changelog count drift (downgraded to warning by `efc-verify.yml`)
- `python3 scripts/maintenance/efc_sync_dois.py --check` → no conflicts
- `ensure_nav()` applied to every page is idempotent

## Test plan
- [ ] `atlas-verify` workflow goes green
- [ ] `efc-verify` workflow goes green
- [ ] All 12 public pages show the same 12 nav links in the same order

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqDFwUNs6YsBuHETUaukgr)_