### PR TITLE
docs(efc): changelog narrative for cross-validation pass + byline dates

### DIFF
--- a/docs/public/EFC_Changelog.html
+++ b/docs/public/EFC_Changelog.html
@@ -92,6 +92,9 @@
 <h2>2026</h2>
 
 <ul>
+  <li><strong>2026-06-08</strong> &mdash; <strong>Canonical narrative + semantic CI.</strong> Added <code>ledger_truth.json</code> as the single source for ledger numbers (each with explicit scope), RCMP-regime status, DOI provenance and EBE caveats. New <code>efc_narrative_consistency.py</code> gate, wired into the page-consistency workflow, catches oversell and self-contradiction classes the structural checks miss (a false zero-count of confirmed falsifications, a fabricated all-modules-DOI-anchored badge, placeholder-data preference verdicts).</li>
+  <li><strong>2026-06-08</strong> &mdash; <strong>Honest-count &amp; RCMP-framing pass.</strong> Falsification counts made scope-explicit (10 public status=failed / 11 L2 truth-ring) and a contradictory zero-falsifications summary removed. Neutralised a bao_desi_y1 oversell &mdash; a spurious EFC-preference verdict computed on a placeholder data file &rarr; honest &ldquo;pending real DESI&rdquo;. Added an RCMP-regime status section to the Gap Analysis: L0/L1 &Lambda;CDM-recovery is a designed feature, L2 the open frontier, L3 (galactic) EFC&rsquo;s strongest sector.</li>
+  <li><strong>2026-06-08</strong> &mdash; <strong>Infrastructure &amp; hygiene.</strong> Resolved committed git conflict markers that had left jwst_hmf_prereg_v4 Python/JSON broken (PR #316). Bound the validation-ledger publisher to RCMP-regime + EBE framing (no hardcoded zero-falsification claim; &ldquo;moves toward&rdquo; not &ldquo;matches&rdquo;; every count carries its scope) and verified its output by dry-run before resuming auto-publish. Byline dates updated April&nbsp;&rarr;&nbsp;June 2026.</li>
   <li><strong>2026-06-08</strong> &mdash; Ledger data: evidence-register.json, ledger.json.</li>
   <li><strong>2026-06-08</strong> &mdash; Public pages updated: Predictions, White_Paper_Series.</li>
   <li><strong>2026-06-08</strong> &mdash; Public pages updated: Changelog.</li>

--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -141,7 +141,7 @@
 <p style="font-size:0.92rem; color:#555;">
   Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
   ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-  April 2026 &middot; CC-BY-4.0
+  June 2026 &middot; CC-BY-4.0
 </p>
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->

--- a/docs/public/EFC_Evaluation_Ledger.html
+++ b/docs/public/EFC_Evaluation_Ledger.html
@@ -57,7 +57,7 @@
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-April 2026 &middot; CC-BY-4.0
+June 2026 &middot; CC-BY-4.0
 </p>
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">

--- a/docs/public/EFC_External_Research_Ledger.html
+++ b/docs/public/EFC_External_Research_Ledger.html
@@ -94,7 +94,7 @@ footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7e3;
 <p class="meta-line">
   Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
   ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-  April 2026 &middot; CC-BY-4.0
+  June 2026 &middot; CC-BY-4.0
 </p>
 
 

--- a/docs/public/EFC_Gap_Analysis.html
+++ b/docs/public/EFC_Gap_Analysis.html
@@ -115,7 +115,7 @@
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-April 2026 &middot; CC-BY-4.0
+June 2026 &middot; CC-BY-4.0
 </p>
 
 <div style="background-color:#f8f9fa; border-left:4px solid #007bff; padding:15px; margin:20px 0;">

--- a/docs/public/EFC_Likelihood_Ledger.html
+++ b/docs/public/EFC_Likelihood_Ledger.html
@@ -69,7 +69,7 @@
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-April 2026 &middot; CC-BY-4.0
+June 2026 &middot; CC-BY-4.0
 </p>
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">

--- a/docs/public/EFC_Model_Comparison.html
+++ b/docs/public/EFC_Model_Comparison.html
@@ -61,7 +61,7 @@
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-April 2026 &middot; CC-BY-4.0
+June 2026 &middot; CC-BY-4.0
 </p>
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">

--- a/docs/public/EFC_Predictions.html
+++ b/docs/public/EFC_Predictions.html
@@ -125,7 +125,7 @@
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-April 2026 &middot; CC-BY-4.0
+June 2026 &middot; CC-BY-4.0
 </p>
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">

--- a/docs/public/EFC_Stage-IV_Data_Roadmap.html
+++ b/docs/public/EFC_Stage-IV_Data_Roadmap.html
@@ -163,7 +163,7 @@
 <p style="font-size:0.95em; color:#555; margin-bottom:1.5em;">
 Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-April 2026 &middot; CC-BY-4.0
+June 2026 &middot; CC-BY-4.0
 </p>
 
 <!-- Plain-English elevator pitch (shared across the three public EFC pages) -->

--- a/docs/public/EFC_White_Paper_Series.html
+++ b/docs/public/EFC_White_Paper_Series.html
@@ -154,7 +154,7 @@
 <p style="font-size: 0.92rem; color: #555;">
   Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
   ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
-  April 2026 &middot; CC-BY-4.0
+  June 2026 &middot; CC-BY-4.0
 </p>
 
 <!-- Plain-English layman pitch (v1.1 — for non-specialists arriving via the public page) -->

--- a/docs/validation-ledger/data/changelog.json
+++ b/docs/validation-ledger/data/changelog.json
@@ -6,6 +6,11 @@
   "changes": [
     {
       "date": "2026-06-08",
+      "type": "cross_validation",
+      "summary": "Cross-validation & honest-narrative pass. Added ledger_truth.json (single source: numbers-with-scope, RCMP-regime status, DOI provenance, EBE caveats) + efc_narrative_consistency.py semantic CI gate wired into page-consistency. Falsification counts made scope-explicit (10 public / 11 L2 truth-ring); a contradictory zero-falsifications summary removed; a bao_desi_y1 placeholder-data preference oversell neutralised to 'pending real DESI'. RCMP-regime status surfaced in Gap Analysis (L0/L1 LCDM-recovery feature, L2 frontier, L3 galactic strength). Resolved jwst_hmf_prereg_v4 conflict markers (PR #316). Publisher bound to RCMP+EBE framing, dry-run verified. Byline dates April->June 2026."
+    },
+    {
+      "date": "2026-06-08",
       "type": "auto_maintenance",
       "summary": "Public pages updated: Changelog, Elevator_Pitch, Stage-IV_Data_Roadmap, Validation_Ledger, White_Paper_Series. Public pages updated: Atlas, Changelog; Ledger data: evidence-register.json, ledger.json. Public pages updated: Changelog. Public pages updated: Predictions, White_Paper_Series."
     },


### PR DESCRIPTION
Audit + housekeeping requested by Morten.

**Audit result:** all 14 public pages verified — both CI gates (page-consistency + semantic-narrative) pass, and the 4 newer pages (Likelihood, Evaluation, Model_Comparison, External_Research) read as honest, EBE-conform infrastructure (Evaluation_Ledger has an explicit 'falsification_status != model_preference' section; External_Research enforces 'consistency is not confirmation'). No data/DOI/narrative corrections needed.

**Changes in this PR:**
- EFC_Changelog.html + changelog.json: 3 curated entries documenting the cross-validation & honest-narrative pass (ledger_truth.json, semantic CI, scope-explicit counts 10 public / 11 L2, bao_desi_y1 neutralisation, RCMP-regime status, jwst fix PR #316, publisher RCMP+EBE binding).
- Byline date April -> June 2026 on 9 static pages. Historical 'April 2026' references (the April update wave, v1.1 stamps) deliberately preserved.

Both CI gates green. No scientific claims changed.