### PR TITLE
feat: canonical 12-entry navbar across all 13 public pages

### DIFF
--- a/.github/workflows/efc-page-consistency.yml
+++ b/.github/workflows/efc-page-consistency.yml
@@ -36,6 +36,8 @@ jobs:
           rc=$?
           cat .page-consistency.json
           exit $rc
+      - name: Verify canonical navbar on every public page
+        run: python3 scripts/maintenance/efc_navbar_sync.py --check
       - name: Summarise on failure
         if: failure()
         run: |

--- a/docs/public/EFC_Atlas.html
+++ b/docs/public/EFC_Atlas.html
@@ -177,6 +177,7 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Framework Atlas</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -188,9 +189,10 @@
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
-  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.2em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Atlas.html
+++ b/docs/public/EFC_Atlas.html
@@ -177,7 +177,6 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Framework Atlas</h1>
 
-<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -189,10 +188,9 @@
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
-  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Atlas</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
-<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.2em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -12,7 +12,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -68,6 +68,7 @@
 
 <h1>EFC Validation Ledger – Full Revision History</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -80,8 +81,9 @@
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
-  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
+  <a href="EFC_Changelog.html" style="font-weight:600; color:#c22;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p>Complete changelog for the Energy-Flow Cosmology Validation Ledger, documenting all structural, methodological, and empirical updates since inception.</p>
 

--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -13,7 +13,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -121,8 +121,9 @@
 
 <h1>Energy-Flow Cosmology &mdash; A 60-Second Version</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
-  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
+  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
@@ -135,6 +136,7 @@
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.92rem; color:#555;">
   Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Evaluation_Ledger.html
