### PR TITLE
chore(maintain): session-resume hook artifacts

### DIFF
--- a/.claude/orcid_sync_report.json
+++ b/.claude/orcid_sync_report.json
@@ -1,7 +1,7 @@
 {
-  "checked_at": "2026-05-08T00:31:51.668805+00:00",
+  "checked_at": "2026-05-08T13:32:46.381956+00:00",
   "orcid_id": "0009-0002-4860-5095",
-  "source": "live",
+  "source": "cache",
   "orcid_works_count": 163,
   "orcid_dois_count": 163,
   "repo_dois_count": 163,

--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -92,6 +92,7 @@
 <h2>2026</h2>
 
 <ul>
+  <li><strong>2026-05-08</strong> &mdash; Public pages updated: Changelog.</li>
   <li><strong>2026-05-08</strong> &mdash; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-07</strong> &mdash; Public pages updated: Changelog; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-05-07</strong> &mdash; Public pages updated: Changelog, Elevator_Pitch, Stage-IV_Data_Roadmap, Validation_Ledger, White_Paper_Series.</li>

--- a/docs/validation-ledger/data/changelog.json
+++ b/docs/validation-ledger/data/changelog.json
@@ -7,7 +7,7 @@
     {
       "date": "2026-05-08",
       "type": "auto_maintenance",
-      "summary": "Ledger data: evidence-register.json, ledger.json."
+      "summary": "Ledger data: evidence-register.json, ledger.json. Public pages updated: Changelog."
     },
     {
       "date": "2026-05-07",


### PR DESCRIPTION
## Summary

Auto-generated artifacts produced by the SessionStart/resume maintenance hook on top of current `main`:

- `.claude/orcid_sync_report.json` — timestamp bump (`source: live → cache`, no DOI changes; 163/163 still aligned).
- `docs/public/EFC_Changelog.html` — adds today's "Public pages updated: Changelog." entry.
- `docs/validation-ledger/data/changelog.json` — same self-referential entry under today's `auto_maintenance` row.

No code or content changes; pure maintenance heartbeat. Branch is one fast-forward commit ahead of `main`.

## Test plan

- [ ] Cross-validation passes on the auto-sync workflow's next run.
- [ ] Changelog renders the new entry on `docs/public/EFC_Changelog.html`.

https://claude.ai/code/session_01KGKXFz7YhRgiHric6MnPBZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGKXFz7YhRgiHric6MnPBZ)_