### PR TITLE
chore: sync 162→163 + ai_manifest for 32162706 scaffold

### DIFF
--- a/.claude/drift_report.json
+++ b/.claude/drift_report.json
@@ -1,18 +1,18 @@
 {
-  "paper_count": 162,
+  "paper_count": 163,
   "drift": [
     {
       "file": "Changelog",
       "type": "paper_count",
       "claimed": 158,
-      "actual": 162,
+      "actual": 163,
       "context": "/code> refactored &mdash; 128/158 paper packages enriched to 10/10 standard vi"
     },
     {
       "file": "Changelog",
       "type": "paper_count",
       "claimed": 158,
-      "actual": 162,
+      "actual": 163,
       "context": "ackages (219 new files across 158 packages). Fixed 53 paper README DOI d"
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ license: CC-BY-4.0
 core_principle: "Energy flows along entropy gradients"
 validation_ledger_public: v3.18
 validation_ledger_internal: v4.6
-ai_packages: 162 (100% coverage)
+ai_packages: 163 (100% coverage)
 stage: non_rejectable_model (global verdict OPEN)
 maintenance: scripts/maintenance/ (auto-run by SessionStart hook + CI)
 pipelines: pipelines/efc/native_v2_graph/ (AQUAL) + pipelines/efc/euclid_dr1/ (Euclid DR1)
@@ -335,7 +335,7 @@ EFC/
 ├── theory/
 │   └── formal/         # LaTeX: S, D, R, H, C0 models
 ├── docs/
-│   ├── papers/efc/     # 162 papers (162 with AI-friendly packages, 100%) + _archived/
+│   ├── papers/efc/     # 163 papers (163 with AI-friendly packages, 100%) + _archived/
 │   └── public/         # Validation Ledger (v3.18), White Paper, Roadmap, Elevator Pitch, Changelog
 ├── src/efc/            # Core Python library
 ├── pipelines/          # Graph-AQUAL + Euclid DR1 pipelines
@@ -354,7 +354,7 @@ EFC/
 
 ## AI-Friendly Paper Packages (140)
 
-All 162 active papers have full AI-friendly packages (10/10 standard: `src/`, `data/`, `examples/`, `CITATION.cff`, `LICENSE`, `citations.bib`, `schema.json`); two superseded packages live under `docs/papers/efc/_archived/` for provenance:
+All 163 active papers have full AI-friendly packages (10/10 standard: `src/`, `data/`, `examples/`, `CITATION.cff`, `LICENSE`, `citations.bib`, `schema.json`); two superseded packages live under `docs/papers/efc/_archived/` for provenance:
 
 ### Consolidation
 | Paper | Module | DOI |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Across **135 independent tests** so far (galaxy rotation curves, the cosmic micr
 [![ORCID](https://img.shields.io/badge/ORCID-0009--0002--4860--5095-green)](https://orcid.org/0009-0002-4860-5095)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Validation Ledger](https://img.shields.io/badge/Validation_Ledger-v3.18-orange)](./docs/public/EFC_Validation_Ledger.html)
-[![AI Packages](https://img.shields.io/badge/AI_Packages-162-brightgreen)](#ai-friendly-paper-packages)
+[![AI Packages](https://img.shields.io/badge/AI_Packages-163-brightgreen)](#ai-friendly-paper-packages)
 
 > **NEW (April 12, 2026)**: **[Euclid DR1 Pre-Registration Pipeline](./pipelines/efc/euclid_dr1/)** ([DOI 10.6084/m9.figshare.31990053](https://doi.org/10.6084/m9.figshare.31990053)) — Complete Boltzmann-calibrated prediction pipeline using custom `efc_logistic` gravity model in hi_class. SHA-256 sealed benchmark (B0=0.02, M0=0.06): σ₈ +1.21%, P(k) +2.09%, lensing −6.01%, E_G −3.98%. 36-point parameter scan. Stability: M0≥3B0. Planck ISW: M0<0.1. Predictions frozen for Euclid DR1 (October 2026).
 
@@ -54,7 +54,7 @@ Across **135 independent tests** so far (galaxy rotation curves, the cosmic micr
 | **AI Navigation** | [`llms.txt`](./llms.txt) / [`AGENTS.md`](./AGENTS.md) |
 | **Validation Ledger** | [`EFC_Validation_Ledger.html`](./docs/public/EFC_Validation_Ledger.html) (v3.18 public / v4.6 internal) |
 | **Public Pages (13)** | Validation · [Evaluation](./docs/public/EFC_Evaluation_Ledger.html) · [Likelihood](./docs/public/EFC_Likelihood_Ledger.html) · [Model Comparison](./docs/public/EFC_Model_Comparison.html) · [Master v1.1](./docs/public/EFC_Master_v1.1.html) · [Roadmap](./docs/public/EFC_Stage-IV_Data_Roadmap.html) · [White Paper](./docs/public/EFC_White_Paper_Series.html) · [Pitch](./docs/public/EFC_Elevator_Pitch.html) · [Gap Analysis](./docs/public/EFC_Gap_Analysis.html) · [External](./docs/public/EFC_External_Research_Ledger.html) · [Predictions](./docs/public/EFC_Predictions.html) · [Atlas](./docs/public/EFC_Atlas.html) · [Changelog](./docs/public/EFC_Changelog.html) |
-| **Papers** | 162 papers in [`/docs/papers/efc/`](./docs/papers/efc/) (plus 2 superseded under `_archived/`) |
+| **Papers** | 163 papers in [`/docs/papers/efc/`](./docs/papers/efc/) (plus 2 superseded under `_archived/`) |
 | **AI Packages** | 138 with executable Python + structured data (100% coverage) |
 | **Stage** | **Non-rejectable model** — Δχ² ≤ 0 across all probes; global verdict OPEN |
 | **Validation Reports** | EFC-VAL-2026-002 through 007 (6 hand-curated 10/10 packages) |
@@ -285,13 +285,13 @@ Pre-registered conditions that would falsify EFC sectors. F7 (η=1) formally **P
 | Core Lock (Consistency Enforcement) | [31223503](https://doi.org/10.6084/m9.figshare.31223503) |
 | ISW Consistency Audit | [31329082](https://doi.org/10.6084/m9.figshare.31329082) |
 
-> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 162 active papers, all with AI-friendly packages (100% coverage), plus 2 superseded packages preserved under `_archived/`. Eight hand-curated 10/10 validation reports with full reproducible pipelines.
+> See [`/docs/papers/efc/`](./docs/papers/efc/) for the complete collection of 163 active papers, all with AI-friendly packages (100% coverage), plus 2 superseded packages preserved under `_archived/`. Eight hand-curated 10/10 validation reports with full reproducible pipelines.
 
 ---
 
 ## AI-Friendly Paper Packages
 
-All 162 active papers have AI-friendly packages (100% coverage as of May 2026). Eight hand-curated 10/10 validation reports with full reproducible pipelines:
+All 163 active papers have AI-friendly packages (100% coverage as of May 2026). Eight hand-curated 10/10 validation reports with full reproducible pipelines:
 
 | Package | Module | Key Functionality |
 |---------|--------|-------------------|
@@ -335,7 +335,7 @@ EFC/
 ├── theory/             # Formal mathematics
 │   └── formal/         # S, D, R, H, C0 models (LaTeX)
 ├── docs/
-│   ├── papers/efc/     # 162 papers with AI-friendly packages (100%) + _archived/
+│   ├── papers/efc/     # 163 papers with AI-friendly packages (100%) + _archived/
 │   ├── public/         # Validation Ledger (v3.18), Master Spec, figures
 │   ├── figures/        # Shared figures
 │   ├── notebooks/      # Jupyter notebooks

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-05-05",
-  "n_packages": 162,
+  "generated": "2026-05-06",
+  "n_packages": 163,
   "packages": [
     {
       "name": "A One-Parameter, Four-Channel Consistency Test for EFC Background Coupling",
@@ -1255,6 +1255,15 @@
       "primary_pdf": "component_weighted_bias.pdf",
       "created": [],
       "n_files": 25
+    },
+    {
+      "name": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+      "title": "composite level aggregation in rotation curve model selection a sign flip decomp",
+      "track": "Spor 1 — Galactic/Cosmological",
+      "regimes": [],
+      "primary_pdf": "component_weighted_bias_v3p1.pdf",
+      "created": [],
+      "n_files": 11
     },
     {
       "name": "efc-weak-lensing-phenomenology",

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/ai_manifest.json
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/ai_manifest.json
@@ -1,0 +1,66 @@
+{
+  "id": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+  "directory": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+  "title": "composite level aggregation in rotation curve model selection a sign flip decomp",
+  "author": "Morten Magnusson",
+  "orcid": "0009-0002-4860-5095",
+  "affiliation": "Symbiose Research",
+  "license": "CC-BY-4.0",
+  "package_type": "ai-friendly-paper",
+  "schema_version": "1.0",
+  "generated": "2026-05-06",
+  "track": "Spor 1 — Galactic/Cosmological",
+  "regimes": [],
+  "primary_pdf": "component_weighted_bias_v3p1.pdf",
+  "all_pdfs": [
+    "component_weighted_bias_v3p1.pdf"
+  ],
+  "files": [
+    {
+      "path": ".scaffolded",
+      "bytes": 486
+    },
+    {
+      "path": "CITATION.cff",
+      "bytes": 286
+    },
+    {
+      "path": "LICENSE",
+      "bytes": 406
+    },
+    {
+      "path": "README.md",
+      "bytes": 401
+    },
+    {
+      "path": "citations.bib",
+      "bytes": 236
+    },
+    {
+      "path": "component_weighted_bias_v3p1.pdf",
+      "bytes": 345550
+    },
+    {
+      "path": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp.jsonld",
+      "bytes": 379
+    },
+    {
+      "path": "index.json",
+      "bytes": 578
+    },
+    {
+      "path": "metadata.json",
+      "bytes": 645
+    },
+    {
+      "path": "schema.json",
+      "bytes": 60
+    },
+    {
+      "path": "src/__init__.py",
+      "bytes": 0
+    }
+  ],
+  "n_files": 11,
+  "n_pdfs": 1
+}

--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -492,11 +492,11 @@
     </tr>
     <tr>
       <td>The code, data, and reproducers</td>
-      <td><a href="https://github.com/supertedai/EFC">github.com/supertedai/EFC</a> &mdash; 162 AI-friendly paper packages, 135 tests (113 active, 105 survived, 8 falsified, 22 pipeline), full reproducible pipelines.</td>
+      <td><a href="https://github.com/supertedai/EFC">github.com/supertedai/EFC</a> &mdash; 163 AI-friendly paper packages, 135 tests (113 active, 105 survived, 8 falsified, 22 pipeline), full reproducible pipelines.</td>
     </tr>
     <tr>
       <td>The single-reference consolidation</td>
-      <td><a href="https://doi.org/10.6084/m9.figshare.31943361">&Lambda;CDM as a Special Case of Energy-Flow Cosmology</a> (DOI 31943361) &mdash; 14 months and 162 papers in one reference.</td>
+      <td><a href="https://doi.org/10.6084/m9.figshare.31943361">&Lambda;CDM as a Special Case of Energy-Flow Cosmology</a> (DOI 31943361) &mdash; 14 months and 163 papers in one reference.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
PR #283 auto-scaffolded the 32162706 (Composite-level aggregation) paper directory but did not propagate the new paper count to root files / Pitch / ai_manifest. The post-merge `verify` workflow caught the drift:

```
.claude/drift_report.json              | 81 ++++++++++++++++++++++++++++++++--
docs/papers/efc/ai_friendly_index.json | 13 +++++-
2 files changed, 89 insertions(+), 5 deletions(-)
```

## What this PR does

- README.md: AI Packages badge 162→163 + Quick Reference table
- AGENTS.md: `ai_packages: 163`, tree map, package paragraph
- EFC_Elevator_Pitch.html: comparison table footnote rows 162→163
- New scaffolded paper gets its `ai_manifest.json` (auto-generated by `efc_gen_ai_friendly.py`)
- `ai_friendly_index.json`: 162→163 catalogue
- `.claude/drift_report.json` refreshed

## Constitution still respected

`Changelog` historical drift remains as designed (entries are immutable per `_FIX_FORBIDDEN`). All other guards green.

## Test plan

- [x] `efc_drift_detector.py` reports only Changelog historical
- [x] `efc_navbar_sync.py --check` ✓
- [x] `efc_page_consistency.py` ✓
- [x] Diff matches verify-job's expectation


---
_Generated by [Claude Code](https://claude.ai/code/session_016kkqDxXZJo2imKp7EQfLW2)_