### PR TITLE
fix(efc): resolve committed conflict markers in jwst_hmf_prereg_v4

### DIFF
--- a/.claude/drift_report.json
+++ b/.claude/drift_report.json
@@ -2,14 +2,6 @@
   "paper_count": 165,
   "drift": [
     {
-      "file": "Elevator_Pitch",
-      "type": "tests_active",
-      "claimed": 105,
-      "actual": 115,
-      "context": "pill survived\">105/105 survived</span>\n    &nb",
-      "match_form": "ratio"
-    },
-    {
       "file": "Changelog",
       "type": "paper_count",
       "claimed": 158,

--- a/docs/papers/efc/jwst_hmf_prereg_v4/ai_manifest.json
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/ai_manifest.json
@@ -8,7 +8,7 @@
   "license": "CC-BY-4.0",
   "package_type": "ai-friendly-paper",
   "schema_version": "1.0",
-  "generated": "2026-05-04",
+  "generated": "2026-06-08",
   "track": "Spor general",
   "regimes": [],
   "primary_pdf": "jwst_hmf_prereg_v4_FINAL.pdf",
@@ -34,11 +34,11 @@
     },
     {
       "path": "data/parameters.json",
-      "bytes": 4939
+      "bytes": 2674
     },
     {
       "path": "examples/demo_jwst_hmf_prereg_v4.py",
-      "bytes": 7325
+      "bytes": 4137
     },
     {
       "path": "index.json",
@@ -66,7 +66,7 @@
     },
     {
       "path": "src/jwst_hmf_prereg_v4.py",
-      "bytes": 19543
+      "bytes": 10537
     }
   ],
   "n_files": 14,

--- a/docs/papers/efc/jwst_hmf_prereg_v4/data/parameters.json
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/data/parameters.json
@@ -1,42 +1,4 @@
 {
-<<<<<<< HEAD
-  "_description": "Key numerical values from the EFC JWST HMF Pre-Registration v4 (DOI 10.6084/m9.figshare.32149654)",
-  "cosmology": {
-    "H0_km_s_Mpc": 67.4,
-    "Omega_m0": 0.315,
-    "Omega_Lambda0": 0.685,
-    "sigma8": 0.811,
-    "n_s": 0.965,
-    "Omega_b": 0.0493,
-    "rho_crit0_h2_Msun_Mpc3": 277500000000.0,
-    "delta_c": 1.686,
-    "CMB_temp_K": 2.7255
-  },
-  "efc_gate_parameters": {
-    "B": {
-      "description": "Perturbation-channel amplitude in mu(a) = 1 - B g(a)",
-      "default_illustrative": 0.04,
-      "note": "To be fixed by joint S(z)-fit (vc 4ea464e38b5f)"
-    },
-    "z_t": {
-      "description": "Transition redshift of the gate function",
-      "default_illustrative": 3.0,
-      "note": "To be fixed by joint S(z)-fit"
-    },
-    "n": {
-      "description": "Steepness exponent of the gate function",
-      "default_illustrative": 4.0,
-      "note": "To be fixed by joint S(z)-fit"
-    }
-  },
-  "efc_equations": {
-    "gate_function": "g(a) = 1 / (1 + (z_t / z(a))^n), z(a) = 1/a - 1",
-    "mu_eff": "mu(a) = 1 - B * g(a)",
-    "delta_E2": "Delta_E2(a) = A * [g(a) - g(0)]",
-    "chain": "g(a) -> mu(a) -> D(a) -> sigma(M,z) -> n(M,z)"
-  },
-  "prediction_redshifts": [
-=======
   "paper_metadata": {
     "title": "Pre-Registration: EFC dN/dM (z>7) \u2014 Halo Mass Function via mu(a) Perturbation Channel",
     "author": "Morten Magnusson",
@@ -86,7 +48,6 @@
     "delta_c": 1.686
   },
   "redshift_targets": [
->>>>>>> origin/main
     7,
     8,
     9,
@@ -104,46 +65,13 @@
     "a": 0.707,
     "p": 0.3
   },
-<<<<<<< HEAD
-  "tinker_2008_params_Delta200": {
-=======
   "tinker2008_params_delta200": {
->>>>>>> origin/main
     "A0": 0.186,
     "a0": 1.47,
     "b0": 2.57,
     "c0": 1.19
   },
   "falsification_criteria": {
-<<<<<<< HEAD
-    "acceptance_threshold": "Delta_chi2 < 4",
-    "falsification_threshold": ">3 sigma disagreement",
-    "datasets": [
-      "JWST CEERS",
-      "JWST COSMOS-Web",
-      "JWST GLASS"
-    ]
-  },
-  "validation_candidates": {
-    "this_document": "vc de9a6ee1deb6",
-    "joint_Sz_fit": "vc 4ea464e38b5f"
-  },
-  "prior_prereg_dois": {
-    "SO_Euclid_EG": "10.6084/m9.figshare.32023788",
-    "Rubin_DP2_shear": "10.6084/m9.figshare.32013738",
-    "DESI_fsigma8": "10.6084/m9.figshare.32013156"
-  },
-  "technical_note_dois": {
-    "TN_I_gate_calibration": "10.6084/m9.figshare.31333414",
-    "TN_II_perturbation_channel": "10.6084/m9.figshare.31333600"
-  },
-  "regime": {
-    "atlas_level": "L3",
-    "mechanism": "S_flow boost at high z",
-    "observable": "high-z mass function / early structure JWST"
-  },
-  "sealing_protocol": "SHA-256 hash of numerical n(M,z) tables computed once (B, z_t, n) are fixed"
-=======
     "acceptance": "Delta_chi2 < 4",
     "falsification": ">3 sigma disagreement against JWST CEERS / COSMOS-Web / GLASS counts"
   },
@@ -169,5 +97,4 @@
     "GLASS"
   ],
   "sealing_protocol": "SHA-256 hash of numerical curves before data confrontation"
->>>>>>> origin/main
 }

