### PR TITLE
feat(efc): verify F7 cosmic-shear data (real arXiv) + declare Σeff-shape pipeline

### DIFF
--- a/docs/likelihood-ledger/likelihoods.json
+++ b/docs/likelihood-ledger/likelihoods.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "generated_at": "2026-06-08T00:00:00Z",
-  "generator": "manual (F7 amplitude-leg formalisation)",
+  "generator": "manual (F7 amplitude-leg formalisation; data verified vs source papers)",
   "likelihoods": [
     {
       "test_id": "shear_s8_amplitude_efc_branches",
@@ -13,15 +13,33 @@
         "S8_efc_fragile": {"type": "fixed", "value": 0.847, "ref": "DOI 32037990 (eta-boost, 0% robust)"}
       },
       "code": "direct_python",
-      "code_version": "reproduce_shear_s8_output.json sha256:cb8dd4d75df9541346d86252191000533027aa7f5c6515b216da585cb038cac8",
+      "code_version": "reproduce_shear_s8_output.json sha256:113d4327f9264100be476573ae34c36a8fa999f1fdfb308220f8033e8146cbbb",
       "entry_point": "reproduce_shear_s8.py",
       "inputs": [
-        "DES Y6 3x2pt S8=0.789+/-0.012 (DOI 10.6084/m9.figshare.31951992, EFC-VAL-2026-002 citing DES Y6)",
-        "KiDS-Legacy S8=0.815 (external_research_watch.json; KiDS-1000 0.766 tested as robustness variant)"
+        "DES Y6 3x2pt S8=0.789+/-0.012 (arXiv:2601.14559, Jan 2026; VERIFIED 2026-06-08)",
+        "KiDS-Legacy S8=0.814 +0.011/-0.012 (arXiv:2503.19442; VERIFIED 2026-06-08; KiDS-1000 0.766 tested as robustness variant)"
       ],
       "outputs": ["chi2", "best_fit"],
       "status": "runnable",
-      "notes": "AMPLITUDE leg of F7 only -- tests the eta-boost amplitude consequence (eta-boost => enhanced growth => high S8). First-look result: the fragile eta-boost branch (S8=0.847) is disfavoured ~3.2 sigma (combined, model-error-propagated) by existing DES Y6 + KiDS, robust to the KiDS-1000/Legacy bifurcation; robust EFC (S8 down, 0.820) is the best fit, ahead of LCDM. The full Sigma_eff(z) crossover (z~0.44, criterion F9) remains a SEPARATE GAP awaiting Euclid DR1 + the Cobaya+MGCAMB shape likelihood. First-look only (diagonal errors, no covariance/nuisance); literature S8 values -- verify vs source DOIs before any sealed Validation-Ledger claim."
+      "notes": "AMPLITUDE leg of F7 only -- tests the eta-boost amplitude consequence (eta-boost => enhanced growth => high S8). Data VERIFIED 2026-06-08 against the source papers (DES Y6 arXiv:2601.14559; KiDS-Legacy arXiv:2503.19442). First-look result: the fragile eta-boost branch (S8=0.847) is disfavoured ~3.3 sigma (combined, model-error-propagated) by existing DES Y6 + KiDS-Legacy, robust to the KiDS-1000/Legacy bifurcation; robust EFC (S8 down, 0.820) is the best fit, ahead of LCDM. Still first-look (diagonal errors, no full covariance/nuisance) -- not a sealed Validation-Ledger verdict. The full Sigma_eff(z) shape (next entry) remains the decisive distinctive test."
+    },
+    {
+      "test_id": "shear_sigma_eff_shape_crossover",
+      "likelihood_type": "mcmc_posterior",
+      "covariance": "TBD (full tomographic DES/KiDS/Euclid shear covariance)",
+      "parameter_priors": {
+        "Sigma_eff_of_z": {"type": "reference", "ref": "DOI 32037990 (non-monotonic Sigma_eff(z), crossover z~0.44; fragile eta-branch only)"}
+      },
+      "code": "cobaya",
+      "code_version": null,
+      "entry_point": null,
+      "inputs": [
+        "Euclid DR1 tomographic cosmic shear (Oct 2026, pending release)",
+        "DES Y6 / KiDS-Legacy tomographic C_ell (for a current-data shape constraint)"
+      ],
+      "outputs": ["posterior_summary", "log_likelihood"],
+      "status": "declared",
+      "notes": "The distinctive Sigma_eff(z) CROSSOVER (z~0.44, criterion F9) -- the part the amplitude leg does NOT test. A monotonic result kills only the fragile eta-boost branch and is consistent with robust EFC (Sigma~0.99 flat, near-GR). DECLARED, not yet runnable: requires the full Cobaya+MGCAMB tomographic-shear shape likelihood + the Euclid DR1 release. This is the genuine remaining GAP -- it needs the MG codes + compute, which are not wired here."
     }
   ]
 }

