### PR TITLE
docs(efc): harmonize RCMP + ΛCDM-special-case framing across ledgers

### DIFF
--- a/docs/public/EFC_Evaluation_Ledger.html
+++ b/docs/public/EFC_Evaluation_Ledger.html
@@ -59,6 +59,10 @@ Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
 June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
 <p style="margin:0; font-size:15px;">

--- a/docs/public/EFC_Likelihood_Ledger.html
+++ b/docs/public/EFC_Likelihood_Ledger.html
@@ -71,6 +71,10 @@ Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
 June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
 <p style="margin:0; font-size:15px;">

--- a/docs/public/EFC_Model_Comparison.html
+++ b/docs/public/EFC_Model_Comparison.html
@@ -63,6 +63,10 @@ Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
 June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
 <p style="margin:0; font-size:15px;">

--- a/docs/public/EFC_Predictions.html
+++ b/docs/public/EFC_Predictions.html
@@ -127,6 +127,10 @@ Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
 June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <div style="background-color:#fff8e1; border-left:4px solid #d4a017; padding:15px; margin:20px 0;">
 <p style="margin:0; font-size:15px;">

--- a/docs/public/EFC_Stage-IV_Data_Roadmap.html
+++ b/docs/public/EFC_Stage-IV_Data_Roadmap.html
@@ -165,6 +165,10 @@ Morten Magnusson &middot; Symbiose Research, Sandnes, Norway &middot;
 ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
 June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <!-- Plain-English elevator pitch (shared across the three public EFC pages) -->
 <div style="background-color:#fffaf0; border:1px solid #d4a76a; border-left:6px solid #c57b2a; padding:16px 22px; margin:18px 0; border-radius:6px;">

--- a/docs/public/EFC_White_Paper_Series.html
+++ b/docs/public/EFC_White_Paper_Series.html
@@ -156,6 +156,10 @@
   ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
   June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <!-- Plain-English layman pitch (v1.1 — for non-specialists arriving via the public page) -->
 <div style="background-color:#fffaf0; border:1px solid #d4a76a; border-left:6px solid #c57b2a; padding:16px 22px; margin:18px 0; border-radius:6px;">


### PR DESCRIPTION
Per Morten — make the narrative *voice* identical across every ledger.

Added one consistent framing block to the 6 pages that carried the regime structure implicitly but did not state it (Predictions, Stage-IV, White Paper, Likelihood/Evaluation/Model_Comparison):

> **RCMP framing.** EFC is read *by regime* (L0–L3), not by the background: ΛCDM is the **special-case limit** of EFC in L0/L1, derived from the variational action (K(ρ)→∞ ⇒ μ,Σ,η→1), so recovering ΛCDM there is a designed *feature, not a contest*. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). *falsification_status ≠ model_preference.*

ΛCDM-as-special-case now appears on **all 12** pages (was explicit on 4). Same regime-stratified, EBE-honest voice everywhere. Both CI gates green; no numbers changed.