--- a/docs/papers/efc/jwst_hmf_prereg_v4/examples/demo_jwst_hmf_prereg_v4.py
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/examples/demo_jwst_hmf_prereg_v4.py
@@ -1,13 +1,7 @@
 """demo_jwst_hmf_prereg_v4.py
 
-<<<<<<< HEAD
-Demonstration of the EFC HMF prediction chain at z = 7-12.
-Produces a comparison of EFC vs LCDM halo mass functions using
-three prescriptions (PS, ST, Tinker).
-=======
 Demonstration script for the EFC JWST HMF pre-registration prediction chain.
 Computes halo mass functions at z=7-12 for LCDM and EFC, and optionally plots them.
->>>>>>> origin/main
 """
 import numpy as np
 import sys
@@ -16,90 +10,6 @@ try:
     import matplotlib
     matplotlib.use('Agg')
     import matplotlib.pyplot as plt
-<<<<<<< HEAD
-    HAS_PLT = True
-except ImportError:
-    HAS_PLT = False
-
-from jwst_hmf_prereg_v4 import (
-    build_D_interpolator, dn_dM,
-    B_DEFAULT, ZT_DEFAULT, N_EXP_DEFAULT
-)
-
-# ---- configuration ----
-redshifts = [7, 8, 9, 10, 11, 12]
-log_M = np.linspace(9.5, 13.0, 40)  # log10(M / [Msun/h])
-M_arr = 10**log_M
-prescriptions = ['PS', 'ST', 'Tinker']
-
-# ---- build growth interpolators ----
-print('Building LCDM growth factor...')
-D_lcdm = build_D_interpolator(B=0.0)
-print('Building EFC growth factor  (B={}, zt={}, n={})...'.format(
-    B_DEFAULT, ZT_DEFAULT, N_EXP_DEFAULT))
-D_efc = build_D_interpolator()
-
-# ---- compute HMFs and print summary table ----
-print('\n{:>4s}  {:>12s}  {:>6s}  {:>12s}  {:>12s}  {:>8s}'.format(
-    'z', 'log10 M', 'HMF', 'dn/dM LCDM', 'dn/dM EFC', 'ratio'))
-print('-' * 70)
-
-results = {}
-for presc in prescriptions:
-    results[presc] = {}
-    for z in redshifts:
-        hmf_lcdm = np.array([dn_dM(M, z, D_lcdm, presc) for M in M_arr])
-        hmf_efc  = np.array([dn_dM(M, z, D_efc,  presc) for M in M_arr])
-        results[presc][z] = (hmf_lcdm, hmf_efc)
-        # print one representative mass bin
-        idx = 20  # ~log M = 11.3
-        if hmf_lcdm[idx] > 0:
-            ratio = hmf_efc[idx] / hmf_lcdm[idx]
-        else:
-            ratio = np.inf
-        if presc == 'ST':  # keep table concise
-            print(f'{z:4d}  {log_M[idx]:12.2f}  {presc:>6s}  '
-                  f'{hmf_lcdm[idx]:12.4e}  {hmf_efc[idx]:12.4e}  '
-                  f'{ratio:8.3f}')
-
-# ---- growth factor comparison ----
-print('\nGrowth factor D(z) comparison:')
-print('{:>4s}  {:>10s}  {:>10s}  {:>10s}'.format(
-    'z', 'D_LCDM', 'D_EFC', 'D_EFC/D_LCDM'))
-for z in redshifts:
-    a = 1.0 / (1.0 + z)
-    dl = float(D_lcdm(a))
-    de = float(D_efc(a))
-    print(f'{z:4d}  {dl:10.6f}  {de:10.6f}  {de/dl:10.6f}')
-
-# ---- optional plot ----
-if HAS_PLT:
-    fig, axes = plt.subplots(2, 3, figsize=(15, 9), sharex=True, sharey=True)
-    colors = {'LCDM': 'C0', 'EFC': 'C1'}
-    for i, z in enumerate(redshifts):
-        ax = axes[i // 3][i % 3]
-        for presc in prescriptions:
-            lcdm, efc = results[presc][z]
-            ls = {"PS": ":", "ST": "-", "Tinker": "--"}[presc]
-            mask = lcdm > 0
-            ax.plot(log_M[mask], np.log10(lcdm[mask]),
-                    ls=ls, color='C0', label=f'LCDM {presc}' if i == 0 else '')
-            mask2 = efc > 0
-            ax.plot(log_M[mask2], np.log10(efc[mask2]),
-                    ls=ls, color='C1', label=f'EFC {presc}' if i == 0 else '')
-        ax.set_title(f'z = {z}')
-        ax.set_xlabel(r'$\log_{10}(M\;[M_\odot/h])$')
-        ax.set_ylabel(r'$\log_{10}(dn/dM)$')
-        ax.set_ylim(-25, -5)
-    axes[0][0].legend(fontsize=7, ncol=2)
-    plt.tight_layout()
-    plt.savefig('efc_hmf_prediction_z7_12.png', dpi=150)
-    print('\nPlot saved to efc_hmf_prediction_z7_12.png')
-else:
-    print('\nMatplotlib not available — skipping plot.')
-
-print('\nDone.')
-=======
     HAS_MPL = True
 except ImportError:
     HAS_MPL = False
@@ -202,4 +112,3 @@ def main():
 
 if __name__ == '__main__':
     main()
->>>>>>> origin/main

--- a/docs/papers/efc/jwst_hmf_prereg_v4/src/jwst_hmf_prereg_v4.py
+++ b/docs/papers/efc/jwst_hmf_prereg_v4/src/jwst_hmf_prereg_v4.py
@@ -1,181 +1,15 @@
 """jwst_hmf_prereg_v4.py
 
-<<<<<<< HEAD
-Reference implementation of the EFC prediction chain for the high-redshift
-halo mass function (HMF) as described in:
-
-  Pre-Registration: EFC dN/dM (z>7) — Halo Mass Function via mu(a)
-  Perturbation Channel, Magnusson 2026, DOI 10.6084/m9.figshare.32149654
-
-Chain: g(a) -> mu(a) -> D(a) -> sigma(M,z) -> n(M,z)
-=======
 Reference implementation of the EFC halo mass function prediction chain
 from Magnusson (2026) Pre-Registration: EFC dN/dM (z>7).
 
 Chain: g(a) -> mu(a) -> D(a) -> sigma(M,z) -> n(M,z)
 
 Equations follow the paper exactly (Eqs. 1-3 and the five-step chain).
->>>>>>> origin/main
 """
 import numpy as np
 from scipy.integrate import solve_ivp, quad
 from scipy.interpolate import interp1d
-<<<<<<< HEAD
-from typing import Tuple, Callable, Optional
-
-# --------------- physical constants / fiducial cosmology -----------------
-H0 = 67.4          # km/s/Mpc  (Planck 2018)
-OMEGA_M0 = 0.315
-OMEGA_L0 = 1.0 - OMEGA_M0
-N_S = 0.965
-SIGMA8 = 0.811
-RHO_CRIT0 = 2.775e11  # h^2 Msun / Mpc^3
-RHO_M0 = OMEGA_M0 * RHO_CRIT0  # h^2 Msun / Mpc^3
-DELTA_C = 1.686      # spherical-collapse threshold
-
-# --------------- EFC gate parameters (placeholders until joint S(z)-fit) --
-B_DEFAULT = 0.04     # perturbation amplitude (illustrative)
-ZT_DEFAULT = 3.0     # transition redshift
-N_EXP_DEFAULT = 4.0  # steepness exponent
-
-
-# ========================== Step 1: gate function =========================
-def gate_function(a: float, zt: float = ZT_DEFAULT,
-                  n: float = N_EXP_DEFAULT) -> float:
-    """EFC gate function g(a) — Eq. (2)."""
-    z = 1.0 / a - 1.0
-    if z <= 0:
-        return 1.0
-    return 1.0 / (1.0 + (zt / z) ** n)
-
-
-# ========================== Step 2: mu(a) =================================
-def mu_eff(a: float, B: float = B_DEFAULT, zt: float = ZT_DEFAULT,
-           n: float = N_EXP_DEFAULT) -> float:
-    """Effective gravitational coupling mu(a) = 1 - B g(a) — Eq. (3)."""
-    return 1.0 - B * gate_function(a, zt, n)
-
-
-# ========================== Step 3: growth factor D(a) ====================
-def _E2_lcdm(a: float) -> float:
-    """(H/H0)^2 for flat LCDM."""
-    return OMEGA_M0 * a**-3 + OMEGA_L0
-
-
-def _delta_E2(a: float, A: float, zt: float, n: float) -> float:
-    """Background EFC correction Delta E^2 — Eq. (1)."""
-    return A * (gate_function(a, zt, n) - gate_function(1e-6, zt, n))
-
-
-def solve_growth(B: float = B_DEFAULT, zt: float = ZT_DEFAULT,
-                 n: float = N_EXP_DEFAULT,
-                 A: float = 0.0,
-                 a_start: float = 1e-4, a_end: float = 1.0,
-                 n_pts: int = 2000) -> Tuple[np.ndarray, np.ndarray]:
-    """Solve the modified linear growth ODE and return (a_arr, D_arr).
-
-    The ODE for f = d ln D / d ln a is:
-        a df/da + f^2 + f [1/2 - 3/2 w_eff(a)] - 3/2 mu(a) Omega_m(a) = 0
-    For dust (w_eff ~ 0 in matter era) this simplifies; we keep the full
-    expression using Omega_m(a) = Omega_m0 a^{-3} / E^2(a).
-
-    We integrate the second-order form for delta:
-        delta'' + (3/a + E'/E) delta' - 3/(2a^2) mu(a) Omega_m(a) delta = 0
-    rewritten as a system in ln(a).
-    """
-    lna = np.linspace(np.log(a_start), np.log(a_end), n_pts)
-
-    def rhs(lna_val, y):
-        a_val = np.exp(lna_val)
-        E2 = _E2_lcdm(a_val) + _delta_E2(a_val, A, zt, n)
-        E2 = max(E2, 1e-30)
-        Om_a = OMEGA_M0 * a_val**-3 / E2
-        # d(E2)/d(lna) via finite diff
-        da = a_val * 1e-5
-        E2p = _E2_lcdm(a_val + da) + _delta_E2(a_val + da, A, zt, n)
-        E2m = _E2_lcdm(a_val - da) + _delta_E2(a_val - da, A, zt, n)
-        dE2_dlna = (E2p - E2m) / (2.0 * 1e-5)  # dE2/dlna = a dE2/da
-        eps = dE2_dlna / (2.0 * E2)  # d ln E / d ln a
-
-        mu = mu_eff(a_val, B, zt, n)
-        # y = [delta, d(delta)/d(lna)]
-        ddelta = y[1]
-        dd_delta = -(2.0 + eps) * y[1] + 1.5 * mu * Om_a * y[0]
-        return [ddelta, dd_delta]
-
-    y0 = [a_start, a_start]  # growing mode D ~ a in matter dom.
-    sol = solve_ivp(rhs, [lna[0], lna[-1]], y0, t_eval=lna,
-                    rtol=1e-10, atol=1e-14, method='DOP853')
-    a_arr = np.exp(sol.t)
-    D_arr = sol.y[0]
-    D_arr = D_arr / D_arr[-1]  # normalise D(a=1)=1
-    return a_arr, D_arr
-
-
-# ========================== Step 4: sigma(M, z) ===========================
-def _top_hat_W(kR: np.ndarray) -> np.ndarray:
-    """Fourier-space top-hat window."""
-    return 3.0 * (np.sin(kR) - kR * np.cos(kR)) / kR**3
-
-
-def mass_to_radius(M: float) -> float:
-    """Lagrangian radius R [Mpc/h] for mass M [Msun/h]."""
-    return (3.0 * M / (4.0 * np.pi * RHO_M0)) ** (1.0 / 3.0)
-
-
-def _Pk_EH(k: np.ndarray) -> np.ndarray:
-    """Eisenstein-Hu no-wiggle power spectrum (shape only), normalised later."""
-    h = H0 / 100.0
-    Omh2 = OMEGA_M0 * h**2
-    Omb = 0.0493
-    Obh2 = Omb * h**2
-    theta = 2.7255 / 2.7  # CMB temp ratio
-    s = 44.5 * np.log(9.83 / Omh2) / np.sqrt(1 + 10 * Obh2**0.75)
-    alpha_g = 1 - 0.328 * np.log(431 * Omh2) * (Obh2 / Omh2) + \
-              0.38 * np.log(22.3 * Omh2) * (Obh2 / Omh2)**2
-    Gamma_eff = OMEGA_M0 * h * (alpha_g + (1 - alpha_g) /
-                                 (1 + (0.43 * k * s)**4))
-    q = k * theta**2 / Gamma_eff
-    L0 = np.log(2 * np.e + 1.8 * q)
-    C0 = 14.2 + 731.0 / (1 + 62.5 * q)
-    T = L0 / (L0 + C0 * q**2)
-    Pk = k**N_S * T**2
-    return Pk
-
-
-def sigma_M(M: float, D_of_z: float, k: Optional[np.ndarray] = None,
-            Pk: Optional[np.ndarray] = None) -> float:
-    """RMS variance sigma(M) at the scale R(M), scaled by D(z)."""
-    R = mass_to_radius(M)
-    if k is None:
-        k = np.logspace(-4, 2, 4000)
-    if Pk is None:
-        Pk = _Pk_EH(k)
-    W = _top_hat_W(k * R)
-    integrand = k**2 * Pk * W**2 / (2.0 * np.pi**2)
-    sig2_raw = np.trapz(integrand, k)
-    # normalise so that sigma8 = SIGMA8 at z=0 (D=1)
-    R8 = 8.0  # Mpc/h
-    W8 = _top_hat_W(k * R8)
-    integrand8 = k**2 * Pk * W8**2 / (2.0 * np.pi**2)
-    sig2_8 = np.trapz(integrand8, k)
-    norm = SIGMA8**2 / sig2_8
-    sigma = np.sqrt(norm * sig2_raw) * D_of_z
-    return sigma
-
-
-# ========================== Step 5: n(M, z) — HMF ========================
-def _dln_sigma_inv_dM(M: float, D_of_z: float, dM_frac: float = 0.01
-                      ) -> float:
-    """Numerical |d ln sigma^{-1} / dM|."""
-    s1 = sigma_M(M * (1 + dM_frac), D_of_z)
-    s0 = sigma_M(M * (1 - dM_frac), D_of_z)
-    dlns_inv = -(np.log(1.0/s1) - np.log(1.0/s0))
-    dM = M * 2 * dM_frac
-    return abs(dlns_inv / dM)
-
-
-=======
 from typing import Tuple, Optional
 
 # --------------- cosmological constants (Planck 2018 flat LCDM baseline) -------
@@ -332,91 +166,12 @@ def calibrate_Pk_norm() -> float:
 # =============================================================================
 # Step 5: Halo Mass Function  n(M, z)
 # =============================================================================
->>>>>>> origin/main
 def f_PS(sigma: float) -> float:
     """Press-Schechter multiplicity function."""
     nu = DELTA_C / sigma
     return np.sqrt(2.0 / np.pi) * nu * np.exp(-0.5 * nu**2)
 
 
-<<<<<<< HEAD
-def f_ST(sigma: float, A_st: float = 0.3222, a_st: float = 0.707,
-         p: float = 0.3) -> float:
-    """Sheth-Tormen multiplicity function."""
-    nu = DELTA_C / sigma
-    nu2 = a_st * nu**2
-    return A_st * np.sqrt(2.0 * nu2 / np.pi) * (1 + nu2**(-p)) * \
-        np.exp(-0.5 * nu2)
-
-
-def f_Tinker(sigma: float, z: float = 0.0, Delta: float = 200.0) -> float:
-    """Tinker 2008 multiplicity (Delta=200 calibration)."""
-    # Tinker 2008 Table 2 params for Delta=200, interpolated to z
-    A0, a0, b0, c0 = 0.186, 1.47, 2.57, 1.19
-    # redshift evolution (Tinker 2010 approx)
-    A = A0 * (1 + z)**(-0.14)
-    a = a0 * (1 + z)**(-0.06)
-    b = b0 * (1 + z)**(-0.0 * np.exp(-(Delta / 500)**2))  # ~constant for 200
-    c = c0
-    return A * ((sigma / b)**(-a) + 1) * np.exp(-c / sigma**2)
-
-
-def dn_dM(M: float, z: float, D_interp: Callable, prescription: str = 'ST',
-          ) -> float:
-    """Comoving halo mass function dn/dM [h^4 Msun^{-1} Mpc^{-3}]."""
-    a = 1.0 / (1.0 + z)
-    D_val = float(D_interp(a))
-    sig = sigma_M(M, D_val)
-    if prescription == 'PS':
-        fval = f_PS(sig)
-    elif prescription == 'ST':
-        fval = f_ST(sig)
-    elif prescription == 'Tinker':
-        fval = f_Tinker(sig, z)
-    else:
-        raise ValueError(f'Unknown prescription {prescription}')
-    return (RHO_M0 / M) * fval * _dln_sigma_inv_dM(M, D_val)
-
-
-# ========================== convenience ==================================
-def build_D_interpolator(B: float = B_DEFAULT, zt: float = ZT_DEFAULT,
-                         n: float = N_EXP_DEFAULT, A: float = 0.0
-                         ) -> Callable:
-    """Return an interpolator D(a) for given EFC parameters."""
-    a_arr, D_arr = solve_growth(B, zt, n, A)
-    return interp1d(a_arr, D_arr, kind='cubic', fill_value='extrapolate')
-
-
-# ========================== self-test ====================================
-if __name__ == '__main__':
-    print('Running self-test...')
-    # gate function checks
-    assert abs(gate_function(1.0, 3.0, 4.0) - 1.0) < 0.01  # z=0 => g~1
-    assert gate_function(0.01, 3.0, 4.0) > 0.9  # z=99 >> zt => g->1
-    assert gate_function(0.5, 3.0, 4.0) < 0.1   # z=1 < zt => g small
-
-    # mu check
-    assert mu_eff(0.01) < 1.0  # suppressed at high z
-    assert abs(mu_eff(0.5) - 1.0) < 0.01  # near unity at low z
-
-    # growth
-    D_interp = build_D_interpolator(B=0.0)  # LCDM limit
-    a_test = 1.0 / (1.0 + 8.0)
-    print(f'  D(z=8) LCDM  = {D_interp(a_test):.6f}')
-
-    D_interp_efc = build_D_interpolator()
-    print(f'  D(z=8) EFC   = {D_interp_efc(a_test):.6f}')
-
-    # sigma
-    M_test = 1e11  # Msun/h
-    sig = sigma_M(M_test, D_interp_efc(a_test))
-    print(f'  sigma(1e11, z=8) EFC = {sig:.6f}')
-
-    # HMF
-    dndm = dn_dM(M_test, 8.0, D_interp_efc, 'ST')
-    print(f'  dn/dM(1e11, z=8) ST  = {dndm:.4e}')
-    print('Self-test passed.')
-=======
 def f_ST(sigma: float, A_st: float = 0.3222, a_st: float = 0.707, p_st: float = 0.3) -> float:
     """Sheth-Tormen multiplicity function."""
     nu = DELTA_C / sigma
@@ -508,4 +263,3 @@ if __name__ == '__main__':
     val = dndlnM(1e11, 8.0, D_interp(1.0/9.0), Pk_norm, 'ST')
     print(f'dn/dlnM(M=1e11, z=8, ST) = {val:.6e} h^3 Mpc^-3')
     print('Self-test complete.')
->>>>>>> origin/main


### PR DESCRIPTION
Three files under docs/papers/efc/jwst_hmf_prereg_v4/ carried committed, unresolved git conflict markers on main, leaving broken Python/JSON: data/parameters.json (3 conflicts), examples/demo_jwst_hmf_prereg_v4.py (2), src/jwst_hmf_prereg_v4.py (3). Root cause: merge commit f26bdfdd committed the markers instead of resolving them.

Resolution: restored the last clean version (3f6fab54, 'auto-generate metadata and fix drift on main') = the canonical origin/main side. That side is strictly more complete — full paper_metadata (DOI 10.6084/m9.figshare.32149654 + ORCID + validation_candidate), sign_lemma, precise Planck cosmology, and a related_dois set that is a strict SUPERSET of the HEAD-side DOIs (no DOI loss). Diff vs origin/main is pure deletion of the duplicated HEAD-side content + markers; no physics values changed.

Verification: py_compile passes on both .py files, json.load passes on parameters.json, git grep finds zero conflict markers repo-wide. Unrelated to PR #313 (identical on both sides there, not in that diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)