### PR TITLE
docs(efc): identical RCMP + ΛCDM-special-case narrative on Pitch/Validation/Gap

### DIFF
--- a/docs/public/EFC_Elevator_Pitch.html
+++ b/docs/public/EFC_Elevator_Pitch.html
@@ -143,6 +143,10 @@
   ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
   June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 <!-- ═══════════════════════════════════════════════════════════════════════ -->
 <!-- The pitch                                                                -->

--- a/docs/public/EFC_External_Research_Ledger.html
+++ b/docs/public/EFC_External_Research_Ledger.html
@@ -96,6 +96,10 @@ footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid #d0d7e3;
   ORCID: <a href="https://orcid.org/0009-0002-4860-5095">0009-0002-4860-5095</a> &middot;
   June 2026 &middot; CC-BY-4.0
 </p>
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 
 
 <p class="meta-line">

--- a/docs/public/EFC_Validation_Ledger.html
+++ b/docs/public/EFC_Validation_Ledger.html
@@ -173,6 +173,10 @@
 </p>
 </div>
 
+<div style="background:#f0f4fa; border-left:4px solid #4a6da7; padding:10px 16px; margin:1.2rem 0; font-size:0.92rem; color:#2a3a52;">
+<strong>RCMP framing.</strong> EFC is read <em>by regime</em> (L0&ndash;L3), not by the background: &Lambda;CDM is the <strong>special-case limit</strong> of EFC in L0/L1, derived from the variational action (K(&rho;)&rarr;&infin; &rArr; &mu;,&Sigma;,&eta;&rarr;1), so recovering &Lambda;CDM there is a designed <em>feature, not a contest</em>. EFC-distinctive physics lives in L2 (perturbation/growth) and L3 (galactic). <em>falsification_status &ne; model_preference.</em>
+</div>
+
 <!-- Executive Summary -->
 <div style="background-color:#f8f9fa; border-left:4px solid #007bff; padding:15px; margin:20px 0;">
 <p style="margin:0; font-size:15px;">


### PR DESCRIPTION
Per Morten — Pitch, Validation and Gap must carry the same RCMP + ΛCDM-as-special-case narrative.

Before: Gap had the rich regime section (gold standard); Validation had the special-case statement but no top framing; Pitch had only the DOI mention. Added the consistent RCMP framing block to Elevator_Pitch + Validation_Ledger (+ External_Research). All three front-door pages now state identically: *read by regime (L0–L3); ΛCDM is the L0/L1 special-case limit (feature not contest); EFC-distinctive physics in L2/L3; falsification_status ≠ model_preference.*

Both CI gates green; no numbers changed.

Note: Validation_Ledger exec-summary still carries a dated **v4.3 (2026-04-26)** version-update line with the old background ΔAIC=+4.05 (same conflation fixed in #320; left as a dated record, like the Changelog). Flag for your call.