### PR TITLE
fix(page-consistency): exempt incomplete/re-ingest DOIs from P8

### DIFF
--- a/scripts/maintenance/efc_page_consistency.py
+++ b/scripts/maintenance/efc_page_consistency.py
@@ -345,12 +345,37 @@ def check_p8_doi_anchored_in_doi_map(report: Report) -> None:
             permitted.add(fid)
 
     figshare_re = re.compile(r"10\.6084/m9\.figshare\.(\d{6,9})")
+    # DOIs explicitly framed as "incomplete / re-ingest needed" in a page
+    # are NOT cited as evidence — they're listed as known-bad records that
+    # the maintenance pipeline still has to fix. Treat them as exempt so
+    # P8 doesn't fire on these self-flagged tasks. We scope the lookup to
+    # the enclosing block element (tr / li / p) rather than a flat
+    # character window, so the context check is independent of HTML
+    # formatting decisions made by atlas-sync.
+    incomplete_context_re = re.compile(
+        r"(re-?ingest|incomplete|missing\s+repo\s+dir|orphaned?)",
+        re.IGNORECASE,
+    )
+
+    def _enclosing_block(text: str, pos: int) -> str:
+        """Return the smallest <tr|li|p>...</tr|li|p> block containing pos."""
+        for opener, closer in (("<tr", "</tr>"), ("<li", "</li>"), ("<p", "</p>")):
+            start = text.rfind(opener, 0, pos)
+            end = text.find(closer, pos)
+            if start != -1 and end != -1 and end > pos:
+                return text[start : end + len(closer)]
+        # Fall back to a generous window if no block element wraps the match
+        return text[max(0, pos - 600) : pos + 600]
+
     for page_path in PUBLIC_ROOT.glob("EFC_*.html"):
         text = page_path.read_text(encoding="utf-8", errors="replace")
         seen_unknown: set[str] = set()
         for m in figshare_re.finditer(text):
             fid = m.group(1)
             if fid in permitted or fid in seen_unknown:
+                continue
+            block = _enclosing_block(text, m.start())
+            if incomplete_context_re.search(block):
                 continue
             seen_unknown.add(fid)
             line_no = text[: m.start()].count("\n") + 1


### PR DESCRIPTION
## Summary

P8 was firing on a planned-task row in `EFC_Atlas.html` that legitimately
references DOIs `10.6084/m9.figshare.31140000` and `…31876324` inside a
"Re-ingest 2 incomplete EFC Figshare DOIs" block. Those DOIs are not in
`figshare/doi-map.json` precisely because they are flagged as needing
re-ingest — they are not citations.

Atlas-sync wrote those references in `7184f5d`; the existing P8 check
couldn't tell them apart from real orphan citations.

### Fix

Inside `efc_page_consistency.py::check_p8_doi_anchored_in_doi_map`, when
an unknown Figshare DOI is found, scope the context check to the
enclosing `<tr|li|p>` block (not a flat character window) and skip the
DOI when the block contains `re-ingest`, `incomplete`, `missing repo
dir`, or `orphan(ed)`.

### Verification

- Local run: `python3 scripts/maintenance/efc_page_consistency.py` → all invariants hold ✓
- Negative test: injecting a fake DOI `…99999999` inside an unrelated
  `<p>` still fails with the original P8 detail. Atlas restored.

## Test plan

- [ ] CI `page-consistency` passes on this PR
- [ ] CI `verify` and `sync` still green
- [ ] If green, this is safe to fast-track — narrow, well-scoped change

https://claude.ai/code/session_014JdZ5ezthGxsKMAQ1ti4jd

---
_Generated by [Claude Code](https://claude.ai/code/session_014JdZ5ezthGxsKMAQ1ti4jd)_