### PR TITLE
BL-2609 phase 1b: remaining EFC docs assets from AGI repo

### DIFF
--- a/docs/data/sparc-175/README.md
+++ b/docs/data/sparc-175/README.md
@@ -1,0 +1,79 @@
+---
+title: SPARC 175 Galaxy Database + EFC-R Analysis
+type: foundational
+date: '2026-01-10'
+tags:
+- analysis
+- database
+- efc
+- galaxy
+- model
+source_path: docs/data/sparc-175/README.md
+---
+
+# SPARC 175 Galaxy Database + EFC-R Analysis
+
+## Oversikt
+
+Komplett datasett fra SPARC-databasen (175 galakser) med integrert EFC-R metodikk for rotasjonskurve-analyse.
+
+## Kilder
+
+| Kilde | Referanse |
+|-------|-----------|
+| SPARC Database | https://astroweb.case.edu/SPARC/ |
+| SPARC Paper | Lelli+2016 (DOI: 10.3847/0004-6256/152/6/157) |
+| EFC-R Paper | Magnusson 2026 (DOI: 10.6084/m9.figshare.31007248) |
+
+## Innhold
+
+### Datasett (fra SPARC)
+```
+rotation_models/     # 175 rotasjonskurver (.dat)
+photometry/          # 219 fotometri-profiler
+bulge_disk/          # 177 bulge/disk-dekomposisjoner
+archives/            # Original zip-filer
+```
+
+### Hovedtabeller
+| Fil | Beskrivelse |
+|-----|-------------|
+| Table1_Galaxy_Sample.mrt | 175 galakser med egenskaper |
+| Table2_Mass_Models.mrt | Rotasjonskurver + baryoniske bidrag |
+| Radial_Acceleration_Relation_*.mrt | RAR data (2630 punkter) |
+| Baryonic_Tully_Fisher_*.mrt | BTFR data |
+
+### Analyser
+| Fil | Innhold |
+|-----|---------|
+| EFC-R_METHOD.md | EFC-R metodikk |
+| efc_r_n20_results.json | Resultater fra N=20 analyse |
+| N175_ANALYSIS_PLAN.md | Plan for utvidet analyse |
+| ANALYSIS_REPORT.md | Komplett analyserapport |
+
+## EFC-R Status
+
+| Metrikk | N=20 | Forventet N=175 |
+|---------|------|-----------------|
+| Suksessrate | 80% | 75-85% |
+| Mean ∇S | 0.082 kpc⁻¹ | ~0.08 kpc⁻¹ |
+| Overlapp med N=175 | - | 19 galakser |
+| Nye galakser | - | 156 galakser |
+
+## Bruk
+
+```python
+# Les rotasjonskurve
+import numpy as np
+data = np.loadtxt('rotation_models/NGC2403_rotmod.dat')
+r, v_obs, v_err, v_gas, v_disk, v_bul, sb = data.T
+```
+
+## Relaterte prosjekter
+
+- **sparc-n20**: Original EFC-R analyse (publisert)
+- **sparc-n175**: Utvidet analyse (pågående)
+- **halo-model**: Entropi-halo prediksjoner
+
+---
+*Sist oppdatert: 2026-01-10*

