### PR TITLE
fix(orcid-sync): skip rewrite when only checked_at timestamp changes

### DIFF
--- a/scripts/maintenance/efc_orcid_sync.py
+++ b/scripts/maintenance/efc_orcid_sync.py
@@ -106,6 +106,16 @@ def _save_json(path, data):
         f.write("\n")
 
 
+def _reports_equivalent(prev, curr):
+    """True if two reports differ only in volatile fields (checked_at)."""
+    if not isinstance(prev, dict) or not isinstance(curr, dict):
+        return False
+    volatile = {"checked_at"}
+    a = {k: v for k, v in prev.items() if k not in volatile}
+    b = {k: v for k, v in curr.items() if k not in volatile}
+    return a == b
+
+
 def _bare(doi):
     if not doi:
         return None
@@ -251,7 +261,12 @@ def main():
             for b in in_repo_not_on_orcid
         ],
     }
-    _save_json(REPORT_PATH, report)
+    # Only rewrite the report if something meaningful changed. Otherwise the
+    # rolling `checked_at` timestamp produces a noise diff on every run and
+    # spams git history with empty SessionStart commits.
+    previous = _load_json(REPORT_PATH)
+    if not _reports_equivalent(previous, report):
+        _save_json(REPORT_PATH, report)
 
     print("=" * 72)
     print(f"EFC ORCID source-of-truth sync — source={source}")


### PR DESCRIPTION
## Kva

`scripts/maintenance/efc_orcid_sync.py` skreiv `.claude/orcid_sync_report.json` på **kvar einaste køyring**, fordi `checked_at` alltid vart sett til `datetime.now(...)`. Alt anna i fila var identisk frå run til run (DOI-set, counts, source). Det produserte ein noise-diff og spamma git-historikken med tomme "SessionStart hook output" commits kvar gong Claude-routines fyrte.

## Fix

Last den eksisterande rapporten først, og samanlikn alt **utanom `checked_at`**. Skriv berre når noko meiningsfullt har drifta (DOI-set, count, source). Manglande/korrupt forrige rapport → skriv på vanleg måte.

```python
previous = _load_json(REPORT_PATH)
if not _reports_equivalent(previous, report):
    _save_json(REPORT_PATH, report)
```

`_reports_equivalent()` droppar `checked_at` frå begge sider før samanlikning.

## Verifisert

| Scenario | Resultat |
| --- | --- |
| 2× sekvensielle runs etter clean checkout | `git status` clean — ingen diff |
| Fila sletta før run | Skripten gjenskaper ho |
| Ekte drift (DOI-set endrar seg) | Ny rapport blir skriven (logikk-traced) |

## Konsekvens

Ingen fleire `chore: SessionStart hook output (ORCID timestamp + navbar regen)` noise-commits. `navbar_sync` og `symbiose_snapshot` er allereie idempotente (`unchanged: 13`, eitt commit i historikken).

https://claude.ai/code/session_011Y9DbQrj5vk5gXUASThdUD

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y9DbQrj5vk5gXUASThdUD)_