--- a/docs/public/EFC_Likelihood_Ledger.html
+++ b/docs/public/EFC_Likelihood_Ledger.html
@@ -140,7 +140,7 @@ the Evaluation Ledger.</p>
 <tr><td>EFC integration (background)</td><td><code>analytic</code></td><td><code>direct_python</code></td><td><code>reproduce_efc.py</code></td><td><span class="badge-runnable">runnable</span></td></tr>
 <tr><td>f&sigma;<sub>8</sub> / S<sub>8</sub> (growth)</td><td><code>gaussian_cov</code></td><td>TBD (Cobaya likely)</td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
 <tr><td>Cosmic shear &mdash; S<sub>8</sub> amplitude (DES&nbsp;Y6, KiDS)</td><td><code>gaussian</code></td><td><code>direct_python</code></td><td><code>reproduce_shear_s8.py</code></td><td><span class="badge-runnable">runnable</span></td></tr>
-<tr><td>Cosmic shear &mdash; &Sigma;<sub>eff</sub>(z) shape / crossover (Euclid)</td><td><code>mcmc_posterior</code></td><td><code>cobaya</code> + <code>mgcamb</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
+<tr><td>Cosmic shear &mdash; &Sigma;<sub>eff</sub>(z) shape / crossover (Euclid)</td><td><code>mcmc_posterior</code></td><td><code>cobaya</code> + <code>mgcamb</code></td><td>TBD</td><td><span class="badge-declared">declared</span></td></tr>
 <tr><td>ISW cross-correlation</td><td><code>gaussian</code></td><td><code>direct_python</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
 <tr><td>GW propagation (KC6)</td><td><code>gaussian</code></td><td><code>direct_python</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>
 <tr><td>Full CMB likelihood (plik_lite TTTEEE)</td><td><code>mcmc_posterior</code></td><td><code>cobaya</code></td><td>TBD</td><td><span class="badge-gap">GAP</span></td></tr>

--- a/reproduce_shear_s8.py
+++ b/reproduce_shear_s8.py
@@ -55,16 +55,16 @@ MODELS = {
 }
 
 # =====================================================================
-# 2. EXISTING COSMIC-SHEAR S8 DATA  (verified 2026-06-08; literature values --
-#    VERIFY against source DOIs before any sealed claim)
+# 2. EXISTING COSMIC-SHEAR S8 DATA  (VERIFIED 2026-06-08 against the source papers:
+#    DES Y6 arXiv:2601.14559, KiDS-Legacy arXiv:2503.19442)
 # =====================================================================
 DATA = [
-    {"name": "DES Y6 3x2pt", "S8": 0.789, "err": 0.012, "src": "DOI 10.6084/m9.figshare.31951992 (EFC-VAL-2026-002) citing DES Y6"},
-    {"name": "KiDS-Legacy",  "S8": 0.815, "err": 0.020, "src": "external_research_watch.json (error approximate)"},
+    {"name": "DES Y6 3x2pt", "S8": 0.789, "err": 0.012, "src": "arXiv:2601.14559 (DES Y6 3x2pt, Jan 2026; verified 2026-06-08)"},
+    {"name": "KiDS-Legacy",  "S8": 0.814, "err": 0.012, "src": "arXiv:2503.19442 (KiDS-Legacy S8=0.814 +0.011/-0.012; verified 2026-06-08)"},
 ]
-# The KiDS-1000 (0.766) vs KiDS-Legacy (0.815) bifurcation is unresolved
+# The KiDS-1000 (0.766) vs KiDS-Legacy (0.814) bifurcation is unresolved
 # (Euclid DR1 will arbitrate); we test robustness to it below.
