### PR TITLE
cost: break ai-audit gpt-5 cascade + reduce system-health cron

### DIFF
--- a/.github/workflows/efc-ai-audit.yml
+++ b/.github/workflows/efc-ai-audit.yml
@@ -16,12 +16,14 @@ on:
       - "README.md"
       - "AGENTS.md"
       - "pipelines/**/README.md"
+    paths-ignore:
+      - "docs/public/EFC_System_Health.html"
   workflow_dispatch:
     inputs:
       model:
-        description: "OpenAI model (default: gpt-5)"
+        description: "OpenAI model (default: gpt-5-mini)"
         required: false
-        default: "gpt-5"
+        default: "gpt-5-mini"
   schedule:
     - cron: "30 6 * * 3"  # Wednesday 06:30 UTC — consistency audit
     - cron: "0 7 * * 1"   # Monday 07:00 UTC — weekly full scan
@@ -54,7 +56,7 @@ jobs:
       - name: Run AI consistency audit (GPT council)
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ inputs.model || 'gpt-5' }}
+          OPENAI_MODEL: ${{ inputs.model || 'gpt-5-mini' }}
         run: |
           if [ -z "$OPENAI_API_KEY" ]; then
             echo "::warning::OPENAI_API_KEY secret not set. Skipping AI audit."

--- a/.github/workflows/efc-system-health.yml
+++ b/.github/workflows/efc-system-health.yml
@@ -10,7 +10,7 @@ name: EFC system health dashboard
 
 on:
   schedule:
-    - cron: "5 * * * *"  # every hour at :05
+    - cron: "0 */6 * * *"  # every 6 hours (was: hourly — reduced to break ai-audit cascade)
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
## Hva

- **efc-ai-audit**: default gpt-5 → gpt-5-mini (linje 24 + 57)
- **efc-ai-audit**: paths-ignore EFC_System_Health.html — bryter kaskaden der hourly system-health auto-commit trigger ai-audit med gpt-5
- **efc-system-health**: cron 5 * * * * → 0 */6 * * * (24x/dag → 4x/dag)

Kilde til $234.93 "GitHub Verifyer": system-health kjøres hver time, auto-committer HTML til main, trigger ai-audit med gpt-5.

🤖 Generated with Claude Code