### PR TITLE
som: layer.yaml + EFC-side mirror of Symbiose Operating Model

### DIFF
--- a/OPERATING_MODEL.md
+++ b/OPERATING_MODEL.md
@@ -1,0 +1,93 @@
+# Operating Model — supertedai/EFC
+
+**This repository follows the Symbiose Operating Model (SOM).**
+
+> ANY work in this repo — by Claude, by Morten, by any other agent —
+> follows the model defined in `som/governance/SOM.md` (canonical in
+> `supertedai/AGI`). Use the SOM as the working template for every task.
+> Same logic everywhere.
+
+The SOM is **not** specific to backend daemon structure. It is the
+universal operating grammar for the whole Symbiose ecosystem (AGI + EFC
++ medicine + economy + biology + earth).
+
+---
+
+## Canonical SOM home
+
+**All shared schemas, governance docs, registries, templates, RFCs live in `supertedai/AGI` at `som/`.** This repo only carries its own `layer.yaml` and `som/capabilities/` (the 5 master EFC orchestrator manifests).
+
+Read these in `supertedai/AGI` before starting non-trivial work here:
+
+1. **[`som/governance/SOM.md`](https://github.com/supertedai/AGI/blob/main/som/governance/SOM.md)** — the doctrine
+2. **[`som/governance/RCE-CONTRACT.md`](https://github.com/supertedai/AGI/blob/main/som/governance/RCE-CONTRACT.md)** — cornerstone 5-component contract
+3. **[`som/governance/loops.md`](https://github.com/supertedai/AGI/blob/main/som/governance/loops.md)** — develop / maintain / update
+4. **[`som/governance/quality-gates.md`](https://github.com/supertedai/AGI/blob/main/som/governance/quality-gates.md)** — CI gates
+5. **[`som/registry/domains.yaml`](https://github.com/supertedai/AGI/blob/main/som/registry/domains.yaml)** — 7 first-class domains
+
+## EFC-specific entrypoints (this repo)
+
+- **[`layer.yaml`](./layer.yaml)** — EFC's declaration in Symbiose topology
+- **[`som/INVENTORY-EFC.md`](./som/INVENTORY-EFC.md)** — EFC-side inventory at 2026-05-19
+- **[`som/capabilities/`](./som/capabilities/)** — 5 capability manifests for master EFC orchestrators (efc.maintain, efc.full-sync, efc.qdrant-ingest, efc.system-health, efc.mcp)
+
+## EFC-specific non-negotiables (in addition to global SOM)
+
+From `AGENTS.md` v3.6 (locked maintenance discipline):
+
+- **Three evidence layers strictly separated**: EFC own DOI / arXiv §4b / EFC working notes. CI rejects mixing.
+- **Language discipline**: never "confirms EFC". Use "consistent with", "overlaps with", "within prediction band".
+- **Pre-registration**: predictions cite prior EFC DOI in same sentence. No post-diction.
+- **Sealed predictions**: `.seal-manifest.json` SHA-256 hashes never mutated without explicit re-seal.
+- **Council audit**: GPT-5 weekly audit must pass before public-page changes land on main (`efc-ai-audit.yml`).
+- **SessionStart hook**: every Claude session in this repo runs `scripts/maintenance/efc_maintain.py` + `efc_drift_detector.py` before any other work.
+
+## Decision tree (EFC-flavored)
+
+```
+I need to ...
+├─ add a new EFC paper
+│   → SessionStart hook runs maintenance + drift
+│     classify against Ledger tier rules (T1/T2/T3)
+│     update 13 public pages per AGENTS.md §Step 4
+│     scripts/maintenance/efc_process_paper.py per-paper flow
+│
+├─ modify a sealed prediction
+│   → RFC FIRST (would invalidate .seal-manifest.json)
+│     efc-sealed-prediction-guard.yml blocks the PR otherwise
+│
+├─ add new pipeline
+│   → use som/templates/capability/pipeline/ from AGI
+│     declare under som/capabilities/ in this repo
+│     update layer.yaml provides:
+│
+├─ fix drift detected by SessionStart hook
+│   → AGENTS.md §Step 1 — fix every reported item before other work
+│
+└─ anything that mutates Symbiose Qdrant/Neo4j directly from here
+    → NO. EFC pushes via SYMBIOSE_WEBHOOK_URL only.
+      Mutation happens in supertedai/AGI's shared.ingestion.repo-sync daemon.
+```
+
+## For AI agents
+
+Before starting work in this repo:
+
+1. **Run SessionStart maintenance** (`efc_maintain.py` + `efc_drift_detector.py`) — fix what it reports before anything else.
+2. **Confirm three evidence layers separated** — never blend own DOI / arXiv 4b / working notes.
+3. **No "confirms EFC"** — language discipline is hard rule.
+4. **Cite prior DOI for any new prediction** — in the same sentence as the prediction.
+5. **Sealed predictions are immutable** — re-seal only via RFC.
+6. **External arbitration is council audit** — GPT-5 audit must agree before public pages change.
+
+## What this is NOT
+
+- Not a duplicate of AGI's SOM. Schemas/governance/templates live ONCE, in AGI.
+- Not an exemption from EFC's existing maintenance discipline (AGENTS.md v3.6 still applies).
+- Not a backend-only model. Same template applies to papers, ledger entries, pipelines, atlas.
+
+---
+
+**Locked**: 2026-05-19, RFC-0001 (in supertedai/AGI).
+**Branch**: `claude/backend-daemon-structure-ilT2W`.
+**Canonical companion**: [`OPERATING_MODEL.md` in supertedai/AGI](https://github.com/supertedai/AGI/blob/main/OPERATING_MODEL.md).

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,0 +1,82 @@
+# Symbiose Layer Manifest — supertedai/EFC
+# Validates against som/schemas/layer.schema.json in supertedai/AGI (canonical)
+# See som/README.md for full context.
+
+layer_id:      efc.research
+repo:          supertedai/EFC
+som_version:   1
+locked_at:     2026-05-19
+owner:         morten
+
+description:   >
+  Energy-Flow Cosmology research surface. Holds 165 AI-friendly paper
+  packages (100% coverage), 4 master maintenance orchestrators, ~44
+  maintenance scripts, 6 cosmology pipelines, 1 MCP server, 6 scheduled
+  GitHub Actions workflows, and 5 reproduction scripts. Bridges to
+  Symbiose orchestrator (supertedai/AGI) via SYMBIOSE_WEBHOOK_URL POST
+  on every push or drift-fix.
+
+domains_served:
+  - cosmos        # ~95% of content (every script, every paper)
+  - cognitive     # 1 dedicated bridge: pipelines/efc/hcp_bridge_b1/
+  - meta          # docs/papers/meta/ (HomoFluxus, Proxy, Autopoiesis)
+
+trust_zone:    public      # all content is publishable / publicly verifiable
+sealed:        false
+
+provides:
+  - cosmos.efc.maintain
+  - cosmos.efc.full-sync
+  - cosmos.efc.qdrant-ingest
+  - cosmos.efc.system-health
+  - shared.efc.mcp
+  - cosmos.pipelines.native-v2-graph
+  - cosmos.pipelines.euclid-dr1
+  - cognitive.pipelines.hcp-bridge-b1
+  - cosmos.pipelines.grav-bridge
+  - cosmos.pipelines.nested-sampling
+  - cosmos.pipelines.weak-lensing-case-b
+  - shared.efc.cron-system-health
+  - shared.efc.cron-sync
+  - shared.efc.cron-atlas-sync
+  - shared.efc.cron-figshare-presence
+  - shared.efc.cron-ai-monitor
+  - shared.efc.cron-ai-audit
+
+requires:
+  - shared.platform.qdrant            # via efc_qdrant_ingest (scaffolding)
+  - shared.platform.neo4j             # via Symbiose snapshot pipeline
+  - shared.external.figshare-api      # for DOI verification + uploads
+  - shared.external.openai            # for ai-audit (GPT-5 council)
+  - shared.external.anthropic         # for ai-monitor (Claude observer)
+  - shared.external.wordpress         # via integrations/mcp
+  - shared.external.orcid             # via efc_orcid_sync
+
+publishes_to:
+  - SYMBIOSE_WEBHOOK_URL              # POST { event: efc_push, commit, papers } on every drift-fix
+  - figshare.com                      # DOI deposits + sealed predictions
+  - energyflow-cosmology.com          # WordPress public site
+  - magnusson.as                      # secondary WordPress
+
+consumes_from:
+  - arxiv.org                         # via efc_dataset_scanner
+  - desi.org, euclid.org, kids.org    # Stage-IV survey data feeds
+
+invariants:
+  - "Three evidence layers strictly separated (own DOI / arXiv 4b / working notes)"
+  - "No EFC paper claims 'confirms EFC' — only 'consistent with' (language discipline)"
+  - "Every prediction cites prior EFC DOI in same sentence (pre-registration discipline)"
+  - "Sealed predictions never mutated without explicit re-seal (efc-sealed-prediction-guard.yml)"
+  - "AI council audit passes before public-page mutations land on main"
+
+related_paper_dois:
+  rcmp:                10.6084/m9.figshare.31222900
+  ebe_core:            10.6084/m9.figshare.31222903
+  ontological_v1_0_2:  10.6084/m9.figshare.31223668
+  core_lock:           10.6084/m9.figshare.31223503
+  l0_l3_regime:        10.6084/m9.figshare.31112536
+  wp3_validation:      10.6084/m9.figshare.31970904
+  wp4_susceptibility:  10.6084/m9.figshare.31970907
+  ledger_epistemology: 10.6084/m9.figshare.32256951
+  rce_synthesis:       10.6084/m9.figshare.32256939
+  bar_instability:     10.6084/m9.figshare.32101111

--- a/som/INVENTORY-EFC.md
+++ b/som/INVENTORY-EFC.md
@@ -1,0 +1,98 @@
+# As-Found Inventory — supertedai/EFC — 2026-05-19
+
+## Snapshot
+
+- **Branch**: `main` (HEAD `56f64592`)
+- **AGENTS.md version**: 3.6 (2026-04-12)
+- **Validation Ledger**: v3.18 public / v4.6 internal
+- **AI-friendly papers**: 165 (100% coverage of active set; 2 superseded in `_archived/`)
+- **Stage**: `non_rejectable_model` (global verdict OPEN)
+- **Repo bridge to Symbiose**: `SYMBIOSE_WEBHOOK_URL` secret POST on every drift-fix
+
+## Master orchestrators (canonical EFC "daemons"): **4**
+
+| ID | Path | Trigger | Notes |
+|---|---|---|---|
+| `cosmos.efc.maintain`        | `scripts/maintenance/efc_maintain.py`        | SessionStart hook + CI workflows | Top-level orchestrator |
+| `cosmos.efc.full-sync`       | `scripts/maintenance/efc_full_sync.py`       | invoked from maintain | Fixpoint-convergence over `sync_engine/` |
+| `cosmos.efc.qdrant-ingest`   | `scripts/maintenance/efc_qdrant_ingest.py`   | manual `--apply` only       | **Scaffolding** — upsert gated until embedder wired |
+| `cosmos.efc.system-health`   | `scripts/maintenance/build_system_health.py` | cron hourly (efc-system-health.yml) | Builds `EFC_System_Health.html` |
+
+## Maintenance script library: **~44 Python files**
+
+Located in `scripts/maintenance/` + `scripts/maintenance/phase2/` (newer reimplementations) + `scripts/maintenance/sync_engine/` package.
+
+Non-orchestrator highlights (≤24 grouped by function):
+
+- **DOI/Metadata sync**: efc_sync_dois, efc_auto_metadata, efc_orcid_sync, efc_regen_index, efc_paper_type_classifier
+- **Ledger/Drift**: efc_drift_detector, efc_rootfile_consistency, efc_page_consistency, efc_ledger_autofill, efc_ledger_impact_sync, efc_evidence_mirror, efc_navbar_sync, efc_unprocessed, efc_process_paper, efc_atlas_export
+- **AI/LLM**: efc_ai_brain (70KB), efc_ai_audit, efc_ai_monitor, efc_council_gate, efc_precommit_gate, ledger_schema
+- **Verification**: efc_verify, efc_cross_validate, efc_weekly_scan, efc_dataset_scanner, efc_symbiose_snapshot
+- **Figshare/sealing**: efc_figshare_check, efc_seal_manifest, generate_doi_map, efc_auto_changelog
+- **Changelogs/build**: build_system_health, build_atlas
+
+## MCP server: **1**
+
+- `integrations/mcp/efc_mcp_server.py` (21 KB, stdio MCP).
+- **Capability ID**: `shared.efc.mcp`
+- **Tools**: 15 across EFC repo + 2 WordPress sites (energyflow-cosmology.com, magnusson.as) + figshare.com + framework atlas.
+- **Spec**: `integrations/mcp/server.json`
+- **Tools list**: wp_list_posts, wp_create_post, wp_update_post, figshare_list_articles, figshare_create_article, figshare_upload_file, figshare_publish, validate_jsonld, update_doi_map, sync_metadata, check_links, atlas_list_frameworks, atlas_query, atlas_diff, atlas_summary, full_sync
+- **Prompts**: publish_paper, update_website, validate_all
+- **Resources**: `efc://schema/global`, `efc://doi/map`, `efc://auth/manifest`
+
+## Cosmology pipelines: **6**
+
+| ID | Path | Notes |
+|---|---|---|
+| `cosmos.pipelines.native-v2-graph`      | `pipelines/efc/native_v2_graph/`      | Graph-based AQUAL solver (KT1–KT5). Kernel: aqual/energy/fields/graph/observables/operators/solver. Configs base.yaml + sweeps.yaml. |
+| `cosmos.pipelines.euclid-dr1`           | `pipelines/efc/euclid_dr1/`           | Stage-IV Euclid DR1 pre-registration. efc_mg_functions + efc_hiclass_bridge + euclid_mock_likelihood. cobaya + PolyChord via efc_cobaya.yaml. Sanity checks A–F. |
+| `cognitive.pipelines.hcp-bridge-b1`     | `pipelines/efc/hcp_bridge_b1/`        | HCP neural connectome bridge B1* (η = C/(1+λ₂·τ_c)). The cognitive bridge. |
+| `cosmos.pipelines.grav-bridge`          | `pipelines/efc/grav_bridge/`          | Gravitational bridge. |
+| `cosmos.pipelines.nested-sampling`      | `pipelines/efc/nested_sampling/`      | Full Bayesian evidence (Hull #3). |
+| `cosmos.pipelines.weak-lensing-case-b`  | `pipelines/efc/weak_lensing_case_b/`  | Growth-modified lensing constraints (Hull #4). |
+
+Plus `tools/cobaya_bridge/` (MCMC bridge: bridge_theory.py, 6 YAML configs, efc_mu_table.json, install.sh, run.sh).
+
+## GitHub Actions: **13 workflows, 6 with cron**
+
+| Workflow | Trigger | Schedule (UTC) |
+|---|---|---|
+| efc-system-health.yml      | schedule + push + dispatch | hourly :05 |
+| efc-sync.yml               | push to non-main + schedule + dispatch | nightly 05:30 |
+| atlas-sync.yml             | push + schedule + dispatch | nightly 05:45 |
+| efc-figshare-presence.yml  | schedule + PR + dispatch | weekly Mon 05:00 |
+| efc-ai-monitor.yml         | schedule + dispatch | weekly Mon 06:00 |
+| efc-ai-audit.yml           | schedule + push (public pages) | Wed 06:30 + Mon 07:00 |
+| efc-main-sync.yml          | push to main + dispatch | — |
+| efc-verify.yml             | PRs only | — |
+| atlas-verify.yml           | PRs + atlas-input push | — |
+| efc-page-consistency.yml   | push/PR | — |
+| efc-rootfile-consistency.yml | push/PR | — |
+| efc-sealed-prediction-guard.yml | PR | — |
+| efc-backfill-pdfs.yml      | dispatch only | — |
+
+## Top-level reproduction scripts: **5**
+
+- `reproduce_bao.py` — BAO reproduction
+- `reproduce_cmb_sanity.py` — CMB sanity
+- `reproduce_efc.py` — Master EFC reproduction
+- `reproduce_sparc.py` — SPARC rotation curves
+- `efc_integration_test.py` — Top-level integration test
+
+## Domain breakdown
+
+- **cosmos**: ~95% — every script, every workflow, every paper directory under `docs/papers/efc/`
+- **cognitive**: 1 dedicated pipeline (`hcp_bridge_b1`) + content under `docs/papers/cognitive/`
+- **meta**: 0 dedicated services; content under `docs/papers/meta/` (HomoFluxus, Proxy, Autopoiesis)
+- **shared**: 0 — this repo IS the cosmos research surface
+
+## Important: `efc_repo_sync_daemon` is NOT here
+
+The architectural reference's per-30min `efc_repo_sync_daemon` does NOT exist in this repo as a long-running daemon. Its function is split:
+
+1. `efc-sync.yml` + `efc-main-sync.yml` — run maintenance + POST `{event: efc_push, commit, papers}` to `SYMBIOSE_WEBHOOK_URL`
+2. `efc_qdrant_ingest.py` — scaffolding only (no upsert)
+3. The receiving "per-30min worker" lives in `supertedai/AGI` at `tools/efc_repo_sync_daemon.py`
+
+See `som/registry/daemons.yaml` in AGI for the receiver-side entry: `shared.ingestion.repo-sync`.

--- a/som/README.md
+++ b/som/README.md
@@ -1,0 +1,27 @@
+# Symbiose Operating Model — EFC side
+
+This is the EFC-side mirror of the Symbiose Operating Model. **Canonical SOM lives in supertedai/AGI** at `som/`:
+
+- Schemas: https://github.com/supertedai/AGI/tree/claude/backend-daemon-structure-ilT2W/som/schemas
+- Governance (SOM.md, RCE-CONTRACT.md, loops.md, quality-gates.md): https://github.com/supertedai/AGI/tree/claude/backend-daemon-structure-ilT2W/som/governance
+- Registries (domains.yaml, ports.yaml, daemons.yaml, layers.yaml): https://github.com/supertedai/AGI/tree/claude/backend-daemon-structure-ilT2W/som/registry
+- Templates: https://github.com/supertedai/AGI/tree/claude/backend-daemon-structure-ilT2W/som/templates
+- RFCs: https://github.com/supertedai/AGI/tree/claude/backend-daemon-structure-ilT2W/som/RFCs
+
+This repo carries:
+
+- `/layer.yaml` at repo root — the canonical declaration of EFC as a layer in Symbiose topology
+- `som/capabilities/*.capability.yaml` — the 5 master EFC orchestrators with full RCE 5-component contract
+- `som/INVENTORY-EFC.md` — EFC-side inventory at bootstrap time (2026-05-19)
+
+## Why two-place storage
+
+The SOM is one operating model that applies to all Symbiose repos. Schemas + governance live once, in AGI. Each repo carries only its own `layer.yaml` + per-capability manifests. CI tooling (`sym` CLI from AGI) walks the registry and validates across repos.
+
+When `supertedai/medicine` + `supertedai/economy` + `supertedai/biology` + `supertedai/earth` come online, each gets the same skeleton: `/layer.yaml`, `/som/capabilities/`, `/som/INVENTORY-<repo>.md`. Same gates apply.
+
+## Status
+
+Bootstrapped 2026-05-19 on `claude/backend-daemon-structure-ilT2W` (this branch).
+
+See RFC-0001 in AGI for the full proposal.

--- a/som/capabilities/cosmos.efc.full-sync.capability.yaml
+++ b/som/capabilities/cosmos.efc.full-sync.capability.yaml
@@ -1,0 +1,72 @@
+id:           cosmos.efc.full-sync
+version:      1.0.0
+kind:         workflow
+domain:       cosmos
+layer:        efc.research
+group:        maintenance
+trust_zone:   public
+maturity:     stable
+lifecycle:    active
+owner:        morten
+
+rce:
+  regime:
+    physical_regime: S_trans
+    epistemic_layer: L1
+    regime_domain:   cosmological_L0_L3
+    coupling_operators: [classify, handlers, derived, invariants]
+  frozen_parameters:
+    declared: [fixpoint_max_iterations]
+    registry_ref: neo4j://FrozenParameter/efc_full_sync_v1
+  sealed_predictions: { deposits_sha256: [], figshare_dois: [] }
+  living_ledger:
+    ledger_path: docs/validation-ledger/data/ledger.json
+    neo4j_label: LedgerEntry
+    last_audit: 2026-05-13T00:00:00Z
+  external_arbitration:
+    channel: council_audit
+    arbiter_ref: efc-cross-validate (cross-checks public pages vs repo)
+
+rcp:
+  regime_locality: true
+  variety_closure: true
+  modelling_closure: true
+  frozen_parameter_governance: true
+  external_arbitration: true
+
+port: { http: null, metrics: null, health: null }
+resources: { cpu: "1", mem: "2Gi", disk: "1Gi" }
+
+schedule:
+  trigger: hybrid
+  events: ["invoked-from-efc_maintain", "on-demand-dispatch"]
+
+restart_policy: "no"
+
+depends_on:
+  - cosmos.efc.maintain
+  - shared.external.figshare-api
+
+storage:
+  qdrant_collections: []
+  neo4j_labels: []
+  files: [scripts/maintenance/sync_engine/state.py]
+
+sli:
+  - { name: fixpoint_iterations_to_converge, threshold: 5, window: 1d }
+  - { name: nondeterminism_drops_total, threshold: 0, window: 24h }
+
+slo:
+  - { objective: convergence, target: 1.0, window: 30d, error_budget: 0.01 }
+
+invariants:
+  - "Fixpoint converges in finite iterations or raises"
+  - "Idempotent on stable state"
+
+runbook: docs/runbooks/cosmos.efc.full-sync.md
+
+provenance:
+  source_repo: supertedai/EFC
+  source_path: scripts/maintenance/efc_full_sync.py
+  generated: false
+  first_seen_inventory: 2026-05-19

--- a/som/capabilities/cosmos.efc.maintain.capability.yaml
+++ b/som/capabilities/cosmos.efc.maintain.capability.yaml
@@ -1,0 +1,98 @@
+id:           cosmos.efc.maintain
+version:      1.0.0
+kind:         workflow
+domain:       cosmos
+layer:        efc.research
+group:        maintenance
+trust_zone:   public
+maturity:     stable
+lifecycle:    active
+owner:        morten
+
+rce:
+  regime:
+    physical_regime: S_trans
+    epistemic_layer: L1
+    regime_domain:   cosmological_L0_L3
+    coupling_operators:
+      - paper_package_to_ledger
+      - drift_to_fix
+      - council_to_gate
+  frozen_parameters:
+    declared:
+      - validation_ledger_version_public
+      - validation_ledger_version_internal
+      - ai_friendly_paper_count_target
+    registry_ref: neo4j://FrozenParameter/efc_maintain_v3.18
+  sealed_predictions:
+    deposits_sha256: []          # populated by efc_seal_manifest.py
+    figshare_dois: []            # 102+ DOIs tracked in figshare/doi-map.json
+  living_ledger:
+    ledger_path: docs/validation-ledger/data/ledger.json
+    neo4j_label: LedgerEntry
+    last_audit: 2026-05-13T00:00:00Z
+  external_arbitration:
+    channel: council_audit
+    arbiter_ref: efc-ai-audit.yml (weekly GPT-5 council)
+
+rcp:
+  regime_locality: true
+  variety_closure: true
+  modelling_closure: true
+  frozen_parameter_governance: true
+  external_arbitration: true
+
+port: { http: null, metrics: null, health: null }   # workflow, no listening port
+resources: { cpu: "1", mem: "2Gi", disk: "2Gi" }
+
+schedule:
+  trigger: hybrid
+  events: ["SessionStart-hook", "on-push-non-main", "cron-efc-sync", "cron-efc-main-sync"]
+
+restart_policy: "no"   # one-shot per invocation
+
+depends_on:
+  - shared.external.figshare-api
+  - shared.external.orcid
+  - shared.external.openai      # ai_brain + ai_audit
+  - shared.external.anthropic   # ai_monitor
+
+publishes:
+  - subject: efc.drift.fixed
+    schema:  schemas/events/efc_drift_fixed.v1.json
+  - subject: SYMBIOSE_WEBHOOK_URL   # POST { event: efc_push, commit, papers }
+    schema:  schemas/events/efc_push_webhook.v1.json
+
+storage:
+  qdrant_collections: []         # invokes efc_qdrant_ingest separately
+  neo4j_labels: []               # writes via Symbiose orchestrator side
+  files:
+    - docs/validation-ledger/data/evidence-register.json
+    - docs/validation-ledger/data/ledger.json
+    - docs/public/*.html
+    - docs/papers/efc/*/index.json
+    - figshare/doi-map.json
+
+sli:
+  - { name: maintain_duration_seconds, threshold: 600, window: 1h }
+  - { name: drift_fix_count_per_run, threshold: 50, window: 24h }
+  - { name: invariant_violations_total, threshold: 0, window: 24h }
+
+slo:
+  - { objective: maintain_completes_clean, target: 1.0, window: 30d, error_budget: 0.05 }
+  - { objective: council_audit_pass_rate, target: 0.95, window: 30d, error_budget: 0.05 }
+
+invariants:
+  - "C1–C8 invariants in efc_verify.py pass before commit"
+  - "No 'confirms EFC' language in public pages"
+  - "Every prediction cites prior DOI in same sentence"
+  - "Three evidence layers strictly separated (own DOI / arXiv 4b / working notes)"
+  - "medicine_clinical content never written to AGI repo"
+
+runbook: scripts/maintenance/README.md
+
+provenance:
+  source_repo: supertedai/EFC
+  source_path: scripts/maintenance/efc_maintain.py
+  generated: false
+  first_seen_inventory: 2026-05-19

--- a/som/capabilities/cosmos.efc.qdrant-ingest.capability.yaml
+++ b/som/capabilities/cosmos.efc.qdrant-ingest.capability.yaml
@@ -1,0 +1,81 @@
+id:           cosmos.efc.qdrant-ingest
+version:      0.1.0
+kind:         workflow
+domain:       cosmos
+layer:        efc.research
+group:        maintenance
+trust_zone:   public
+maturity:     experimental
+lifecycle:    active
+owner:        morten
+
+# NOTE: Currently scaffolding-only. Upsert is intentionally gated until
+# provider-specific embedder is wired (env: EMBEDDING_PROVIDER).
+# Runs on demand via `--apply`. No cron.
+
+rce:
+  regime:
+    physical_regime: S_flow
+    epistemic_layer: L1
+    regime_domain:   cosmological_L0_L3
+    coupling_operators: [paper_to_chunk, chunk_to_embedding, embedding_to_qdrant_point]
+  frozen_parameters:
+    declared:
+      - qdrant_url
+      - qdrant_api_key
+      - embedding_provider
+      - point_id_strategy
+    registry_ref: neo4j://FrozenParameter/efc_qdrant_ingest_v0_1
+  sealed_predictions: { deposits_sha256: [], figshare_dois: [] }
+  living_ledger:
+    ledger_path: docs/validation-ledger/data/qdrant-ingest.ledger.json
+    neo4j_label: LedgerEntry
+    last_audit: 2026-05-13T00:00:00Z
+  external_arbitration:
+    channel: none_yet
+    arbiter_ref: ""
+
+rcp:
+  regime_locality: true
+  variety_closure: true
+  modelling_closure: true
+  frozen_parameter_governance: true
+  external_arbitration: false
+  rcp_exemption_rfc: RFC-0001  # experimental — external arbiter pending embedder wiring
+
+port: { http: null, metrics: null, health: null }
+resources: { cpu: "1", mem: "4Gi", disk: "4Gi" }
+
+schedule:
+  trigger: manual
+
+restart_policy: "no"
+
+depends_on:
+  - shared.platform.qdrant
+  - shared.external.openai      # or voyage / local per EMBEDDING_PROVIDER
+
+storage:
+  qdrant_collections: [efc_papers, efc_atlas]
+  neo4j_labels: []
+  files: []
+
+sli:
+  - { name: ingest_throughput_papers_per_minute, threshold: 1, window: 5m }
+  - { name: embedding_error_rate, threshold: 0.05, window: 1h }
+
+slo:
+  - { objective: scaffolding_completes, target: 1.0, window: 30d, error_budget: 0.05 }
+
+invariants:
+  - "Upsert disabled until embedder wired (currently scaffolding)"
+  - "Point IDs stable across runs (deterministic from paper DOI)"
+  - "Two collections created: efc_papers + efc_atlas"
+
+runbook: docs/runbooks/cosmos.efc.qdrant-ingest.md
+
+provenance:
+  source_repo: supertedai/EFC
+  source_path: scripts/maintenance/efc_qdrant_ingest.py
+  generated: false
+  first_seen_inventory: 2026-05-19

--- a/som/capabilities/cosmos.efc.system-health.capability.yaml
+++ b/som/capabilities/cosmos.efc.system-health.capability.yaml
@@ -1,0 +1,74 @@
+id:           cosmos.efc.system-health
+version:      1.0.0
+kind:         workflow
+domain:       cosmos
+layer:        efc.research
+group:        maintenance
+trust_zone:   public
+maturity:     stable
+lifecycle:    active
+owner:        morten
+
+rce:
+  regime:
+    physical_regime: S_trans
+    epistemic_layer: L1
+    regime_domain:   cosmological_L0_L3
+    coupling_operators: [orcid_to_doi_to_ledger_to_html]
+  frozen_parameters:
+    declared: [system_health_page_path, orcid_cache_ttl_hours]
+    registry_ref: neo4j://FrozenParameter/efc_system_health_v1
+  sealed_predictions: { deposits_sha256: [], figshare_dois: [] }
+  living_ledger:
+    ledger_path: docs/validation-ledger/data/system-health.ledger.json
+    neo4j_label: LedgerEntry
+    last_audit: 2026-05-13T00:00:00Z
+  external_arbitration:
+    channel: external_replication
+    arbiter_ref: "public users replicate EFC_System_Health.html numbers"
+
+rcp:
+  regime_locality: true
+  variety_closure: true
+  modelling_closure: true
+  frozen_parameter_governance: true
+  external_arbitration: true
+
+port: { http: null, metrics: null, health: null }
+resources: { cpu: "500m", mem: "512Mi", disk: "500Mi" }
+
+schedule:
+  trigger: cron
+  cron: "5 * * * *"   # hourly :05 via efc-system-health.yml
+
+restart_policy: "no"
+
+depends_on:
+  - shared.external.orcid
+  - shared.external.figshare-api
+
+publishes: []
+
+storage:
+  qdrant_collections: []
+  neo4j_labels: []
+  files: [docs/public/EFC_System_Health.html]
+
+sli:
+  - { name: build_duration_seconds, threshold: 60, window: 1h }
+  - { name: orcid_cache_hit_rate, threshold: 0.95, window: 24h }
+
+slo:
+  - { objective: hourly_run_success, target: 0.99, window: 30d, error_budget: 0.01 }
+
+invariants:
+  - "Always commits if file changed; never commits if file unchanged"
+  - "Cache misses do not block run (graceful degrade to last good)"
+
+runbook: docs/runbooks/cosmos.efc.system-health.md
+
+provenance:
+  source_repo: supertedai/EFC
+  source_path: scripts/maintenance/build_system_health.py
+  generated: false
+  first_seen_inventory: 2026-05-19

--- a/som/capabilities/shared.efc.mcp.capability.yaml
+++ b/som/capabilities/shared.efc.mcp.capability.yaml
@@ -1,0 +1,108 @@
+id:           shared.efc.mcp
+version:      1.0.0
+kind:         mcp_server
+domain:       shared
+layer:        efc.research
+group:        api
+trust_zone:   internal
+maturity:     stable
+lifecycle:    active
+owner:        morten
+
+rce:
+  regime:
+    physical_regime: S_flow
+    epistemic_layer: L2
+    regime_domain:   cross
+    coupling_operators: [tool_invocation, multi_surface_write]
+  frozen_parameters:
+    declared:
+      - wp_endpoints
+      - figshare_endpoints
+      - tools_list_spec
+    registry_ref: neo4j://FrozenParameter/efc_mcp_v1
+  sealed_predictions: { deposits_sha256: [], figshare_dois: [] }
+  living_ledger:
+    ledger_path: integrations/mcp/_ledger.json
+    neo4j_label: LedgerEntry
+    last_audit: 2026-05-13T00:00:00Z
+  external_arbitration:
+    channel: external_replication
+    arbiter_ref: "WordPress + Figshare external state"
+
+rcp:
+  regime_locality: true
+  variety_closure: true
+  modelling_closure: true
+  frozen_parameter_governance: true
+  external_arbitration: true
+
+port: { http: null, metrics: null, health: null }   # stdio MCP, no port
+resources: { cpu: "500m", mem: "512Mi", disk: "100Mi" }
+
+schedule:
+  trigger: continuous
+
+restart_policy: always
+
+depends_on:
+  - shared.external.wordpress      # energyflow-cosmology.com + magnusson.as
+  - shared.external.figshare-api
+  - efc-repo-fs
+
+subscribes: []  # MCP is request/response, not subscribe
+publishes: []
+
+storage:
+  qdrant_collections: []
+  neo4j_labels: []
+  files:
+    - figshare/doi-map.json     # via update_doi_map tool
+    - docs/papers/efc/*/index.json  # via sync_metadata tool
+
+tools_exposed:
+  - wp_list_posts
+  - wp_create_post
+  - wp_update_post
+  - figshare_list_articles
+  - figshare_create_article
+  - figshare_upload_file
+  - figshare_publish
+  - validate_jsonld
+  - update_doi_map
+  - sync_metadata
+  - check_links
+  - atlas_list_frameworks
+  - atlas_query
+  - atlas_diff
+  - atlas_summary
+  - full_sync
+prompts_exposed:
+  - publish_paper
+  - update_website
+  - validate_all
+resources_exposed:
+  - efc://schema/global
+  - efc://doi/map
+  - efc://auth/manifest
+
+sli:
+  - { name: tool_call_latency_p95_seconds, threshold: 5, window: 5m }
+  - { name: tool_error_rate, threshold: 0.02, window: 1h }
+
+slo:
+  - { objective: availability, target: 0.99, window: 30d, error_budget: 0.01 }
+
+invariants:
+  - "WP API credentials never logged"
+  - "Figshare token never logged"
+  - "validate_jsonld is read-only (cannot mutate schema)"
+  - "check_links never modifies repo state"
+
+runbook: docs/runbooks/shared.efc.mcp.md
+
+provenance:
+  source_repo: supertedai/EFC
+  source_path: integrations/mcp/efc_mcp_server.py
+  generated: false
+  first_seen_inventory: 2026-05-19


### PR DESCRIPTION
## Summary

Lands EFC's side of the Symbiose Operating Model (SOM): a `layer.yaml` at repo root declaring EFC as the `cosmos.research` layer, plus 5 per-capability manifests for the master EFC orchestrators with full RCE 5-component contract.

**Canonical SOM lives in `supertedai/AGI` at `som/`** — schemas, governance, registries, templates, RFCs. This repo carries only its own `layer.yaml` + per-capability files. Same model will apply to medicine/economy/biology/earth when scope opens.

## What landed

- `/layer.yaml` — EFC layer declaration: provides 5 master orchestrators + 1 MCP + 6 pipelines + 6 scheduled workflows; requires Qdrant/Neo4j (Symbiose side) + Figshare/ORCID/OpenAI/Anthropic externals; publishes to SYMBIOSE_WEBHOOK_URL + figshare.com + energyflow-cosmology.com
- `som/README.md` — pointer to AGI as canonical SOM
- `som/INVENTORY-EFC.md` — detailed 2026-05-19 EFC inventory
- `som/capabilities/cosmos.efc.maintain.capability.yaml` — master orchestrator (efc_maintain.py)
- `som/capabilities/cosmos.efc.full-sync.capability.yaml` — fixpoint sync engine
- `som/capabilities/cosmos.efc.qdrant-ingest.capability.yaml` — scaffolding (rcp_exemption pending embedder)
- `som/capabilities/cosmos.efc.system-health.capability.yaml` — hourly build_system_health.py
- `som/capabilities/shared.efc.mcp.capability.yaml` — efc_mcp_server.py with full tool/prompt/resource catalog

Each capability declares: physical_regime, epistemic_layer, regime_domain, coupling_operators, frozen_parameters, sealed_predictions, living_ledger, external_arbitration + RCP 5 conditions.

## Important: `efc_repo_sync_daemon` is split

The architectural reference's per-30min `efc_repo_sync_daemon` does NOT live in this repo as a daemon. Its function is split between:

1. `efc-sync.yml` + `efc-main-sync.yml` (CI workflows posting to `SYMBIOSE_WEBHOOK_URL`)
2. `efc_qdrant_ingest.py` (scaffolding, no upsert yet)
3. The receiver in AGI at `tools/efc_repo_sync_daemon.py` (registered as `shared.ingestion.repo-sync` in `som/registry/daemons.yaml`)

This is documented in `som/INVENTORY-EFC.md`.

## Companion PR

AGI side (canonical SOM home): https://github.com/supertedai/AGI/pull/new/claude/backend-daemon-structure-ilT2W

## Test plan

- [ ] Manual: read `layer.yaml` + 5 capability files, verify field correctness vs actual scripts
- [ ] Validate `provides:` list in layer.yaml matches the 17 capabilities listed in AGI's `som/registry/daemons.yaml` (EFC section)
- [ ] Validate SYMBIOSE_WEBHOOK_URL is the only outbound mutation channel (per invariants)
- [ ] Confirm `cosmos.efc.qdrant-ingest`'s `rcp_exemption_rfc: RFC-0001` is acceptable while embedder is unwired
- [ ] Review with morten: do RCE field choices survive scrutiny?

## Out of scope here

- No changes to `scripts/maintenance/` Python files
- No changes to `.github/workflows/` configs
- No changes to `docs/papers/efc/` paper packages
- No changes to `pipelines/efc/` pipeline implementations

This PR is purely additive metadata. Existing EFC maintenance discipline (AGENTS.md v3.6, Ledger v3.18 public / v4.6 internal) is unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmd5UBp7tTEgLbnErHDe6S)_