--- a/docs/efc_master.css
+++ b/docs/efc_master.css
@@ -1,0 +1,63 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: "Georgia", "Times New Roman", serif;
+  background: #fdfdfd;
+  color: #222;
+}
+
+.main-wrapper {
+  max-width: 850px;
+  margin: 40px auto 60px auto;
+  padding: 0 16px;
+}
+
+h1, h2, h3, h4 {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  margin-top: 1.8em;
+  margin-bottom: 0.6em;
+}
+
+h1 {
+  text-align: center;
+  margin-top: 0;
+}
+
+p {
+  line-height: 1.6;
+  margin: 0.6em 0;
+}
+
+ul, ol {
+  line-height: 1.6;
+}
+
+figure {
+  margin: 2em auto;
+  text-align: center;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.math.display {
+  margin: 1.2em 0;
+}
+
+header.article-meta {
+  text-align: center;
+  margin-bottom: 2em;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+header.article-meta .author {
+  font-weight: 500;
+}
+
+header.article-meta .date {
+  font-size: 0.9em;
+  color: #666;
+}

--- a/docs/index.jsonld
+++ b/docs/index.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "identifier": "docs/index",
+  "name": "Docs",
+  "author": {
+    "@type": "Person",
+    "name": "Morten Magnusson",
+    "identifier": "https://orcid.org/0009-0002-4860-5095"
+  },
+  "version": "1.0",
+  "isPartOf": {
+    "@type": "CreativeWorkSeries",
+    "name": "docs"
+  },
+  "layer": "docs",
+  "encodingFormat": "md",
+  "url": "docs/index.md",
+  "description": "Auto-generated Markdown wrapper.",
+  "keywords": [
+    "docs"
+  ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,15 @@
+---
+title: Docs
+type: documentation
+date: '2026-01-04'
+tags:
+- docs
+source_path: docs/index.md
+---
+
+# Docs
+
+Auto-generated Markdown wrapper.
+
+[Open HTML](index.html)
+

--- a/docs/meta/critical_insights/EFC_Empirical_Self_Correction_2026-01-15.md
+++ b/docs/meta/critical_insights/EFC_Empirical_Self_Correction_2026-01-15.md
@@ -1,0 +1,122 @@
+---
+title: KRITISK INNSIKT - EFC Empirisk Validering Selvkorreksjon
+type: documentation
+date: '2026-01-15'
+tags:
+- cosmology
+- efc
+- empirisk
+- energy
+- flow
+- model
+- selvkorreksjon
+- validering
+source_path: docs/meta/critical_insights/EFC_Empirical_Self_Correction_2026-01-15.md
+---
+
+# KRITISK INNSIKT - EFC Empirisk Validering Selvkorreksjon
+# Dato: 2026-01-15
+# Type: Metodologisk selvkritikk og referee-standard
+
+## HOVED-INNSIKT
+EFC har kun 1 genuint empirisk test (SPARC N=175), IKKE 8 som opprinnelig hevdet.
+Dette er en kritisk selvkorreksjon basert på referee-standard feedback.
+
+## KLASSIFISERINGSSYSTEM FOR EMPIRISKE PÅSTANDER
+All fremtidig EFC-kommunikasjon må skille mellom:
+
+1. **Faktiske tester** (A-kategori)
+   - Direct model vs data comparison
+   - Kvantitative prediksjoner testet
+   - Reproduserbar metode med DOI
+   - Eksempel: SPARC N=175
+
+2. **Motiverende anomalier** (B-kategori)
+   - Problemer i standardmodellen
+   - EFC gir kvalitativ forklaring
+   - Mangler kvantitativ test
+   - Eksempler: JWST early galaxies, H₀/S8 tensions
+
+3. **Konsistenssjekker** (C-kategori)
+   - Både standardmodell og EFC predikerer samme
+   - Ikke diskriminerende alene
+   - Eksempel: CMB/ISW correlations
+
+4. **Framtidige tester** (D-kategori)
+   - Data tilgjengelig eller planlagt
+   - EFC-prediksjoner kan testes
+   - Eksempler: DESI w(z), weak lensing
+
+5. **Feilklassifiserte påstander** (E-kategori)
+   - Krevde kvantitative prediksjoner som ikke eksisterer
+   - Eksempler: Bullet Cluster, FIRE simulations
+
+## KORRIGERT EMPIRISK STATUS (januar 2026)
+
+### Faktisk validering:
+- **Antall tester:** 1
+- **Datasett:** SPARC N=175 rotation curves
+- **DOI:** 10.6084/m9.figshare.31045126
+- **Statistikk:** p < 0.0001 (regime struktur), 60% success rate
+- **CMB null-test:** Bestått (p = 0.251)
+- **Peer review:** NEI (Figshare preprint)
+- **Begrensninger:** 
+  - Single dataset
+  - Quality confound (ρ = -0.43)
+  - Ingen uavhengig replikasjon
+
+### Tidligere feilaktige påstander:
+- ❌ "8 uavhengige observasjonelle tester"
+- ❌ Bullet Cluster som "uavhengig validering"
+- ❌ FIRE simulations som "samme mønster"
+- ❌ JWST/H₀/S8 som "validering" (er motiverende anomalier)
+
+## NESTE KRITISKE STEG
+
+1. **MNRAS peer review** (EBE paper) - venter på svar
+2. **Uavhengig replikasjon** på andre datasett:
+   - LITTLE THINGS survey
+   - DMS (Dwarf Masses Survey)
+3. **Kvantitative prediksjoner** for:
+   - JWST number density vs redshift
+   - H₀/S8 full likelihood fit
+   - Weak lensing shear power spectra
+4. **Diskriminerende null-test** som skiller EFC fra ΛCDM
+
+## REFEREE-TETT SAMMENDRAG (133 ord)
+
+"Energy-Flow Cosmology (EFC) has been empirically tested against one dataset: 
+SPARC N=175 galaxy rotation curves (DOI: 10.6084/m9.figshare.31045126). The 
+analysis demonstrates statistically significant regime-dependent model preference 
+(p < 0.0001, Mann-Whitney U test) with 60% overall success rate and 100% success 
+in the FLOW regime. A CMB null-test passed as expected (p = 0.251). The analysis 
+is limited by single-dataset dependence, quality confounding (ρ = -0.43), and 
+lack of peer review. Additional observational phenomena (H₀/S8 tensions, JWST 
+early galaxies) motivate EFC but require quantitative predictions before 
+constituting validation. Future discriminating tests include DESI w(z) evolution 
+and weak lensing power spectra (Euclid/Rubin)."
+
+## INTELLECTUAL HONESTY LEVEL
+**Brutal selvkorreksjon** - fra overgenerøse påstander til referee-standard realisme.
+
+## KILDE
+Kritisk ekstern feedback som påpekte forskjellen mellom:
+- Empirisk test vs kvalitativ forklaring
+- Konsistenssjekk vs diskriminerende test
+- Framtidig test vs eksisterende validering
+
+## DOKUMENT SKAPT
+`/repo/docs/validation/EFC_Empirical_Status_Honest_Assessment_2026.md`
+
+## IMPLIKASJON FOR FREMTIDIGE PÅSTANDER
+All EFC-kommunikasjon må nå:
+1. Bruke A/B/C/D/E klassifiseringssystemet eksplisitt
+2. Aldri kalle noe "validering" uten kvantitativ model-vs-data test
+3. Være transparent om begrensninger
+4. Skille mellom "kan forklare" og "har testet og bekreftet"
+
+## LÆRDOMMER
+- **Overgeneralisering er farlig** - ødelegger troverdighet
+- **Referee-standard er strengt** - må følges fra starten
+- **Selvkritikk er styrke** - ikke svakhet
+- **Ett godt datasett >> mange kvalitative påstander**

--- a/docs/validation/EFC_Empirical_Status_Honest_Assessment_2026.md
+++ b/docs/validation/EFC_Empirical_Status_Honest_Assessment_2026.md
@@ -1,0 +1,150 @@
+---
+title: ÆRLIG EFC EMPIRISK STATUS (januar 2026)
+type: documentation
+date: '2026-01-15'
+tags:
+- cosmology
+- efc
+- energy
+- entropy
+- flow
+- model
+source_path: docs/validation/EFC_Empirical_Status_Honest_Assessment_2026.md
+---
+
+# ÆRLIG EFC EMPIRISK STATUS (januar 2026)
+
+**Kritisk selvkorreksjon basert på referee-standard**
+
+---
+
+## A) ✅ FAKTISK EMPIRISK TESTET (EFC vs data)
+
+### 1. SPARC N=175 Rotation Curves
+- **DOI:** `10.6084/m9.figshare.31045126`
+- **Metode:** Direct model comparison (EFC-R vs ΛCDM) på 175 galakser
+- **Resultat:** 
+  - EFC suksess: 60% overall, 100% i FLOW-regime
+  - Regime-struktur validert (p < 0.0001, Mann-Whitney U)
+  - CMB null-test bestått (p = 0.251)
+- **Status:** Publisert (Figshare), ikke fagfellevurdert
+- **Begrensning:** Kun ett datasett, kvalitetsconfound (ρ=-0.43)
+
+**Det er alt.** Resten er IKKE validering på samme nivå.
+
+---
+
+## B) ⚠️ OBSERVASJONSFENOMENER SOM EFC HEVDER Å FORKLARE
+*(Ikke validering før kvantitativ test)*
+
+### 2. JWST Early Massive Galaxies (z > 10)
+- **Problem for ΛCDM:** Uventet rask strukturformasjon
+- **EFC-påstand:** Entropy-driven tidlig vekst kan forklare
+- **Mangler for test:**
+  - Kvantitativ EFC-prediksjon (number density, luminosity function)
+  - Like pipeline som ΛCDM (samme seleksjon)
+- **Status:** Kvalitativ forklaring, ikke test
+
+### 3. H₀ Tension (73.2 vs 67.4 km/s/Mpc)
+- **Problem for ΛCDM:** Uforklart diskrepans lokal vs CMB
+- **EFC-påstand:** Lokal-til-global entropi-gradient varians
+- **Mangler for test:**
+  - Eksplisitt EFC likelihood-fit mot begge datasett
+  - Vise at EFC løser tension uten å ødelegge andre observables
+- **Status:** Kvalitativ forklaring, ikke test
+
+### 4. S8 Tension (clustering amplitude)
+- **Problem for ΛCDM:** Svakere clustering enn CMB predikerer
+- **EFC-påstand:** Entropy gradients gir glattere clustering
+- **Mangler for test:** Samme som H₀
+- **Status:** Kvalitativ forklaring, ikke test
+
+---
+
+## C) ✓ KONSISTENSSJEKKER (IKKE diskriminerende)
+
+### 5. CMB/Planck ISW Correlations
+- **Observasjon:** Integrated Sachs-Wolfe effekt detektert
+- **Resultat:** Både ΛCDM og EFC predikerer ISW
+- **EFC-forskjell:** Tillater små tidsmessige variasjoner
+- **Status:** Konsistent med EFC (og ΛCDM)
+- **Konklusjon:** Ikke diskriminerende uten spesifikk EFC-signatur
+
+---
+
+## D) 🔮 FRAMTIDIGE DISKRIMINERINGSTESTER
+
+### 6. DESI BAO + w(z) evolution
+- **Test:** Dark energy equation of state w(z)
+- **EFC-prediksjon:** w(z) varierer med entropi-gradienter
+- **Status:** DESI DR1 publisert, hints om evolusjon, men ikke EFC-spesifikk test
+- **Timing:** Data tilgjengelig, analyse gjenstår
+
+### 7. Weak Gravitational Lensing (Euclid/Rubin)
+- **Test:** Shear power spectra, tomographic cross-correlations
+- **EFC-prediksjon:** Glattere clustering enn ΛCDM
+- **Status:** Planlagt, data ikke tilgjengelig ennå
+
+---
+
+## E) ❌ FEILAKTIG KLASSIFISERT SOM "VALIDERING"
+
+### 8. Bullet Cluster ❌
+- **Min påstand:** "Uavhengig validering"
+- **Realitet:** Krever konkret EFC lensing-prediksjon (shear/kappa-kart) som matcher offset og amplitude
+- **Status:** Kvalitativ påstand uten kvantitativ test
+- **Referee vil:** Avvise som validering
+
+### 9. FIRE Simulations ❌
+- **Min påstand:** "Samme mønster som EFC"
+- **Realitet:** FIRE bruker ΛCDM-bakgrunn. "Regime-avhengighet" er ikke EFC-validering uten:
+  - Regime-mål definert før, ikke etter
+  - Samme mønster fra EFC uten parameter-tuning
+- **Status:** Ikke validering
+- **Referee vil:** Avvise som validering
+
+---
+
+## 📊 ÆRLIG KONKLUSJON
+
+### Faktisk empirisk validering av EFC (januar 2026):
+- **1 datasett:** SPARC N=175 rotation curves
+- **Status:** Publisert (ikke fagfellevurdert)
+- **Styrke:** Regime-struktur statistisk signifikant (p < 0.0001)
+- **Svakhet:** 
+  - Kun ett datasett
+  - Kvalitetsconfound eksisterer (ρ = -0.43 med N_points)
+  - Mangler uavhengig replikasjon
+  - Ingen fagfellevurdering
+
+### Alt annet er:
+- **Motiverende anomalier** (H₀/S8, JWST)
+- **Konsistenssjekker** (CMB/ISW)
+- **Framtidige tester** (DESI, lensing)
+- **Eller feilaktig klassifisert** (Bullet, FIRE)
+
+---
+
+## 🎯 NESTE KRITISKE STEG
+
+For å gå fra "1 datasett" til "seriøs alternativ teori":
+
+1. **Fagfellevurdering:** MNRAS submission for EBE-paper
+2. **Uavhengig replikasjon:** LITTLE THINGS survey, DMS survey
+3. **Kvantitative prediksjoner:**
+   - JWST: Spesifikk number density vs z
+   - H₀/S8: Full likelihood-fit
+   - Lensing: Konkrete shear power spectra
+4. **Null-test som diskriminerer:** Finn observabel der EFC og ΛCDM gir ulike prediksjoner
+
+---
+
+## 📝 REFEREE-TETT VERSJON (for publikasjoner)
+
+> Energy-Flow Cosmology (EFC) has been empirically tested against one dataset: SPARC N=175 galaxy rotation curves (DOI: 10.6084/m9.figshare.31045126). The analysis demonstrates statistically significant regime-dependent model preference (p < 0.0001, Mann-Whitney U test) with 60% overall success rate and 100% success in the FLOW regime. A CMB null-test passed as expected (p = 0.251). The analysis is limited by single-dataset dependence, quality confounding (ρ = -0.43), and lack of peer review. Additional observational phenomena (H₀/S8 tensions, JWST early galaxies) motivate EFC but require quantitative predictions before constituting validation. Future discriminating tests include DESI w(z) evolution and weak lensing power spectra (Euclid/Rubin).
+
+---
+
+**Sist oppdatert:** 15. januar 2026  
+**Basert på:** Kritisk feedback og referee-standard vurdering  
+**Status:** Ærlig selvkorreksjon av tidligere for generøse påstander


### PR DESCRIPTION
Completes the content half of the AGI/EFC separation (follow-up to #337). 6 additive files: SPARC-175 dataset doc, empirical status/self-correction assessments, docs-root scaffolding. Everything else from the AGI repo already exists here in newer versions (full md5+git-date diff run; 0 overwrites). Reviewer PASS with independent leak scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)