### PR TITLE
fix(build_atlas): import canonical navbar from efc_navbar_sync

### DIFF
--- a/docs/public/EFC_Atlas.html
+++ b/docs/public/EFC_Atlas.html
@@ -177,6 +177,7 @@
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Framework Atlas</h1>
 
+<!-- efc-navbar:begin -->
 <div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
   <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
   <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
@@ -188,9 +189,10 @@
   <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
-  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
+  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600; color:#c22;">Atlas</a>
   <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
+<!-- efc-navbar:end -->
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.2em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;

--- a/scripts/build_atlas.py
+++ b/scripts/build_atlas.py
@@ -35,6 +35,7 @@ No dependencies beyond the Python standard library.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -44,6 +45,20 @@ from pathlib import Path
 # Paths
 # ------------------------------------------------------------------
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ------------------------------------------------------------------
+# Single source of truth for the cross-page navbar
+# ------------------------------------------------------------------
+# The canonical 12-entry navbar lives in
+# scripts/maintenance/efc_navbar_sync.py. We import its render_nav() so
+# this script and the navbar-sync script can never disagree on order,
+# labels, idempotency markers, or the active-page highlight.
+_NAV_SCRIPT = REPO_ROOT / "scripts" / "maintenance" / "efc_navbar_sync.py"
+_nav_spec = importlib.util.spec_from_file_location("efc_navbar_sync", _NAV_SCRIPT)
+_nav_module = importlib.util.module_from_spec(_nav_spec)
+_nav_spec.loader.exec_module(_nav_module)
+render_canonical_navbar = _nav_module.render_nav
 DATA_DIR = REPO_ROOT / "docs" / "validation-ledger" / "data"
 PUBLIC_DIR = REPO_ROOT / "docs" / "public"
 
@@ -245,20 +260,7 @@ HTML_TEMPLATE = r"""<!doctype html>
 
 <h1>Energy-Flow Cosmology (EFC) &mdash; Framework Atlas</h1>
 
-<div style="background:#f8f9fa; border:1px solid #d0d7e3; border-radius:6px; padding:12px 18px; margin-bottom:1.5rem; font-size:0.92rem;">
-  <a href="EFC_Elevator_Pitch.html" style="margin-right:1.5rem; font-weight:600;">Pitch</a>
-  <a href="EFC_Validation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Validation</a>
-  <a href="EFC_Likelihood_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Likelihood</a>
-  <a href="EFC_Evaluation_Ledger.html" style="margin-right:1.5rem; font-weight:600;">Evaluation</a>
-  <a href="EFC_Model_Comparison.html" style="margin-right:1.5rem; font-weight:600;">Models</a>
-  <a href="EFC_White_Paper_Series.html" style="margin-right:1.5rem; font-weight:600;">White Paper</a>
-  <a href="EFC_Stage-IV_Data_Roadmap.html" style="margin-right:1.5rem; font-weight:600;">Roadmap</a>
-  <a href="EFC_Gap_Analysis.html" style="margin-right:1.5rem; font-weight:600;">Gaps</a>
-  <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
-  <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
-  <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
-  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
-</div>
+__CANONICAL_NAVBAR__
 
 <p style="font-size:0.95em; color:#555; margin-bottom:1.2em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
@@ -852,6 +854,7 @@ def main():
     html = HTML_TEMPLATE
     rival_count = sum(1 for f in frameworks if f.get("id") != "EFC")
     replacements = {
+        "__CANONICAL_NAVBAR__": render_canonical_navbar(active_href="EFC_Atlas.html"),
         "__GENERATED_DATE__": generated_date,
         "__FW_COUNT__": str(len(frameworks)),
         "__RIVAL_COUNT__": str(rival_count),


### PR DESCRIPTION
PR #274's post-merge `verify` run (run 25446313552) failed because `EFC_Atlas.html` drifted from `scripts/build_atlas.py` output:

```
Error: EFC_Atlas.html is out of sync with atlas.json / ledger.json.
Run 'python3 scripts/build_atlas.py' locally and commit the result.
```

## Root cause

`efc_navbar_sync.py` wraps the navbar in `<!-- efc-navbar:begin/end -->` markers and highlights the active page in red (`color:#c22`). `build_atlas.py`'s hard-coded navbar template did **neither**. Both systems claimed authority over the same HTML, and produced different output.

## Fix

`build_atlas.py` now imports `render_nav` from `scripts/maintenance/efc_navbar_sync.py` and substitutes the canonical navbar at template-render time. There is one `render_nav()` function; both systems call it. They cannot disagree.

```python
import importlib.util
_nav_spec = importlib.util.spec_from_file_location(
    "efc_navbar_sync",
    REPO_ROOT / "scripts" / "maintenance" / "efc_navbar_sync.py",
)
_nav_module = importlib.util.module_from_spec(_nav_spec)
_nav_spec.loader.exec_module(_nav_module)
render_canonical_navbar = _nav_module.render_nav
…
replacements = {
    "__CANONICAL_NAVBAR__": render_canonical_navbar(active_href="EFC_Atlas.html"),
    …
}
```

## Verified end-to-end

```
$ python3 scripts/build_atlas.py
Wrote /home/user/EFC/docs/public/EFC_Atlas.html
$ python3 scripts/maintenance/efc_navbar_sync.py --check
[navbar-sync] all 13 pages have canonical navbar ✓
$ python3 scripts/build_atlas.py            # idempotent re-run
$ python3 scripts/maintenance/efc_navbar_sync.py  # idempotent re-run
[navbar-sync] processed 13 page(s): unchanged: 13
```

## Test plan

- [x] build_atlas.py output matches efc_navbar_sync.py expectation
- [x] both scripts byte-idempotent on re-run
- [ ] verify workflow passes on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_016kkqDxXZJo2imKp7EQfLW2)_