-KIDS_VARIANTS = {"KiDS-Legacy": {"S8": 0.815, "err": 0.020},
+KIDS_VARIANTS = {"KiDS-Legacy": {"S8": 0.814, "err": 0.012},
                  "KiDS-1000":   {"S8": 0.766, "err": 0.020}}
 
 

--- a/reproduce_shear_s8_output.json
+++ b/reproduce_shear_s8_output.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "script": "reproduce_shear_s8.py",
-    "timestamp": "2026-06-08T12:51:45Z",
+    "timestamp": "2026-06-08T13:10:24Z",
     "scope": "S8-amplitude leg of F7 ONLY; Sigma_eff(z) crossover (F9) is a separate GAP awaiting Euclid DR1",
     "note": "First-look: diagonal errors, no covariance/nuisance; literature S8 values -- verify vs source DOIs before any sealed claim"
   },
@@ -27,23 +27,23 @@
       "name": "DES Y6 3x2pt",
       "S8": 0.789,
       "err": 0.012,
-      "src": "DOI 10.6084/m9.figshare.31951992 (EFC-VAL-2026-002) citing DES Y6"
+      "src": "arXiv:2601.14559 (DES Y6 3x2pt, Jan 2026; verified 2026-06-08)"
     },
     {
       "name": "KiDS-Legacy",
-      "S8": 0.815,
-      "err": 0.02,
-      "src": "external_research_watch.json (error approximate)"
+      "S8": 0.814,
+      "err": 0.012,
+      "src": "arXiv:2503.19442 (KiDS-Legacy S8=0.814 +0.011/-0.012; verified 2026-06-08)"
     }
   ],
   "results": {
     "chi2": {
-      "EFC robust (mu<1, Sigma~0.99)": 6.736,
-      "LCDM / Planck": 13.563,
-      "EFC fragile (eta-boost, 0%rob)": 25.921
+      "EFC robust (mu<1, Sigma~0.99)": 6.924,
+      "LCDM / Planck": 15.09,
+      "EFC fragile (eta-boost, 0%rob)": 30.924
     },
     "best_fit": "EFC robust (mu<1, Sigma~0.99)",
-    "fragile_combined_tension_sigma": 3.174,
+    "fragile_combined_tension_sigma": 3.35,
     "robust_to_kids_bifurcation": true
   },
   "checks": [
@@ -65,12 +65,12 @@
     {
       "name": "fragile_disfavoured",
       "passed": true,
-      "detail": "fragile chi2=25.9 > best 6.7 (dchi2=+19.2)"
+      "detail": "fragile chi2=30.9 > best 6.9 (dchi2=+24.0)"
     },
     {
       "name": "fragile_tension_gt_2sigma",
       "passed": true,
-      "detail": "fragile disfavoured at 3.2 sigma (combined, model-error-propagated)"
+      "detail": "fragile disfavoured at 3.3 sigma (combined, model-error-propagated)"
     },
     {
       "name": "fragile_disfavoured_under_both_kids",
@@ -88,5 +88,5 @@
     "passed": 7,
     "failed": 0
   },
-  "content_hash": "cb8dd4d75df9541346d86252191000533027aa7f5c6515b216da585cb038cac8"
+  "content_hash": "113d4327f9264100be476573ae34c36a8fa999f1fdfb308220f8033e8146cbbb"
 }


### PR DESCRIPTION
Follows #325 ("ta alt"). The biggest first-look caveat was "literature S8 values -- verify". Done:

| Data | Ledger value | Verified source | Result |
|---|---|---|---|
| DES Y6 3x2pt | 0.789±0.012 | **arXiv:2601.14559** (Jan 2026) | exact ✓ |
| KiDS-Legacy | 0.815 | **arXiv:2503.19442** → 0.814 +0.011/−0.012 | value ✓; I had conservative ±0.020, actual ±0.012 (tighter) |

Both are **real 2026 releases**, independently verified — the ~3σ result rests on real data, not projections.

**With verified (tighter) data:** fragile η-boost disfavoured **~3.3σ** (was ~3.2), robust to the KiDS bifurcation; robust EFC (S8 down) best fit. SHA-256 re-sealed.

**Also:** added a `declared` likelihood entry + ledger row for the full Σeff(z) shape/crossover (F9) — the genuine remaining GAP (needs Cobaya+MGCAMB + Euclid DR1; the MG codes + compute are not wired here, honestly flagged).

Still amplitude-leg first-look (diagonal errors) — **not a sealed Validation-Ledger verdict**; your merge + VC approval are the public-seal steps. Both CI gates green.