### PR TITLE
chore(efc-sync): auto-propagate DOIs and refresh manifests

### DIFF
--- a/.claude/dataset_scan_report.json
+++ b/.claude/dataset_scan_report.json
@@ -1,28 +1,28 @@
 {
   "date": "2026-05-06",
   "known": [
-    "Euclid DR1",
     "Euclid DR2",
-    "DES Y6",
-    "KiDS Legacy",
-    "DESI DR1",
-    "Simons Observatory",
     "DESI DR2",
-    "DESI DR3",
-    "Euclid DR3"
+    "DESI DR1",
+    "KiDS Legacy",
+    "Euclid DR1",
+    "Simons Observatory",
+    "DES Y6",
+    "Euclid DR3",
+    "DESI DR3"
   ],
   "findings": [
     {
       "source": "DESI",
       "term": "data release",
       "url": "https://data.desi.lbl.gov/doc/releases/",
-      "timestamp": "2026-05-06T13:08:30.348920"
+      "timestamp": "2026-05-06T20:32:18.296592"
     },
     {
       "source": "KiDS",
       "term": "DR5",
       "url": "https://kids.strw.leidenuniv.nl/DR5/",
-      "timestamp": "2026-05-06T13:08:30.955357"
+      "timestamp": "2026-05-06T20:32:19.555465"
     }
   ]
 }