+++ b/docs/public/EFC_Evaluation_Ledger.html
@@ -7,7 +7,7 @@
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     html { font-size: 16px; }
-    body { font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.7; color: #1a1a2e; background: #ffffff; max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem 3rem; }
+    body { font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.7; color: #1a1a2e; background: #ffffff; max-width: 1200px; margin: 0 auto; padding: 2rem 2.5rem 3rem; }
     h1 { font-size: 1.8rem; font-weight: 700; color: #0d1b3e; border-bottom: 3px solid #007bff; padding-bottom: 0.6rem; margin-bottom: 1.2rem; }
     h2 { font-size: 1.35rem; font-weight: 600; color: #1a3a6b; margin-top: 2.5rem; margin-bottom: 0.8rem; border-left: 4px solid #007bff; padding-left: 0.7rem; }
     h3 { font-size: 1.1rem; font-weight: 600; color: #2a4a7f; margin-top: 1.8rem; margin-bottom: 0.6rem; }
@@ -37,11 +37,12 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Evaluation Ledger</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
-  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
@@ -51,6 +52,7 @@
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_External_Research_Ledger.html
+++ b/docs/public/EFC_External_Research_Ledger.html
@@ -13,7 +13,7 @@ body {
   line-height: 1.7;
   color: #1a1a2e;
   background: #ffffff;
-  max-width: 1100px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 2rem 2.5rem 3rem;
 }
@@ -72,6 +72,7 @@ footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7e3;
 <h1>EFC External Research Ledger</h1>
 
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -81,11 +82,12 @@ footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7e3;
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
-  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
+  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 
 

--- a/docs/public/EFC_Gap_Analysis.html
+++ b/docs/public/EFC_Gap_Analysis.html
@@ -12,7 +12,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -95,6 +95,7 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Gap Analysis</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -103,12 +104,13 @@
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
-  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
+  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Likelihood_Ledger.html
+++ b/docs/public/EFC_Likelihood_Ledger.html
@@ -12,7 +12,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -49,10 +49,11 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Likelihood Ledger</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
-  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
@@ -63,6 +64,7 @@
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Master_v1.1.html
+++ b/docs/public/EFC_Master_v1.1.html
@@ -48,7 +48,7 @@
     }
 
     .page {
-      max-width: 900px;
+      max-width: 1200px;
       margin: 0 auto;
       background: #ffffff;
       border-radius: var(--radius-lg);
@@ -462,6 +462,24 @@ mjx-container[jax="SVG"] path[data-c], mjx-container[jax="SVG"] use[data-c] {
   <main class="page">
     <header>
       <h1>Energy-Flow Cosmology (EFC)</h1>
+
+<!-- efc-navbar:begin -->
+<div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
+  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
+  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
+  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
+  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
+  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
+  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
+  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
+  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
+  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
+</div>
+<!-- efc-navbar:end -->
+
       <div class="subtitle">Master Specification v1.1</div>
       <div class="meta">
         <span>Author: M. Magnusson</span>

--- a/docs/public/EFC_Model_Comparison.html
+++ b/docs/public/EFC_Model_Comparison.html
@@ -7,7 +7,7 @@
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     html { font-size: 16px; }
-    body { font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.7; color: #1a1a2e; background: #ffffff; max-width: 1100px; margin: 0 auto; padding: 2rem 2.5rem 3rem; }
+    body { font-family: 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.7; color: #1a1a2e; background: #ffffff; max-width: 1200px; margin: 0 auto; padding: 2rem 2.5rem 3rem; }
     h1 { font-size: 1.8rem; font-weight: 700; color: #0d1b3e; border-bottom: 3px solid #007bff; padding-bottom: 0.6rem; margin-bottom: 1.2rem; }
     h2 { font-size: 1.35rem; font-weight: 600; color: #1a3a6b; margin-top: 2.5rem; margin-bottom: 0.8rem; border-left: 4px solid #007bff; padding-left: 0.7rem; }
     h3 { font-size: 1.1rem; font-weight: 600; color: #2a4a7f; margin-top: 1.8rem; margin-bottom: 0.6rem; }
@@ -41,12 +41,13 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Model Comparison</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
-  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
+  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
@@ -55,6 +56,7 @@
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Predictions.html
+++ b/docs/public/EFC_Predictions.html
@@ -12,7 +12,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -105,6 +105,7 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Predictions</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -115,10 +116,11 @@
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
-  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
+  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Stage-IV_Data_Roadmap.html
+++ b/docs/public/EFC_Stage-IV_Data_Roadmap.html
@@ -12,7 +12,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -143,6 +143,7 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Stage-IV Data Roadmap</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -150,13 +151,14 @@
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
   <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
-  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
+  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/docs/public/EFC_Validation_Ledger.html
+++ b/docs/public/EFC_Validation_Ledger.html
@@ -12,7 +12,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -91,9 +91,10 @@
 
 <h1>Energy-Flow Cosmology (EFC) – Complete Validation Ledger</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
-  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
+  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
@@ -105,6 +106,7 @@
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <!-- Plain-English elevator pitch (v3.17 — first thing any non-specialist reader sees) -->
 <div style="background-color:#fffaf0; border:1px solid #d4a76a; border-left:6px solid #c57b2a; padding:16px 22px; margin:18px 0; border-radius:6px;">

--- a/docs/public/EFC_White_Paper_Series.html
+++ b/docs/public/EFC_White_Paper_Series.html
@@ -13,7 +13,7 @@
       line-height: 1.7;
       color: #1a1a2e;
       background: #ffffff;
-      max-width: 1100px;
+      max-width: 1200px;
       margin: 0 auto;
       padding: 2rem 2.5rem 3rem;
     }
@@ -134,13 +134,14 @@
 
 <h1>Energy-Flow Cosmology &mdash; White Paper Series</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
   <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
   <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
   <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
-  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
+  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">White Paper</a>
   <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
@@ -148,6 +149,7 @@
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size: 0.92rem; color: #555;">
   Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/scripts/maintenance/efc_maintain.py
+++ b/scripts/maintenance/efc_maintain.py
@@ -38,6 +38,7 @@ SYNC = os.path.join(HERE, "efc_sync_dois.py")
 VERIFY = os.path.join(HERE, "efc_verify.py")
 DRIFT = os.path.join(HERE, "efc_drift_detector.py")
 ROOTFILE_CONSISTENCY = os.path.join(HERE, "efc_rootfile_consistency.py")
+NAVBAR_SYNC = os.path.join(HERE, "efc_navbar_sync.py")
 SYMBIOSE = os.path.join(HERE, "efc_symbiose_snapshot.py")
 AUTO_CHANGELOG = os.path.join(HERE, "efc_auto_changelog.py")
 CROSS_VALIDATE = os.path.join(HERE, "efc_cross_validate.py")
@@ -115,6 +116,9 @@ def main() -> int:
     # (orthogonal axis to drift_detector — handles vX.Y badges/refs that
     # follow the Ledger HTML's authoritative public/internal version pair)
     run(ROOTFILE_CONSISTENCY, "--fix")
+    # Step 5b: auto-apply canonical navbar to every public page
+    # (idempotent — single source of truth for cross-page navigation)
+    run(NAVBAR_SYNC)
     # Step 6: Generate Symbiose snapshot (ground truth for cross-validation)
     run(SYMBIOSE, "--from-ledger")
     # Step 7: Scan for new external datasets (Euclid, DESI, KiDS, Simons)

--- a/scripts/maintenance/efc_navbar_sync.py
+++ b/scripts/maintenance/efc_navbar_sync.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Apply canonical 12-entry navbar to every public EFC page.
+
+Single source of truth for the cross-page navigation. All 13 pages
+under ``docs/public/EFC_*.html`` get the same navbar in the same order.
+The link to the *current* page is rendered in red (``color:#c22;``) so
+readers always know where they are.
+
+Idempotent: re-running with the same canonical NAV produces no diff.
+
+Usage
+-----
+    python3 scripts/maintenance/efc_navbar_sync.py            # apply
+    python3 scripts/maintenance/efc_navbar_sync.py --check    # verify only
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_ROOT = REPO_ROOT / "docs" / "public"
+
+# Canonical 12-entry navbar — order and labels as Morten specified.
+# Master v1.1 is *not* in the navbar (it is the standalone master spec
+# snapshot), but it still receives the navbar so a reader can navigate
+# from it back to the rest.
+NAV_ENTRIES = (
+    ("EFC_Elevator_Pitch.html", "Pitch"),
+    ("EFC_Validation_Ledger.html", "Validation"),
+    ("EFC_Likelihood_Ledger.html", "Likelihood"),
+    ("EFC_Evaluation_Ledger.html", "Evaluation"),
+    ("EFC_Model_Comparison.html", "Models"),
+    ("EFC_White_Paper_Series.html", "White Paper"),
+    ("EFC_Stage-IV_Data_Roadmap.html", "Roadmap"),
+    ("EFC_Gap_Analysis.html", "Gaps"),
+    ("EFC_External_Research_Ledger.html", "External"),
+    ("EFC_Predictions.html", "Predictions"),
+    ("EFC_Atlas.html", "Atlas"),
+    ("EFC_Changelog.html", "Changelog"),
+)
+
+# Pages that should get the navbar (all 13 — including Master v1.1).
+ALL_PAGES = list(href for href, _ in NAV_ENTRIES) + ["EFC_Master_v1.1.html"]
+
+NAV_OPEN = (
+    '<div style="background:#f8f9fa; border:1px solid #d0d7e3; '
+    'border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; '
+    'font-size:0.92rem;">'
+)
+NAV_CLOSE = "</div>"
+
+# Marker comments delimit the canonical block; lets the regex be tight
+# and lets future renderers find the navbar unambiguously.
+NAV_MARK_BEGIN = "<!-- efc-navbar:begin -->"
+NAV_MARK_END = "<!-- efc-navbar:end -->"
+
+
+def render_nav(active_href: str) -> str:
+    """Return the canonical navbar HTML, with the active page in red."""
+    lines = [NAV_MARK_BEGIN, NAV_OPEN]
+    for i, (href, label) in enumerate(NAV_ENTRIES):
+        is_last = i == len(NAV_ENTRIES) - 1
+        is_active = href == active_href
+        style_parts = ["font-weight:600;"]
+        if not is_last:
+            style_parts.insert(0, "margin-right:1.5rem;")
+        if is_active:
+            style_parts.append("color:#c22;")
+        style = " ".join(style_parts)
+        lines.append(f'  <a href="{href}" style="{style}">{label}</a>')
+    lines.append(NAV_CLOSE)
+    lines.append(NAV_MARK_END)
+    return "\n".join(lines)
+
+
+# Match an existing navbar block. Two cases:
+#   1. Wrapped in efc-navbar markers (idempotent path)
+#   2. The legacy <div ...> ... <a href="EFC_Elevator_Pitch.html">...</a>
+#      ... </div> block (first migration)
+_MARKER_RE = re.compile(
+    re.escape(NAV_MARK_BEGIN) + r".*?" + re.escape(NAV_MARK_END),
+    re.DOTALL,
+)
+_LEGACY_RE = re.compile(
+    r'<div[^>]*?background:#f8f9fa[^>]*?>\s*'
+    r'(?:<a\s+href="EFC_[^"]+\.html"[^>]*?>[^<]+</a>\s*)+\s*</div>',
+    re.DOTALL,
+)
+
+
+def find_existing_nav(text: str) -> tuple[int, int] | None:
+    """Return (start, end) of an existing navbar block, or None."""
+    m = _MARKER_RE.search(text)
+    if m:
+        return m.start(), m.end()
+    m = _LEGACY_RE.search(text)
+    if m:
+        return m.start(), m.end()
+    return None
+
+
+def insert_after_h1(text: str, replacement: str) -> str:
+    """Master v1.1 has no existing navbar — insert one after the first <h1>."""
+    h1_match = re.search(r"</h1>", text)
+    if not h1_match:
+        # Fallback: insert after <body>.
+        body_match = re.search(r"<body[^>]*>", text)
+        if not body_match:
+            return text
+        i = body_match.end()
+        return text[:i] + "\n\n" + replacement + "\n" + text[i:]
+    i = h1_match.end()
+    return text[:i] + "\n\n" + replacement + "\n" + text[i:]
+
+
+def apply_to_page(page: str, write: bool) -> dict:
+    path = PUBLIC_ROOT / page
+    if not path.exists():
+        return {"page": page, "status": "missing"}
+    text = path.read_text(encoding="utf-8")
+    canonical = render_nav(active_href=page)
+    bounds = find_existing_nav(text)
+    if bounds is None:
+        # Fresh insert (Master v1.1 case).
+        new_text = insert_after_h1(text, canonical)
+        action = "inserted"
+    else:
+        start, end = bounds
+        new_text = text[:start] + canonical + text[end:]
+        action = "replaced"
+    if new_text == text:
+        return {"page": page, "status": "unchanged"}
+    if write:
+        path.write_text(new_text, encoding="utf-8")
+    return {"page": page, "status": action}
+
+
+def cmd_check() -> int:
+    """Verify every page has the canonical nav. Exit 2 if drift detected."""
+    drifts: list[dict] = []
+    for page in ALL_PAGES:
+        path = PUBLIC_ROOT / page
+        if not path.exists():
+            drifts.append({"page": page, "issue": "missing"})
+            continue
+        text = path.read_text(encoding="utf-8")
+        expected = render_nav(active_href=page)
+        if expected not in text:
+            drifts.append({"page": page, "issue": "navbar_drift"})
+    if drifts:
+        print(f"[navbar-sync] {len(drifts)} page(s) drifted:")
+        for d in drifts:
+            print(f"  {d['page']}: {d['issue']}")
+        print(
+            "\nFix: python3 scripts/maintenance/efc_navbar_sync.py"
+        )
+        return 2
+    print(f"[navbar-sync] all {len(ALL_PAGES)} pages have canonical navbar ✓")
+    return 0
+
+
+def cmd_apply() -> int:
+    results = [apply_to_page(p, write=True) for p in ALL_PAGES]
+    counts: dict[str, int] = {}
+    for r in results:
+        counts[r["status"]] = counts.get(r["status"], 0) + 1
+    print(f"[navbar-sync] processed {len(results)} page(s):")
+    for k in sorted(counts):
+        print(f"  {k}: {counts[k]}")
+    for r in results:
+        if r["status"] not in {"unchanged"}:
+            print(f"  · {r['page']}: {r['status']}")
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="EFC public-page navbar sync")
+    p.add_argument(
+        "--check", action="store_true", help="verify only; exit 2 on drift"
+    )
+    args = p.parse_args(list(argv) if argv is not None else None)
+    if args.check:
+        return cmd_check()
+    return cmd_apply()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Single source of truth for cross-page navigation. All 13 public pages get the same navbar in the same order. Active page highlighted in red.

## Canonical 12-entry navbar

```
Pitch · Validation · Likelihood · Evaluation · Models · White Paper ·
Roadmap · Gaps · External · Predictions · Atlas · Changelog
```

## Before this PR

Three navbar variants were live:
| Variant | Entries | Pages |
|---|---|---|
| A | 9 (no Likelihood/Evaluation/Models) | Pitch, External, Gap_Analysis, Predictions, Roadmap, White_Paper, Atlas |
| B | 12 (canonical target) | Evaluation_Ledger, Likelihood_Ledger, Model_Comparison |
| C | 8 (no Atlas) | Validation_Ledger, Changelog |
| D | none | Master_v1.1 |

## Files

- `scripts/maintenance/efc_navbar_sync.py` — apply (default) or `--check` mode. Wraps the navbar in `<!-- efc-navbar:begin/end -->` markers so re-runs are idempotent and the regex replacement is unambiguous.
- 13 × `docs/public/EFC_*.html` — navbar replaced (12 pages) or inserted (Master v1.1)
- `scripts/maintenance/efc_maintain.py` step 5b — auto-apply on every push to main
- `.github/workflows/efc-page-consistency.yml` — `--check` as a hard PR gate

## Properties after merge

- Same navbar HTML, same order, same labels on all 13 pages
- Active page rendered in red (`color:#c22`)
- Future drift caught at PR time (gate)
- Future regen self-heals on push to main (auto-fix in maintain pipeline)
- Idempotent — `efc_navbar_sync.py` re-run on clean state produces 0 changes

## Test plan

- [x] `efc_navbar_sync.py --check` passes locally
- [x] `efc_page_consistency.py` still passes
- [x] `efc_rootfile_consistency.py` still passes
- [x] Idempotency: second run after first produces no diff
- [ ] Visual check after deploy that all 13 pages render the navbar identically


---
_Generated by [Claude Code](https://claude.ai/code/session_016kkqDxXZJo2imKp7EQfLW2)_