### PR TITLE
docs(efc): Atlas RCMP + ΛCDM-special-case framing (completes harmonization)

### DIFF
--- a/docs/public/EFC_Atlas.html
+++ b/docs/public/EFC_Atlas.html
@@ -200,6 +200,10 @@ ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &
 2026-04-29 &middot; CC-BY-4.0
 </p>
 
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 <p style="font-size:0.93rem; color:#1a3a6b; background:#f0f5fc; border:1px solid #c9d4e4; border-radius:5px; padding:10px 14px;">
 The Atlas joins two data sources: the immutable sealed <strong>Validation Ledger</strong>
 (EFC's own predictions with DOI, hash, freeze-timestamp) and the

--- a/scripts/build_atlas.py
+++ b/scripts/build_atlas.py
@@ -268,6 +268,10 @@ ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &
 __GENERATED_DATE__ &middot; CC-BY-4.0
 </p>
 
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 <p style="font-size:0.93rem; color:#1a3a6b; background:#f0f5fc; border:1px solid #c9d4e4; border-radius:5px; padding:10px 14px;">
 The Atlas joins two data sources: the immutable sealed <strong>Validation Ledger</strong>
 (EFC's own predictions with DOI, hash, freeze-timestamp) and the


### PR DESCRIPTION
Completes PR #321. The Atlas was the last page without the explicit statement — it is generated by build_atlas.py, so the framing block is added to the template; EFC_Atlas.html now carries it on every regen. Clean 4-line diff (framing only). All 12 public ledgers now carry the identical regime-stratified, ΛCDM-as-special-case, EBE-honest voice. Both CI gates green.