--- a/.claude/orcid_cache.json
+++ b/.claude/orcid_cache.json
@@ -1,7 +1,7 @@
 {
   "orcid_id": "0009-0002-4860-5095",
-  "fetched_at_epoch": 1778005541,
-  "fetched_at_iso": "2026-05-05T18:25:41.446730+00:00",
+  "fetched_at_epoch": 1778096865,
+  "fetched_at_iso": "2026-05-06T19:47:45.912932+00:00",
   "works_count": 163,
   "works": [
     {

--- a/.claude/orcid_sync_report.json
+++ b/.claude/orcid_sync_report.json
@@ -1,12 +1,12 @@
 {
-  "checked_at": "2026-05-06T18:32:31.447027+00:00",
+  "checked_at": "2026-05-06T19:47:45.929352+00:00",
   "orcid_id": "0009-0002-4860-5095",
-  "source": "cache",
+  "source": "live",
   "orcid_works_count": 163,
   "orcid_dois_count": 163,
-  "repo_dois_count": 162,
-  "matched_count": 162,
-  "on_orcid_not_in_repo_count": 1,
+  "repo_dois_count": 163,
+  "matched_count": 163,
+  "on_orcid_not_in_repo_count": 0,
   "in_repo_not_on_orcid_count": 0,
   "matched": [
     "28098299",
@@ -170,13 +170,9 @@
     "32101213",
     "32113399",
     "32114530",
-    "32149654"
+    "32149654",
+    "32162706"
   ],
-  "on_orcid_not_in_repo": [
-    {
-      "doi": "32162706",
-      "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175"
-    }
-  ],
+  "on_orcid_not_in_repo": [],
   "in_repo_not_on_orcid": []
 }

--- a/.claude/symbiose_snapshot.json
+++ b/.claude/symbiose_snapshot.json
@@ -1,6 +1,6 @@
 {
   "source": "ledger_fallback",
-  "generated_at": "2026-05-05T21:35:45.474886Z",
+  "generated_at": "2026-05-06T20:32:16.512924Z",
   "tests": {
     "total": 135,
     "active": 113,
@@ -13,8 +13,8 @@
     "framework_constraint": 28
   },
   "papers": {
-    "total": 163,
-    "with_doi": 162,
+    "total": 164,
+    "with_doi": 163,
     "sealed_predictions_total": 348
   },
   "grav": {

--- a/.claude/unprocessed_papers.json
+++ b/.claude/unprocessed_papers.json
@@ -530,6 +530,16 @@
     "track": "unknown"
   },
   {
+    "directory": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+    "doi": "32162706",
+    "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of \u2206AIC for SPARC-175",
+    "missing_from": [
+      "Changelog"
+    ],
+    "has_key_results": true,
+    "track": "unknown"
+  },
+  {
     "directory": "efc_formal_spec",
     "doi": "30630500",
     "title": "EFC \u2014 Formal Specification",

--- a/docs/papers/efc/ai_friendly_index.json
+++ b/docs/papers/efc/ai_friendly_index.json
@@ -1263,7 +1263,7 @@
       "regimes": [],
       "primary_pdf": "component_weighted_bias_v3p1.pdf",
       "created": [],
-      "n_files": 11
+      "n_files": 12
     },
     {
       "name": "efc-weak-lensing-phenomenology",

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/CITATION.cff
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/CITATION.cff
@@ -1,7 +1,13 @@
 cff-version: 1.2.0
-title: Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175
+title: "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of ∆AIC for SPARC-175"
+message: "If you use this work, please cite it as below."
 authors:
-  - family-names: Magnusson
-    given-names: Morten
-    orcid: https://orcid.org/0009-0002-4860-5095
-doi: 10.6084/m9.figshare.32162706
+  - family-names: "Magnusson"
+    given-names: "Morten"
+    orcid: "https://orcid.org/0009-0002-4860-5095"
+    affiliation: "Symbiose Research, Sandnes, Norway"
+date-released: "2026-05-01"
+version: "1.0"
+doi: "10.6084/m9.figshare.32162706"
+license: "CC-BY-4.0"
+repository-code: "https://github.com/supertedai/EFC"

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/README.md
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/README.md
@@ -1,7 +1,19 @@
-# Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175
+# Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of ∆AIC for SPARC-175
 
-**DOI:** [10.6084/m9.figshare.32162706](https://doi.org/10.6084/m9.figshare.32162706)
+## AI-Friendly Package
 
-**Status:** scaffolded — awaiting review.
+- **DOI:** [10.6084/m9.figshare.32162706](https://doi.org/10.6084/m9.figshare.32162706)
+- **Version:** 1.0
+- **Author:** Morten Magnusson (ORCID: [0009-0002-4860-5095](https://orcid.org/0009-0002-4860-5095))
+- **Date:** 2026-05-01
+- **License:** CC-BY-4.0
 
-This directory was created by `efc_figshare_check.py --scaffold-missing`. Please review and remove the `.scaffolded` marker once content is in place.
+---
+
+## Overview
+
+Re-fits the SPARC-175 rotation-curve sample with an EFC vs NFW comparison and decomposes each galaxy’s ∆AIC into inner (r < rc) and outer (r ≥ rc) contributions. Finds that 17.5% of galaxies flip the preference sign between the global and outer-only ∆AIC at rc = 3 kpc (robustly 16.4–22.2% for rc ∈ {2,3,4,5} kpc), showing that a single global ∆AIC mixes physically distinct radial regimes. A reweighting test (uniform vs 1/σ²) shifts the sample further toward EFC, indicating the effect is aggregation-level, not a χ²-weighting bias.
+
+## Key Result
+
+At rc = 3 kpc, 30/171 galaxies (17.5%) flip the preference sign between global and outer-only ∆AIC, robustly 16.4–22.2% for rc ∈ {2,3,4,5} kpc; removing χ² weights increases EFC wins (66.7% → 86.5%), indicating the issue is aggregation-level, not weighting bias.

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/ai_manifest.json
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/ai_manifest.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "CITATION.cff",
-      "bytes": 286
+      "bytes": 522
     },
     {
       "path": "LICENSE",
@@ -30,7 +30,7 @@
     },
     {
       "path": "README.md",
-      "bytes": 401
+      "bytes": 1257
     },
     {
       "path": "citations.bib",
@@ -42,15 +42,15 @@
     },
     {
       "path": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp.jsonld",
-      "bytes": 379
+      "bytes": 653
     },
     {
       "path": "index.json",
-      "bytes": 578
+      "bytes": 6647
     },
     {
       "path": "metadata.json",
-      "bytes": 645
+      "bytes": 1591
     },
     {
       "path": "schema.json",
@@ -61,6 +61,6 @@
       "bytes": 0
     }
   ],
-  "n_files": 11,
+  "n_files": 12,
   "n_pdfs": 1
 }

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp.jsonld
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp.jsonld
@@ -1,11 +1,18 @@
 {
-  "@context": "https://schema.org",
+  "@context": {
+    "@vocab": "https://schema.org/"
+  },
   "@type": "ScholarlyArticle",
-  "name": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175",
-  "identifier": "10.6084/m9.figshare.32162706",
+  "name": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of ∆AIC for SPARC-175",
   "author": {
     "@type": "Person",
     "name": "Morten Magnusson",
     "identifier": "https://orcid.org/0009-0002-4860-5095"
-  }
+  },
+  "datePublished": "2026-05-01",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
+  "@id": "doi:10.6084/m9.figshare.32162706",
+  "identifier": "https://doi.org/10.6084/m9.figshare.32162706",
+  "doi": "10.6084/m9.figshare.32162706",
+  "sameAs": "https://doi.org/10.6084/m9.figshare.32162706"
 }

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/index.json
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/index.json
@@ -1,16 +1,94 @@
 {
   "$schema": "./schema.json",
   "id": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
-  "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175",
+  "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of \u2206AIC for SPARC-175",
+  "description": "Re-fits the SPARC-175 rotation-curve sample with an EFC vs NFW comparison and decomposes each galaxy\u2019s \u2206AIC into inner (r < rc) and outer (r \u2265 rc) contributions. Finds that 17.5% of galaxies flip the preference sign between the global and outer-only \u2206AIC at rc = 3 kpc (robustly 16.4\u201322.2% for rc \u2208 {2,3,4,5} kpc), showing that a single global \u2206AIC mixes physically distinct radial regimes. A reweighting test (uniform vs 1/\u03c3\u00b2) shifts the sample further toward EFC, indicating the effect is aggregation-level, not a \u03c7\u00b2-weighting bias.",
+  "version": "1.0",
+  "date": "2026-05-01",
   "doi": "10.6084/m9.figshare.32162706",
-  "version": "0.1-scaffold",
-  "date": "",
+  "keywords": [
+    "SPARC-175",
+    "rotation curves",
+    "model selection",
+    "AIC decomposition",
+    "sign-flip diagnostic",
+    "EFC",
+    "NFW",
+    "chi-square weighting",
+    "entropy-bounded empiricism",
+    "radial stratification",
+    "inner-outer split",
+    "differential evolution"
+  ],
   "author": {
     "name": "Morten Magnusson",
     "orcid": "0009-0002-4860-5095",
     "affiliation": "Symbiose Research, Sandnes, Norway"
   },
+  "core_equations": {
+    "delta_aic_definition": {
+      "latex": "\\Delta \\mathrm{AIC} \\equiv \\mathrm{AIC}_{\\mathrm{NFW}} - \\mathrm{AIC}_{\\mathrm{EFC}}",
+      "description": "Sign convention used throughout; positive values mean EFC is preferred over NFW."
+    },
+    "efc_velocity_curve": {
+      "latex": "V_{\\mathrm{EFC}}(r) = v_{\\mathrm{flat}}\\,\\sqrt{1 - \\exp\\!\\left[-\\left(\\frac{r}{r_{\\mathrm{turnon}}}\\right)^{p}\\right]}",
+      "description": "Three-parameter EFC rotation-curve model (k_EFC = 3) fit to each galaxy."
+    },
+    "nfw_velocity_curve": {
+      "latex": "V_{\\mathrm{NFW}}(r) = V_{200}\\,\\sqrt{\\frac{\\ln(1+s) - s/(1+s)}{\\ln(1+c)-c/(1+c)}\\cdot\\frac{1}{r/r_{200}}},\\quad s = \\frac{c\\,r}{r_{200}},\\; r_{200} = \\frac{V_{200}}{10\\,H_0\\cdot 10^{-3}}",
+      "description": "Two-parameter NFW rotation-curve model (k_NFW = 2); s and r200 follow the paper\u2019s definitions with H0 = 67.4 km s^{-1} Mpc^{-1}."
+    },
+    "aic_inner_contribution": {
+      "latex": "\\Delta\\mathrm{AIC}_{\\mathrm{inner}}(r_c) = \\sum_{r_i<r_c} w_i\\Big[(V_{\\mathrm{obs},i}-V_{\\mathrm{NFW},i})^2 - (V_{\\mathrm{obs},i}-V_{\\mathrm{EFC},i})^2\\Big] + 2\\,(k_{\\mathrm{NFW}}-k_{\\mathrm{EFC}})",
+      "description": "Inner-region contribution to the \u2206AIC at a chosen split radius rc; weights are w_i = 1/\\sigma_i^2 unless stated otherwise."
+    },
+    "aic_outer_contribution": {
+      "latex": "\\Delta\\mathrm{AIC}_{\\mathrm{outer}}(r_c) = \\sum_{r_i\\ge r_c} w_i\\Big[(V_{\\mathrm{obs},i}-V_{\\mathrm{NFW},i})^2 - (V_{\\mathrm{obs},i}-V_{\\mathrm{EFC},i})^2\\Big] + 2\\,(k_{\\mathrm{NFW}}-k_{\\mathrm{EFC}})",
+      "description": "Outer-region contribution to the \u2206AIC at rc, computed at the global best-fit parameters (no subset refits)."
+    },
+    "aic_global_relation": {
+      "latex": "\\Delta\\mathrm{AIC}_{\\mathrm{global}}(r_c) = \\Delta\\mathrm{AIC}_{\\mathrm{inner}}(r_c) + \\Delta\\mathrm{AIC}_{\\mathrm{outer}}(r_c) - 2\\,(k_{\\mathrm{NFW}}-k_{\\mathrm{EFC}})",
+      "description": "By construction, the global \u2206AIC equals the sum of inner and outer contributions minus one penalty term to avoid double-counting."
+    },
+    "sign_flip_condition": {
+      "latex": "\\operatorname{sign}\\big(\\Delta\\mathrm{AIC}_{\\mathrm{global}}\\big) \\ne \\operatorname{sign}\\big(\\Delta\\mathrm{AIC}_{\\mathrm{outer}}\\big)",
+      "description": "Diagnostic for regime-mixing: the model preferred globally is disfavored by outer points alone."
+    }
+  },
+  "key_results": {
+    "main_finding": "At rc = 3 kpc, 30/171 galaxies (17.5%) flip the preference sign between global and outer-only \u2206AIC, robustly 16.4\u201322.2% for rc \u2208 {2,3,4,5} kpc; removing \u03c7\u00b2 weights increases EFC wins (66.7% \u2192 86.5%), indicating the issue is aggregation-level, not weighting bias.",
+    "delta_chi2": null,
+    "significance_sigma": null,
+    "parameters_tested": [
+      "EFC parameters: v_flat, r_turnon, p (k=3)",
+      "NFW parameters: V200, c (k=2)",
+      "Split radius rc \u2208 {2, 3, 4, 5} kpc",
+      "Weighting schemes: w_i = 1/\u03c3_i^2 vs uniform weights",
+      "Spearman correlation between \u2206AIC_global and \u2206AIC_outer"
+    ],
+    "datasets_used": [
+      "SPARC-175 (171 galaxies with converged fits for both models)"
+    ],
+    "verdict": "N/A"
+  },
+  "sealed_predictions": [],
+  "kill_criteria": [
+    "KC1: If independent refits of EFC and NFW on the inner (r < rc) and outer (r \u2265 rc) subsets across rc \u2208 {2,3,4,5} kpc reduce the sign-flip fraction to <5% with bootstrap-validated uncertainty, the claimed regime-mixing misclassification would be falsified.",
+    "KC2: If applying small-sample corrections (AICc) or alternative criteria (BIC) eliminates the sign-flip phenomenon such that >95% of galaxies show matching global and outer-only signs for all rc choices, the necessity of the proposed decomposition would be invalidated.",
+    "KC3: If reanalysis with revised uncertainties or full covariance (e.g., SPARC updates including beam smearing and inclination systematics) yields a Spearman correlation \u03c1 > 0.98 between \u2206AIC_global and \u2206AIC_outer and a sign-flip rate indistinguishable from zero within errors, the aggregation-level claim would fail.",
+    "KC4: If posterior predictive checks show no significant radial structure in per-point residuals for both models (residual slopes consistent with zero across radii at the sample level after systematics), then a single global statistic would be adequate and the paper\u2019s central claim would be undermined.",
+    "KC5: If Monte Carlo simulations under realistic noise/uncertainty models show that the observed 16\u201322% sign-flip rate is fully explained by random fluctuations (i.e., equals the null expectation within 1\u03c3 across rc choices), the reported effect would be attributable to noise rather than regime mixing."
+  ],
+  "tier": "T3",
+  "paper_type": "methodology",
+  "related_packages": [],
+  "files": {
+    "pdf": "paper.pdf",
+    "readme": "README.md"
+  },
+  "figshare_url": "https://doi.org/10.6084/m9.figshare.32162706",
   "license": "CC-BY-4.0",
   "scaffolded": true,
-  "scaffolded_at": "2026-05-06T19:43:52+00:00"
+  "scaffolded_at": "2026-05-06T19:43:52+00:00",
+  "paper_type_inferred": true
 }

--- a/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/metadata.json
+++ b/docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/metadata.json
@@ -1,19 +1,36 @@
 {
-  "paper": {
-    "$schema": "./schema.json",
-    "id": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
-    "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175",
-    "doi": "10.6084/m9.figshare.32162706",
-    "version": "0.1-scaffold",
-    "date": "",
-    "author": {
-      "name": "Morten Magnusson",
-      "orcid": "0009-0002-4860-5095",
-      "affiliation": "Symbiose Research, Sandnes, Norway"
-    },
-    "license": "CC-BY-4.0",
-    "scaffolded": true,
-    "scaffolded_at": "2026-05-06T19:43:52+00:00"
+  "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of \u2206AIC for SPARC-175",
+  "short_id": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+  "version": "1.0",
+  "date": "2026-05-01",
+  "author": {
+    "name": "Morten Magnusson",
+    "orcid": "0009-0002-4860-5095",
+    "affiliation": "Symbiose Research, Sandnes, Norway"
   },
-  "scaffolded": true
+  "license": "CC-BY-4.0",
+  "doi": "10.6084/m9.figshare.32162706",
+  "abstract": "Re-fits the SPARC-175 rotation-curve sample with an EFC vs NFW comparison and decomposes each galaxy\u2019s \u2206AIC into inner (r < rc) and outer (r \u2265 rc) contributions. Finds that 17.5% of galaxies flip the preference sign between the global and outer-only \u2206AIC at rc = 3 kpc (robustly 16.4\u201322.2% for rc \u2208 {2,3,4,5} kpc), showing that a single global \u2206AIC mixes physically distinct radial regimes. A reweighting test (uniform vs 1/\u03c3\u00b2) shifts the sample further toward EFC, indicating the effect is aggregation-level, not a \u03c7\u00b2-weighting bias.",
+  "keywords": [
+    "SPARC-175",
+    "rotation curves",
+    "model selection",
+    "AIC decomposition",
+    "sign-flip diagnostic",
+    "EFC",
+    "NFW",
+    "chi-square weighting",
+    "entropy-bounded empiricism",
+    "radial stratification",
+    "inner-outer split",
+    "differential evolution"
+  ],
+  "files": {
+    "pdf": "paper.pdf",
+    "readme": "README.md"
+  },
+  "paper": {
+    "doi": "10.6084/m9.figshare.32162706",
+    "figshare_url": "https://doi.org/10.6084/m9.figshare.32162706"
+  }
 }

--- a/docs/papers/efc/efc_index.json
+++ b/docs/papers/efc/efc_index.json
@@ -1,8 +1,8 @@
 {
-  "version": "2.8",
-  "generated": "2026-05-06T00:26:08.803041+00:00",
+  "version": "2.9",
+  "generated": "2026-05-06T19:47:46.010150+00:00",
   "root": "docs/papers/efc",
-  "paper_count": 162,
+  "paper_count": 163,
   "papers": [
     {
       "id": "a-one-parameter,-four-channel-consistency-test-for-efc-background-coupling",
@@ -1061,6 +1061,13 @@
       "doi": "10.6084/m9.figshare.32019723",
       "title": "Component-weighted bias in rotation curve model selection: A proxy-chain audit of χ2-based ∆AIC statistics",
       "tier": "T3"
+    },
+    {
+      "id": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+      "path": "composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp",
+      "type": "theory",
+      "doi": "10.6084/m9.figshare.32162706",
+      "title": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of Delta-AIC for SPARC-175"
     },
     {
       "id": "efc-weak-lensing-phenomenology",

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -81,7 +81,7 @@
   <a href="EFC_External_Research_Ledger.html" style="margin-right:1.5rem; font-weight:600;">External</a>
   <a href="EFC_Predictions.html" style="margin-right:1.5rem; font-weight:600;">Predictions</a>
   <a href="EFC_Atlas.html" style="margin-right:1.5rem; font-weight:600;">Atlas</a>
-  <a href="EFC_Changelog.html" style="font-weight:600; color:#c22;">Changelog</a>
+  <a href="EFC_Changelog.html" style="font-weight:600;">Changelog</a>
 </div>
 <!-- efc-navbar:end -->
 
@@ -92,6 +92,8 @@
 <h2>2026</h2>
 
 <ul>
+  <li><strong>2026-05-06</strong> &mdash; 3 paper packages enriched; Public pages updated: Changelog; Ledger data: evidence-register.json, ledger.json.</li>
+  <li><strong>2026-05-06</strong> &mdash; <strong>Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of ∆AIC for SPARC-175</strong> (<a href="https://doi.org/10.6084/m9.figshare.32162706">32162706</a>, T3, methodology). At rc = 3 kpc, 30/171 galaxies (17.5%) flip the preference sign between global and outer-only ∆AIC, robustly 16.4–22.2% for rc ∈ {2,3,4,5} kpc; removing χ² weights increases EFC wins (66.7% → 86.5%), indicating the issue is aggregation-level, not weighting bias.</li>
   <li><strong>2026-05-06</strong> &mdash; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-06</strong> &mdash; 1 paper package enriched; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-05</strong> &mdash; 7 paper packages enriched; Public pages updated: Changelog, Elevator_Pitch; Ledger data: evidence-register.json, ledger.json.</li>

--- a/docs/validation-ledger/data/changelog.json
+++ b/docs/validation-ledger/data/changelog.json
@@ -7,7 +7,7 @@
     {
       "date": "2026-05-06",
       "type": "auto_maintenance",
-      "summary": "Ledger data: evidence-register.json, ledger.json."
+      "summary": "Ledger data: evidence-register.json, ledger.json. 3 paper packages enriched; Public pages updated: Changelog; Ledger data: evidence-register.json, ledger.json."
     },
     {
       "name": "Bullet \u03b4\u03ba test: promote from preregistered to in_pipeline (JWST data ready)",

--- a/docs/validation-ledger/data/evidence-register.json
+++ b/docs/validation-ledger/data/evidence-register.json
@@ -648,6 +648,11 @@
         "doi": "32149654",
         "name": "Pre-Registration: EFC dN/dM (z>7) Halo Mass Function via µ(a) Perturbation Channel",
         "category": "empirical"
+      },
+      {
+        "doi": "32162706",
+        "name": "Composite-level aggregation in rotation curve model selection: A sign-flip decom",
+        "category": "structural"
       }
     ],
     "methodological": [
@@ -774,6 +779,11 @@
       {
         "doi": "32113399",
         "name": "A Three-Window Decomposition of Cosmological Redshift in Energy-Flow Cosmology A synthesis note: TCMB , CDDR, and S(z) consistency under one regime parameter",
+        "category": "methodological"
+      },
+      {
+        "doi": "32162706",
+        "name": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of ∆AIC for SPARC-175",
         "category": "methodological"
       }
     ],

--- a/docs/validation-ledger/data/ledger.json
+++ b/docs/validation-ledger/data/ledger.json
@@ -3025,6 +3025,11 @@
         "doi": "32149654",
         "name": "Pre-Registration: EFC dN/dM (z>7) Halo Mass Function via µ(a) Perturbation Channel",
         "category": "empirical"
+      },
+      {
+        "doi": "32162706",
+        "name": "Composite-level aggregation in rotation curve model selection: A sign-flip decom",
+        "category": "structural"
       }
     ],
     "methodological": [
@@ -3151,6 +3156,11 @@
       {
         "doi": "32113399",
         "name": "A Three-Window Decomposition of Cosmological Redshift in Energy-Flow Cosmology A synthesis note: TCMB , CDDR, and S(z) consistency under one regime parameter",
+        "category": "methodological"
+      },
+      {
+        "doi": "32162706",
+        "name": "Composite-level aggregation in rotation curve model selection: A sign-flip decomposition of ∆AIC for SPARC-175",
         "category": "methodological"
       }
     ],

--- a/maintain.log
+++ b/maintain.log
@@ -1,19 +1,17 @@
 [efc-auto-meta] all paper directories have index.json
 ========================================================================
-EFC ORCID source-of-truth sync — source=cache
+EFC ORCID source-of-truth sync — source=live
 ========================================================================
   ORCID works               : 163
   ORCID Figshare DOIs       : 163
-  Repo Figshare DOIs        : 162
-  Matched                   : 162
-  On ORCID, not in repo     : 1
+  Repo Figshare DOIs        : 163
+  Matched                   : 163
+  On ORCID, not in repo     : 0
   In repo, not on ORCID     : 0
-
-PAPERS ON ORCID, NOT IN REPO (action: download + process):
-  - 10.6084/m9.figshare.32162706  Composite-level aggregation in rotation curve model selection: A sign-flip decom
 ========================================================================
-[efc-paper-type] all papers already classified
-[efc-regen-index] no diff — 162 papers, version 2.8
+[efc-paper-type] inferred paper_type for 1 paper(s):
+  theory                  composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp
+[efc-regen-index] wrote efc_index.json — 163 papers, version 2.9
 ============================================================
 EFC AI BRAIN — Full Autonomous Processing
 LLM providers: OpenAI/gpt-5 → Anthropic/claude-opus-4-6
@@ -21,8 +19,11 @@ Mode: LIVE
 pdftotext: /usr/bin/pdftotext
 ============================================================
 
->>> Step 1: Enriching 4 paper(s) to 10/10 <<<
+>>> Step 1: Enriching 5 paper(s) to 10/10 <<<
 
+  composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp  (missing: key_results, kill_criteria, tier, examples/, data/)
+    Enriched metadata (key_results, kill_criteria, tier)
+    Generated examples/, data/
   hypothesis-the-universe-as-an-energy-driven-system  (missing: examples/, data/)
     Generated examples/, data/
   white-paper-part-2-of-4-energy-flow-cosmology-part-2-field-equations-and-observa  (missing: examples/, data/)
@@ -32,7 +33,7 @@ pdftotext: /usr/bin/pdftotext
   white-paper-part-4-of-4-energy-flow-cosmology-part-4-regime-susceptibility-and-c  (missing: examples/, data/)
     Generated examples/, data/
 
-  Enriched: 4/4
+  Enriched: 6/5
 
 >>> Step 1.5: Holistic Impact Analysis for 8 paper(s) <<<
 
@@ -76,7 +77,7 @@ pdftotext: /usr/bin/pdftotext
     Graph: 10 concepts, 0 related papers
     [WARN] OpenAI empty (finish_reason=length) attempt 1/4
     [WARN] OpenAI empty (finish_reason=length) attempt 2/4
-    [WARN] OpenAI empty (finish_reason=length) attempt 3/4
+    [RETRY] OpenAI HTTP 502 — waiting 20s (3/4)
     [WARN] OpenAI empty (finish_reason=length) attempt 4/4
     [INFO] openai exhausted — trying fallback provider
     [WARN] Could not parse holistic impact JSON
@@ -121,30 +122,32 @@ pdftotext: /usr/bin/pdftotext
     [WARN] OpenAI empty (finish_reason=length) attempt 3/4
     [WARN] OpenAI empty (finish_reason=length) attempt 4/4
     [INFO] openai exhausted — trying fallback provider
-    Added 60 DOI(s) to evidence register
-    Added 3 DOI(s) to evidence register
+    Added 1 DOI(s) to evidence register
 
 ============================================================
 EFC AI BRAIN — done
 ============================================================
-[efc-gen] 162 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
+[efc-gen] 163 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
 ========================================================================
-EFC DOI sync — 163 paper dirs scanned
+EFC DOI sync — 164 paper dirs scanned
 ========================================================================
-  papers with registered DOI : 162
+  papers with registered DOI : 163
   papers without DOI         : 1
   papers with conflicts      : 0
+
+PROPAGATED DOIs into 1 papers:
+  composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp -> *.jsonld
 ========================================================================
-[efc-gen] 162 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
-[efc-verify] 162 paper dirs · 0 errors · 1 warnings
+[efc-gen] 163 packages · 0 new files · catalogue: /home/runner/work/EFC/EFC/docs/papers/efc/ai_friendly_index.json
+[efc-verify] 163 paper dirs · 0 errors · 1 warnings
   [WARN ] C4 internal-versions: drift within internal track: {'ledger.json': '3.0', 'index.md': '4.1'}
 ======================================================================
 EFC LEDGER IMPACT SYNC — LIVE
 ======================================================================
 Known gap IDs in HTML: 13
 
-Processed 162 paper(s)
-  skip: 154
+Processed 163 paper(s)
+  skip: 155
   warn: 8
     - A_Falsified_Bar-Instability_Criterion_Reveals_an_Independent_Disk-State_Parameter_from_EFC-Modified_Disk_Kinematics: DOI registered but no ledger_impact block
     - A_structural_closure_of_growth_sector_couplings: DOI registered but no ledger_impact block
@@ -156,20 +159,24 @@ Processed 162 paper(s)
     - white-paper-part-3-of-4-energy-flow-cosmology-part-3-data-validation-ledger-and-: DOI registered but no ledger_impact block
 
 [ledger-impact-sync] nothing to do — all papers in steady state
-[efc-ledger-autofill] nothing to add — Ledger + Changelog already cover every empirical/sealed DOI
+[efc-ledger-autofill] Changelog: added 1 entry/ies for DOI(s) 32162706
 ========================================================================
 EFC Evidence Mirror — registers reconciled
 ========================================================================
-  empirical       ev: 85 → 129  (+44)    ledger: 22 → 129 (+107)
-  methodological  ev:  3 →  25  (+22)    ledger:  3 →  25 (+22)
-  structural      ev:  2 →  75  (+73)    ledger:  2 →  75 (+73)
+  empirical       ev:130 → 130  (+0)    ledger:129 → 130 (+1)
+  methodological  ev: 25 →  26  (+1)    ledger: 25 →  26 (+1)
+  structural      ev: 75 →  75  (+0)    ledger: 75 →  75 (+0)
 ========================================================================
-[efc-drift] 162 papers · 2 drift(s) detected:
-  Changelog: claims 158 but actual is 162
-  Changelog: claims 158 but actual is 162
+[efc-drift] 163 papers · 2 drift(s) detected:
+  Changelog: claims 158 but actual is 163
+  Changelog: claims 158 but actual is 163
 [efc-drift] auto-fixed 0 file(s)
 [efc-drift] 2 drift(s) remain (need manual fix)
 [rootfile-consistency] no drift to fix ✓
+[navbar-sync] processed 13 page(s):
+  replaced: 1
+  unchanged: 12
+  · EFC_Changelog.html: replaced
 ============================================================
 EFC SYMBIOSE SNAPSHOT
 ============================================================
@@ -177,7 +184,7 @@ Source: Git ledger (fallback mode)
 
 Snapshot written to /home/runner/work/EFC/EFC/.claude/symbiose_snapshot.json
   Tests: 135 total, 105 survived, 8 falsified
-  Papers: 163 (162 DOIs)
+  Papers: 164 (163 DOIs)
   GRAV: KT1=unknown, KT2=unknown, KT3=unknown
   Source: ledger_fallback
 ============================================================
@@ -205,19 +212,19 @@ Scanning 4 sources...
 
 Report saved to /home/runner/work/EFC/EFC/.claude/dataset_scan_report.json
 [efc-auto-changelog] checking for changes...
-[efc-auto-changelog] Ledger data: evidence-register.json, ledger.json.
+[efc-auto-changelog] 3 paper packages enriched; Public pages updated: Changelog; Ledger data: evidence-register.json, ledger.json.
 [efc-auto-changelog] updated EFC_Changelog.html
 [efc-auto-changelog] updated changelog.json
 ============================================================
 EFC CROSS-VALIDATION GATE (with Symbiose Council)
 ============================================================
 
-Repo: 163 papers, 162 DOIs
+Repo: 164 papers, 163 DOIs
 Ledger: 135 tests, 8 falsified
 
 --- Elevator Pitch ---
-  [OK]       Paper count 162 close to repo 163
-  [OK]       Paper count 162 close to repo 163
+  [OK]       Paper count 163 close to repo 164
+  [OK]       Paper count 163 close to repo 164
   [OK]       Survival count 105/113 matches ledger
 
 --- Validation Ledger ---
@@ -247,10 +254,10 @@ Ledger: 135 tests, 8 falsified
   [CRITICAL] 3 inference modules still on LCDM stubs
 
 --- Cross-consistency ---
-  [OK]       README paper count 162 matches repo 163
-  [OK]       README paper count 162 matches repo 163
+  [OK]       README paper count 163 matches repo 164
+  [OK]       README paper count 163 matches repo 164
   [OK]       Stats categories sum to 135 = total_public
-  [OK]       DOI sync script present, 162/163 papers have DOIs
+  [OK]       DOI sync script present, 163/164 papers have DOIs
   [OK]       119 papers have sealed predictions (348 total)
 
 --- Gap Analysis Coherence ---
@@ -259,7 +266,7 @@ Ledger: 135 tests, 8 falsified
 --- Symbiose Council ---
   Snapshot source: ledger_fallback
   [OK]       Symbiose test count 135 matches ledger
-  [OK]       Symbiose paper count 163 matches repo
+  [OK]       Symbiose paper count 164 matches repo
   [OK]       Sealed freeze_1: alpha=-0.689, hash=7a850cfa...
   [OK]       Sealed freeze_2: alpha=-0.702, hash=dbccda15...
 
@@ -271,7 +278,7 @@ Fix these before auto-commit:
   - EFC Inference: fs8_extended: still LCDM stub — no DOI data
   - EFC Inference: hz_chronometers: still LCDM stub — no DOI data
   - 3 inference modules still on LCDM stubs
-[full-sync] invariants: 0 error(s), 164 warning(s)
+[full-sync] invariants: 0 error(s), 165 warning(s)
   [WARN] §1 internal_ledger_version: expected='4.1' observed='3.0'
   [WARN] §2 doi_in_index_but_not_in_doi_map:28098299: expected='present' observed='absent'
   [WARN] §2 doi_in_index_but_not_in_doi_map:28098305: expected='present' observed='absent'
@@ -435,7 +442,8 @@ Fix these before auto-commit:
   [WARN] §2 doi_in_index_but_not_in_doi_map:32113399: expected='present' observed='absent'
   [WARN] §2 doi_in_index_but_not_in_doi_map:32114530: expected='present' observed='absent'
   [WARN] §2 doi_in_index_but_not_in_doi_map:32149654: expected='present' observed='absent'
-  [WARN] §3 packages_below_10_10: expected=0 observed=5
+  [WARN] §2 doi_in_index_but_not_in_doi_map:32162706: expected='present' observed='absent'
+  [WARN] §3 packages_below_10_10: expected=0 observed=6
 [efc-maintain] --- EFC maintenance pass ---
 [efc-maintain] running efc_auto_metadata.py …
 [efc-maintain] running efc_orcid_sync.py …
@@ -451,6 +459,7 @@ Fix these before auto-commit:
 [efc-maintain] running efc_evidence_mirror.py …
 [efc-maintain] running efc_drift_detector.py --fix…
 [efc-maintain] running efc_rootfile_consistency.py --fix…
+[efc-maintain] running efc_navbar_sync.py …
 [efc-maintain] running efc_symbiose_snapshot.py --from-ledger…
 [efc-maintain] running efc_dataset_scanner.py …
 [efc-maintain] running efc_auto_changelog.py …


### PR DESCRIPTION
Generated by scripts/maintenance/efc_maintain.py running under .github/workflows/efc-sync.yml on commit 1628be1efadad458f29733485050c854c64f59c6.

Pipeline: efc_gen_ai_friendly -> efc_sync_dois --apply ->
          efc_gen_ai_friendly -> efc_verify

Files touched:
  - .claude/dataset_scan_report.json
  - .claude/orcid_cache.json
  - .claude/orcid_sync_report.json
  - .claude/symbiose_snapshot.json
  - .claude/unprocessed_papers.json
  - docs/papers/efc/ai_friendly_index.json
  - docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/CITATION.cff
  - docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/README.md
  - docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/ai_manifest.json
  - docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp.jsonld
  - docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/index.json
  - docs/papers/efc/composite-level-aggregation-in-rotation-curve-model-selection-a-sign-flip-decomp/metadata.json
  - docs/papers/efc/efc_index.json
  - docs/public/EFC_Changelog.html
  - docs/validation-ledger/data/changelog.json
  - docs/validation-ledger/data/evidence-register.json
  - docs/validation-ledger/data/ledger.json
  - maintain.log

Run log excerpt:
    [WARN] §2 doi_in_index_but_not_in_doi_map:32023788: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32029704: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32037990: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32045592: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32080059: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32080080: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32080083: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32084670: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32091700: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32099389: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32101111: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32101213: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32113399: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32114530: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32149654: expected='present' observed='absent' [WARN] §2 doi_in_index_but_not_in_doi_map:32162706: expected='present' observed='absent' [WARN] §3 packages_below_10_10: expected=0 observed=6 [efc-maintain] --- EFC maintenance pass --- [efc-maintain] running efc_auto_metadata.py … [efc-maintain] running efc_orcid_sync.py … [efc-maintain] running efc_paper_type_classifier.py … [efc-maintain] running efc_regen_index.py … [efc-maintain] running efc_ai_brain.py … [efc-maintain] running efc_gen_ai_friendly.py … [efc-maintain] running efc_sync_dois.py --apply… [efc-maintain] running efc_gen_ai_friendly.py … [efc-maintain] running efc_verify.py … [efc-maintain] running efc_ledger_impact_sync.py --apply… [efc-maintain] running efc_ledger_autofill.py … [efc-maintain] running efc_evidence_mirror.py … [efc-maintain] running efc_drift_detector.py --fix… [efc-maintain] running efc_rootfile_consistency.py --fix… [efc-maintain] running efc_navbar_sync.py … [efc-maintain] running efc_symbiose_snapshot.py --from-ledger… [efc-maintain] running efc_dataset_scanner.py … [efc-maintain] running efc_auto_changelog.py … [efc-maintain] running efc_cross_validate.py … [efc-maintain] CROSS-VALIDATION FAILED — public pages have critical errors [efc-maintain] running efc_full_sync.py --verify… [efc-maintain] --- done (issues) ---